### PR TITLE
gap analysis feature for benchmark mode

### DIFF
--- a/Magpie/benchmark_images.yaml
+++ b/Magpie/benchmark_images.yaml
@@ -11,12 +11,12 @@
 
 vllm:
   # AMD GPUs
-  gfx942: "rocm/vllm:rocm7.0.0_vllm_0.11.2_20251210"
-  gfx950: "rocm/vllm:rocm7.0.0_vllm_0.11.2_20251210"
+  gfx942: "vllm/vllm-openai-rocm:v0.15.1"
+  gfx950: "vllm/vllm-openai-rocm:v0.15.1"
   # NVIDIA GPUs
-  sm_80: "vllm/vllm-openai:v0.11.2"
-  sm_90: "vllm/vllm-openai:v0.11.2"
-  sm_100: "vllm/vllm-openai:v0.11.2"
+  sm_80: "vllm/vllm-openai:v0.15.1"
+  sm_90: "vllm/vllm-openai:v0.15.1"
+  sm_100: "vllm/vllm-openai:v0.15.1"
 
 sglang:
   # AMD GPUs

--- a/Magpie/config.yaml
+++ b/Magpie/config.yaml
@@ -155,7 +155,7 @@ benchmark:
   
   # Path to InferenceMAX installation
   # If not configured or path doesn't exist, InferenceMAX will be auto-cloned from:
-  # https://github.com/haofrank/InferenceMAX.git
+  # https://github.com/SemiAnalysisAI/InferenceX.git
   inferencemax_path: ""
   
   # Default timeout for benchmark tasks

--- a/Magpie/main.py
+++ b/Magpie/main.py
@@ -617,10 +617,84 @@ def load_benchmark_config(benchmark_config_path: Path) -> Dict[str, Any]:
     return data.get("benchmark", {})
 
 
+def run_gap_analysis_standalone(args) -> int:
+    """Run standalone gap analysis on existing torch traces."""
+    from .modes.benchmark.gap_analysis import GapAnalyzer
+    from .modes.benchmark.config import GapAnalysisConfig
+
+    trace_dir = args.trace_dir.resolve()
+
+    # Auto-detect: if user passed a workspace dir, look for torch_trace/ inside
+    if (trace_dir / "torch_trace").is_dir():
+        trace_dir = trace_dir / "torch_trace"
+
+    if not trace_dir.is_dir():
+        print(f"Error: trace directory not found: {trace_dir}")
+        return 1
+
+    gap_config = GapAnalysisConfig(
+        enabled=True,
+        trace_start_pct=args.start_pct,
+        trace_end_pct=args.end_pct,
+        top_k=args.top_k,
+        min_duration_us=args.min_duration_us,
+        categories=getattr(args, "categories", None),
+        ignore_categories=getattr(args, "ignore_categories", None),
+    )
+
+    # All output goes into a gap_analysis/ subfolder
+    base_dir = getattr(args, "output_dir", None) or trace_dir.parent
+    gap_dir = Path(base_dir) / "gap_analysis"
+    gap_dir.mkdir(parents=True, exist_ok=True)
+
+    analyzer = GapAnalyzer(gap_config)
+    result = analyzer.analyze(trace_dir)
+
+    if result.errors:
+        for err in result.errors:
+            print(f"Warning: {err}")
+
+    if not result.merged_kernels:
+        print("No kernel events found in traces.")
+        return 1
+
+    csv_path = result.to_csv(gap_dir / "gap_analysis.csv")
+    if len(result.rank_results) > 1:
+        result.to_rank_csv(gap_dir)
+
+    # Print summary
+    start = gap_config.trace_start_pct
+    end = gap_config.trace_end_pct
+    print(f"\nGap Analysis ({start}%-{end}% window, category-filtered)")
+    print(f"{'=' * 60}")
+    print(f"Ranks analyzed: {len(result.rank_results)}")
+    if gap_config.categories:
+        print(f"Categories: {', '.join(gap_config.categories)}")
+    if gap_config.ignore_categories:
+        print(f"Ignore: {', '.join(gap_config.ignore_categories)}")
+    print(f"Total duration: {result.total_duration_us:.2f} us")
+    print(f"\n{'Name':50s} {'Calls':>6s} {'Self CUDA (us)':>15s} {'Avg (us)':>12s} {'% Total':>8s}")
+    print("-" * 95)
+    for k in result.merged_kernels:
+        pct = (
+            k.total_duration_us / result.total_duration_us * 100.0
+            if result.total_duration_us > 0 else 0.0
+        )
+        name = k.name if len(k.name) <= 50 else k.name[:47] + "..."
+        print(f"  {name:50s} {k.calls:6d} {k.total_duration_us:15.2f} {k.avg_us:12.2f} {pct:7.2f}%")
+    print(f"\nOutput: {gap_dir}")
+
+    return 0
+
+
 def run_benchmark(args, config: Dict[str, Any]) -> int:
     """Run benchmark mode."""
     from .modes.benchmark import BenchmarkMode, BenchmarkConfig
-    
+
+    # Handle gap-analysis sub-subcommand
+    if getattr(args, "benchmark_action", None) == "gap-analysis":
+        return run_gap_analysis_standalone(args)
+
     # Build benchmark config
     benchmark_cfg = {}
     
@@ -867,6 +941,43 @@ def create_parser() -> argparse.ArgumentParser:
         type=Path,
         default=Path("./results"),
         help="Output directory",
+    )
+
+    # Sub-subcommands under benchmark
+    benchmark_subs = benchmark_parser.add_subparsers(
+        dest="benchmark_action", help="Benchmark sub-actions"
+    )
+
+    gap_parser = benchmark_subs.add_parser(
+        "gap-analysis", help="Run gap analysis on existing torch traces"
+    )
+    gap_parser.add_argument(
+        "--trace-dir", type=Path, required=True,
+        help="Path to torch_trace directory (or benchmark workspace)",
+    )
+    gap_parser.add_argument(
+        "--start-pct", type=float, default=0.0,
+        help="Start of analysis window (0-100, default: 0)",
+    )
+    gap_parser.add_argument(
+        "--end-pct", type=float, default=100.0,
+        help="End of analysis window (0-100, default: 100)",
+    )
+    gap_parser.add_argument(
+        "--top-k", type=int, default=20,
+        help="Number of top bottleneck kernels (default: 20)",
+    )
+    gap_parser.add_argument(
+        "--min-duration-us", type=float, default=0.0,
+        help="Minimum event duration in microseconds (default: 0)",
+    )
+    gap_parser.add_argument(
+        "--categories", type=str, nargs="*", default=None,
+        help="Event categories to include (e.g. kernel gpu). None = all.",
+    )
+    gap_parser.add_argument(
+        "--ignore-categories", type=str, nargs="*", default=None,
+        help="Event categories to exclude (e.g. gpu_user_annotation)",
     )
 
     return parser

--- a/Magpie/modes/benchmark/__init__.py
+++ b/Magpie/modes/benchmark/__init__.py
@@ -12,12 +12,16 @@ This module provides:
 - BenchmarkResult: Results from benchmark execution
 """
 
-from .config import BenchmarkConfig, ProfilerConfig, TorchProfilerConfig, SystemProfilerConfig
+from .config import (
+    BenchmarkConfig, ProfilerConfig, TorchProfilerConfig,
+    SystemProfilerConfig, GapAnalysisConfig,
+)
 from .benchmarker import BenchmarkMode
 from .result import BenchmarkResult
 from .workspace import WorkspaceManager
 from .image_selector import ImageSelector
 from .inferencemax import InferenceMAXManager, ensure_inferencemax_available
+from .gap_analysis import GapAnalyzer, GapAnalysisResult
 
 __all__ = [
     "BenchmarkMode",
@@ -26,6 +30,9 @@ __all__ = [
     "ProfilerConfig",
     "TorchProfilerConfig",
     "SystemProfilerConfig",
+    "GapAnalysisConfig",
+    "GapAnalyzer",
+    "GapAnalysisResult",
     "WorkspaceManager",
     "ImageSelector",
     "InferenceMAXManager",

--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -304,22 +304,23 @@ class BenchmarkMode:
         # InferenceMAX mount
         inferencemax_path = self.config.inferencemax_path
         if os.path.exists(inferencemax_path):
-            cmd.extend(["-v", f"{inferencemax_path}:/workspace/InferenceMAX"])
+            cmd.extend(["-v", f"{inferencemax_path}:/opt/InferenceMAX"])
         
-        # Workspace mount (for results output)
-        cmd.extend(["-v", f"{workspace}:/workspace/output"])
+        # Workspace mount — map directly to /workspace so all output
+        # (server.log, results, torch_trace/) lands on the host automatically
+        cmd.extend(["-v", f"{workspace}:/workspace"])
         
         # Environment variables
         env_vars = self.config.get_env_vars()
-        env_vars["RESULT_FILENAME"] = "/workspace/output/inferencemax_result"
-        env_vars["RESULT_DIR"] = "/workspace/output"
+        env_vars["RESULT_FILENAME"] = "inferencemax_result"
+        env_vars["RESULT_DIR"] = "/workspace"
         env_vars["RUNNER_TYPE"] = runner_type
         
         # torch_profiler environment (matches official InferenceX: PROFILE=1)
         if self.config.profiler.torch_profiler.enabled:
             env_vars["PROFILE"] = "1"
-            env_vars["VLLM_TORCH_PROFILER_DIR"] = "/workspace/output/torch_trace"
-            env_vars["SGLANG_TORCH_PROFILER_DIR"] = "/workspace/output/torch_trace"
+            env_vars["VLLM_TORCH_PROFILER_DIR"] = "/workspace/torch_trace"
+            env_vars["SGLANG_TORCH_PROFILER_DIR"] = "/workspace/torch_trace"
 
         
         # HuggingFace token from environment
@@ -331,7 +332,7 @@ class BenchmarkMode:
             cmd.extend(["-e", f"{key}={value}"])
         
         # Working directory
-        cmd.extend(["-w", "/workspace/InferenceMAX"])
+        cmd.extend(["-w", "/opt/InferenceMAX"])
         
         # Image and entrypoint - always override to bash for script compatibility
         cmd.extend(["--entrypoint", "/bin/bash"])
@@ -343,7 +344,7 @@ class BenchmarkMode:
         # With --entrypoint /bin/bash, pass -c as first arg
         cmd.extend([
             "-c",
-            f"cd /workspace/InferenceMAX && bash {benchmark_script}"
+            f"cd /opt/InferenceMAX && bash {benchmark_script}"
         ])
         
         return cmd

--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -83,7 +83,7 @@ class BenchmarkMode:
             result = BenchmarkResult()
             result.success = False
             result.errors.append(f"Failed to setup InferenceMAX: {e}")
-            result.errors.append(f"Please clone manually: git clone https://github.com/haofrank/InferenceMAX.git")
+            result.errors.append(f"Please clone manually: git clone https://github.com/SemiAnalysisAI/InferenceX.git")
             return result
         
         # 1. Copy Magpie generic scripts to InferenceMAX/benchmarks/
@@ -315,9 +315,9 @@ class BenchmarkMode:
         env_vars["RESULT_DIR"] = "/workspace/output"
         env_vars["RUNNER_TYPE"] = runner_type
         
-        # torch_profiler environment
+        # torch_profiler environment (matches official InferenceX: PROFILE=1)
         if self.config.profiler.torch_profiler.enabled:
-            env_vars["ENABLE_PROFILE"] = "true"
+            env_vars["PROFILE"] = "1"
             env_vars["VLLM_TORCH_PROFILER_DIR"] = "/workspace/output/torch_trace"
             env_vars["SGLANG_TORCH_PROFILER_DIR"] = "/workspace/output/torch_trace"
 

--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -169,6 +169,11 @@ class BenchmarkMode:
                     torch_trace_dir, workspace
                 )
                 result.tracelens_analysis = tracelens_result
+            
+            # Run gap analysis if enabled
+            if self.config.gap_analysis.enabled:
+                gap_result = self._run_gap_analysis(torch_trace_dir, workspace)
+                result.gap_analysis = gap_result
         
         # Save report
         self.workspace_mgr.save_report(result.to_dict())
@@ -546,6 +551,63 @@ class BenchmarkMode:
             
         except Exception as e:
             logger.exception(f"TraceLens analysis failed: {e}")
+            return {"enabled": True, "error": str(e)}
+    
+    def _run_gap_analysis(
+        self,
+        torch_trace_dir: Path,
+        workspace: Path,
+    ) -> Dict[str, Any]:
+        """
+        Run gap analysis on torch profiler traces.
+        
+        Analyzes a time window of the trace to identify kernel-level
+        bottlenecks and writes a CSV report.
+        
+        Args:
+            torch_trace_dir: Directory containing torch trace files
+            workspace: Workspace directory for output
+        
+        Returns:
+            Gap analysis results dictionary
+        """
+        from .gap_analysis import GapAnalyzer
+
+        logger.info("Running gap analysis on torch traces...")
+        
+        try:
+            gap_dir = workspace / "gap_analysis"
+            gap_dir.mkdir(parents=True, exist_ok=True)
+
+            analyzer = GapAnalyzer(self.config.gap_analysis)
+            result = analyzer.analyze(torch_trace_dir)
+            
+            # Write merged CSV
+            csv_path = gap_dir / "gap_analysis.csv"
+            result.to_csv(csv_path)
+            logger.info(f"Wrote gap analysis CSV: {csv_path}")
+            
+            # Write per-rank CSVs if multiple ranks
+            if len(result.rank_results) > 1:
+                rank_paths = result.to_rank_csv(gap_dir)
+                for rp in rank_paths:
+                    logger.info(f"Wrote per-rank CSV: {rp}")
+            
+            ga_dict = result.to_dict()
+            ga_dict["csv_path"] = str(csv_path)
+            ga_dict["output_dir"] = str(gap_dir)
+            
+            if result.errors:
+                for err in result.errors:
+                    logger.warning(f"Gap analysis warning: {err}")
+            else:
+                n = len(result.merged_kernels)
+                logger.info(f"Gap analysis complete: {n} kernels in CSV")
+            
+            return ga_dict
+            
+        except Exception as e:
+            logger.exception(f"Gap analysis failed: {e}")
             return {"enabled": True, "error": str(e)}
     
     def cleanup(self) -> None:

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -192,6 +192,68 @@ class ProfilerConfig:
 
 
 @dataclass
+class GapAnalysisConfig:
+    """
+    Gap analysis configuration for torch profiler trace analysis.
+    
+    Analyzes a time window of the trace to identify kernel-level bottlenecks.
+    
+    Attributes:
+        enabled: Whether gap analysis is enabled (default: False)
+        trace_start_pct: Start of analysis window as percentage of trace duration (0-100)
+        trace_end_pct: End of analysis window as percentage of trace duration (0-100)
+        top_k: Number of top bottleneck events to include in the report
+        min_duration_us: Filter out events shorter than this (microseconds)
+        categories: Event categories to include (e.g., ["kernel", "gpu"]). None = all.
+        ignore_categories: Event categories to exclude (e.g., ["gpu_user_annotation"])
+    """
+    enabled: bool = False
+    trace_start_pct: float = 0.0
+    trace_end_pct: float = 100.0
+    top_k: int = 20
+    min_duration_us: float = 0.0
+    categories: Optional[List[str]] = field(default_factory=lambda: ["kernel", "gpu"])
+    ignore_categories: Optional[List[str]] = field(default_factory=lambda: ["gpu_user_annotation"])
+    
+    def __post_init__(self):
+        """Validate percentage range."""
+        if not (0.0 <= self.trace_start_pct <= 100.0):
+            raise ValueError(f"trace_start_pct must be 0-100, got {self.trace_start_pct}")
+        if not (0.0 <= self.trace_end_pct <= 100.0):
+            raise ValueError(f"trace_end_pct must be 0-100, got {self.trace_end_pct}")
+        if self.trace_start_pct >= self.trace_end_pct:
+            raise ValueError(
+                f"trace_start_pct ({self.trace_start_pct}) must be less than "
+                f"trace_end_pct ({self.trace_end_pct})"
+            )
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "enabled": self.enabled,
+            "trace_start_pct": self.trace_start_pct,
+            "trace_end_pct": self.trace_end_pct,
+            "top_k": self.top_k,
+            "min_duration_us": self.min_duration_us,
+            "categories": self.categories,
+            "ignore_categories": self.ignore_categories,
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GapAnalysisConfig":
+        """Create from dictionary."""
+        return cls(
+            enabled=data.get("enabled", False),
+            trace_start_pct=data.get("trace_start_pct", 0.0),
+            trace_end_pct=data.get("trace_end_pct", 100.0),
+            top_k=data.get("top_k", 20),
+            min_duration_us=data.get("min_duration_us", 0.0),
+            categories=data.get("categories", ["kernel", "gpu"]),
+            ignore_categories=data.get("ignore_categories", ["gpu_user_annotation"]),
+        )
+
+
+@dataclass
 class BenchmarkConfig:
     """
     Configuration for benchmark mode.
@@ -228,6 +290,9 @@ class BenchmarkConfig:
     inferencemax_path: str = "/root/hao_workspace/InferenceMAX"
     hf_cache_path: Optional[str] = None
     
+    # Gap analysis
+    gap_analysis: GapAnalysisConfig = field(default_factory=GapAnalysisConfig)
+    
     # InferenceMAX specific
     runner_type: Optional[str] = None
     benchmark_script: Optional[str] = None
@@ -252,6 +317,10 @@ class BenchmarkConfig:
         # Convert profiler dict to ProfilerConfig if needed
         if isinstance(self.profiler, dict):
             self.profiler = ProfilerConfig.from_dict(self.profiler)
+        
+        # Convert gap_analysis dict to GapAnalysisConfig if needed
+        if isinstance(self.gap_analysis, dict):
+            self.gap_analysis = GapAnalysisConfig.from_dict(self.gap_analysis)
     
     def get_env_vars(self) -> Dict[str, str]:
         """
@@ -299,6 +368,7 @@ class BenchmarkConfig:
             "precision": self.precision,
             "envs": self.envs,
             "profiler": self.profiler.to_dict(),
+            "gap_analysis": self.gap_analysis.to_dict(),
             "docker_image": self.docker_image,
             "gpu_arch": self.gpu_arch,
             "timeout_seconds": self.timeout_seconds,
@@ -314,12 +384,16 @@ class BenchmarkConfig:
         profiler_data = data.get("profiler", {})
         profiler = ProfilerConfig.from_dict(profiler_data) if profiler_data else ProfilerConfig()
         
+        gap_data = data.get("gap_analysis", {})
+        gap_analysis = GapAnalysisConfig.from_dict(gap_data) if gap_data else GapAnalysisConfig()
+        
         return cls(
             framework=data.get("framework", "sglang"),
             model=data.get("model", ""),
             precision=data.get("precision", "fp8"),
             envs=data.get("envs", {}),
             profiler=profiler,
+            gap_analysis=gap_analysis,
             docker_image=data.get("docker_image"),
             gpu_arch=data.get("gpu_arch"),
             timeout_seconds=data.get("timeout_seconds", 3600.0),

--- a/Magpie/modes/benchmark/gap_analysis.py
+++ b/Magpie/modes/benchmark/gap_analysis.py
@@ -1,0 +1,550 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""
+Gap analysis for torch profiler traces.
+
+Matches the behavior of workloads-inference gen_kstats_clamped_traces.py:
+  - Kernel stats CSV uses ALL events (no time window), category-filtered only
+  - Clamped trace files use time window, no category filter
+  - Category matching is case-insensitive substring matching
+
+CSV columns: Name, Calls, Self CUDA total (us), Avg time (us), % Total
+"""
+
+import csv
+import gzip
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from statistics import stdev
+from typing import Any, Dict, List, Optional, Tuple
+
+from .config import GapAnalysisConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class KernelStat:
+    """Aggregated statistics for a single kernel/function name."""
+    name: str
+    total_duration_us: float = 0.0
+    calls: int = 0
+    durations_us: List[float] = field(default_factory=list)
+
+    @property
+    def avg_us(self) -> float:
+        return self.total_duration_us / self.calls if self.calls else 0.0
+
+    @property
+    def min_us(self) -> float:
+        return min(self.durations_us) if self.durations_us else 0.0
+
+    @property
+    def max_us(self) -> float:
+        return max(self.durations_us) if self.durations_us else 0.0
+
+    @property
+    def std_us(self) -> float:
+        return stdev(self.durations_us) if len(self.durations_us) > 1 else 0.0
+
+
+@dataclass
+class RankResult:
+    """Gap analysis result for a single rank."""
+    rank: int
+    trace_file: str
+    total_duration_us: float = 0.0
+    kernels: List[KernelStat] = field(default_factory=list)
+
+
+@dataclass
+class GapAnalysisResult:
+    """Complete gap analysis result across all ranks."""
+    config: Dict[str, Any] = field(default_factory=dict)
+    rank_results: List[RankResult] = field(default_factory=list)
+    merged_kernels: List[KernelStat] = field(default_factory=list)
+    total_duration_us: float = 0.0
+    clamped_trace_paths: List[Path] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "config": self.config,
+            "total_duration_us": self.total_duration_us,
+            "num_ranks": len(self.rank_results),
+            "top_kernels": [
+                {
+                    "name": k.name,
+                    "calls": k.calls,
+                    "self_cuda_total_us": k.total_duration_us,
+                    "avg_time_us": k.avg_us,
+                    "pct_total": (
+                        k.total_duration_us / self.total_duration_us * 100.0
+                        if self.total_duration_us > 0 else 0.0
+                    ),
+                }
+                for k in self.merged_kernels
+            ],
+            "clamped_trace_paths": [str(p) for p in self.clamped_trace_paths],
+            "errors": self.errors,
+        }
+
+    def to_csv(self, output_path: Path) -> Path:
+        """Write merged kernel stats to CSV."""
+        output_path = Path(output_path)
+        with open(output_path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow([
+                "Name", "Calls", "Self CUDA total (us)",
+                "Avg time (us)", "% Total",
+            ])
+            for k in self.merged_kernels:
+                pct = (
+                    k.total_duration_us / self.total_duration_us * 100.0
+                    if self.total_duration_us > 0 else 0.0
+                )
+                writer.writerow([
+                    k.name,
+                    k.calls,
+                    f"{k.total_duration_us:.2f}",
+                    f"{k.avg_us:.2f}",
+                    f"{pct:.2f}",
+                ])
+        logger.info(f"Wrote gap analysis CSV: {output_path}")
+        return output_path
+
+    def to_rank_csv(self, output_dir: Path) -> List[Path]:
+        """Write per-rank CSV files. Returns list of written paths."""
+        paths: List[Path] = []
+        for rr in self.rank_results:
+            rank_path = Path(output_dir) / f"gap_analysis_rank{rr.rank}.csv"
+            with open(rank_path, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow([
+                    "Name", "Calls", "Self CUDA total (us)",
+                    "Avg time (us)", "% Total",
+                ])
+                for k in rr.kernels:
+                    pct = (
+                        k.total_duration_us / rr.total_duration_us * 100.0
+                        if rr.total_duration_us > 0 else 0.0
+                    )
+                    writer.writerow([
+                        k.name,
+                        k.calls,
+                        f"{k.total_duration_us:.2f}",
+                        f"{k.avg_us:.2f}",
+                        f"{pct:.2f}",
+                    ])
+            paths.append(rank_path)
+            logger.debug(f"Wrote per-rank CSV: {rank_path}")
+        return paths
+
+
+class GapAnalyzer:
+    """
+    Analyzes torch profiler Chrome-trace files, producing kernel stats CSVs.
+
+    Pipeline:
+      1. Apply time window (trace_start_pct – trace_end_pct)
+      2. Filter by category (case-insensitive substring matching)
+      3. Aggregate stats and rank by total duration
+    """
+
+    def __init__(self, config: Optional[GapAnalysisConfig] = None):
+        self.config = config or GapAnalysisConfig(enabled=True)
+
+    def analyze(self, trace_dir: Path) -> GapAnalysisResult:
+        """
+        Run gap analysis on all rank traces in *trace_dir*.
+
+        Produces kernel stats (category-filtered, no time window).
+        Does NOT generate clamped traces — call
+        :meth:`generate_clamped_traces` separately if needed.
+
+        Returns a GapAnalysisResult with per-rank and merged kernel stats.
+        """
+        trace_dir = Path(trace_dir)
+        result = GapAnalysisResult(config=self.config.to_dict())
+
+        if not trace_dir.exists():
+            result.errors.append(f"Trace directory not found: {trace_dir}")
+            return result
+
+        rank_files = self.detect_trace_files(trace_dir)
+        if not rank_files:
+            result.errors.append(f"No trace files found in {trace_dir}")
+            return result
+
+        logger.info(
+            f"Found {len(rank_files)} trace file(s) in {trace_dir}"
+        )
+
+        for rank, trace_file in rank_files:
+            try:
+                _data, events = self._load_trace_data(trace_file)
+
+                rr = self._analyze_single_rank(rank, trace_file, events)
+                result.rank_results.append(rr)
+
+            except Exception as e:
+                msg = f"Failed to analyze rank {rank} ({trace_file.name}): {e}"
+                logger.warning(msg)
+                result.errors.append(msg)
+
+        if result.rank_results:
+            result.merged_kernels = self._merge_ranks(result.rank_results)
+            result.total_duration_us = sum(
+                rr.total_duration_us for rr in result.rank_results
+            )
+            result.merged_kernels = result.merged_kernels[: self.config.top_k]
+            for rr in result.rank_results:
+                rr.kernels = rr.kernels[: self.config.top_k]
+
+        return result
+
+    def generate_clamped_traces(
+        self,
+        trace_dir: Path,
+        output_dir: Optional[Path] = None,
+    ) -> List[Path]:
+        """
+        Generate time-windowed (clamped) trace files for each rank.
+
+        This is a separate step from :meth:`analyze` — call it only
+        when you explicitly need clamped trace output.
+
+        Args:
+            trace_dir: Directory containing torch profiler trace files.
+            output_dir: Where to write clamped traces.
+                        Defaults to *trace_dir* itself.
+
+        Returns:
+            List of paths to generated clamped trace files.
+        """
+        trace_dir = Path(trace_dir)
+        dest = Path(output_dir) if output_dir else trace_dir
+        dest.mkdir(parents=True, exist_ok=True)
+
+        rank_files = self.detect_trace_files(trace_dir)
+        paths: List[Path] = []
+
+        for _rank, trace_file in rank_files:
+            try:
+                data, events = self._load_trace_data(trace_file)
+                p = self._generate_clamped_trace(
+                    data, events, trace_file, output_dir=dest,
+                )
+                if p:
+                    paths.append(p)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to generate clamped trace for "
+                    f"{trace_file.name}: {e}"
+                )
+
+        return paths
+
+    # -- trace file discovery -----------------------------------------------
+
+    @staticmethod
+    def detect_trace_files(trace_dir: Path) -> List[Tuple[int, Path]]:
+        """
+        Discover per-rank trace files in *trace_dir*.
+
+        Rank traces match ``*-rank-N.*.json.gz`` or ``*-rank-N.*.json``.
+        Falls back to any ``.json.gz`` / ``.json`` if no rank pattern found.
+        """
+        rank_files: List[Tuple[int, Path]] = []
+
+        for gz in sorted(trace_dir.glob("*-rank-*.pt.trace.json.gz")):
+            rank = _extract_rank(gz.name)
+            if rank is not None:
+                rank_files.append((rank, gz))
+        if rank_files:
+            return sorted(rank_files, key=lambda x: x[0])
+
+        for jf in sorted(trace_dir.glob("*-rank-*.pt.trace.json")):
+            rank = _extract_rank(jf.name)
+            if rank is not None:
+                rank_files.append((rank, jf))
+        if rank_files:
+            return sorted(rank_files, key=lambda x: x[0])
+
+        # Fallback: any trace file (e.g. async_llm trace)
+        for idx, gz in enumerate(sorted(trace_dir.glob("*.json.gz"))):
+            rank_files.append((idx, gz))
+        for idx, jf in enumerate(sorted(trace_dir.glob("*.json")), start=len(rank_files)):
+            rank_files.append((idx, jf))
+
+        return sorted(rank_files, key=lambda x: x[0])
+
+    # -- single-rank analysis -----------------------------------------------
+
+    def _analyze_single_rank(
+        self,
+        rank: int,
+        trace_file: Path,
+        events: List[Dict[str, Any]],
+    ) -> RankResult:
+        """
+        Build kernel stats for one rank.
+
+        Applies time window first, then category filter.
+        """
+        logger.debug(
+            f"Rank {rank}: loaded {len(events)} events from {trace_file.name}"
+        )
+
+        windowed = self._apply_time_window(events)
+        logger.debug(
+            f"Rank {rank}: {len(windowed)} events in time window "
+            f"({self.config.trace_start_pct}%-{self.config.trace_end_pct}%)"
+        )
+
+        filtered = self._filter_by_category(windowed)
+        logger.debug(
+            f"Rank {rank}: {len(filtered)} events after category filter"
+        )
+
+        if self.config.min_duration_us > 0:
+            filtered = [
+                (n, d) for n, d in filtered
+                if d >= self.config.min_duration_us
+            ]
+
+        kernels = self._aggregate_stats(filtered)
+        total_us = sum(k.total_duration_us for k in kernels)
+
+        return RankResult(
+            rank=rank,
+            trace_file=str(trace_file),
+            total_duration_us=total_us,
+            kernels=kernels,
+        )
+
+    # -- time window --------------------------------------------------------
+
+    def _apply_time_window(
+        self, events: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """
+        Keep only events that overlap with the configured time window.
+
+        If the window is 0%-100% (default), returns all events unchanged.
+        """
+        start_pct = self.config.trace_start_pct
+        end_pct = self.config.trace_end_pct
+
+        if start_pct <= 0 and end_pct >= 100:
+            return events
+
+        t_min = float("inf")
+        t_max = float("-inf")
+        for e in events:
+            ts = e.get("ts")
+            if ts is None:
+                continue
+            dur = e.get("dur", 0)
+            t_min = min(t_min, ts)
+            t_max = max(t_max, ts + dur)
+
+        if t_min == float("inf"):
+            return events
+
+        span = t_max - t_min
+        t_start = t_min + span * (start_pct / 100.0)
+        t_end = t_min + span * (end_pct / 100.0)
+
+        result = []
+        for e in events:
+            ts = e.get("ts")
+            if ts is None:
+                continue
+            dur = e.get("dur", 0)
+            if (ts + dur) >= t_start and ts <= t_end:
+                result.append(e)
+
+        return result
+
+    # -- trace loading ------------------------------------------------------
+
+    @staticmethod
+    def _load_trace_data(
+        trace_file: Path,
+    ) -> Tuple[Any, List[Dict[str, Any]]]:
+        """Load Chrome-trace data and events from .json or .json.gz."""
+        if trace_file.name.endswith(".json.gz"):
+            opener = gzip.open(trace_file, "rt")
+        else:
+            opener = open(trace_file, "r")
+
+        with opener as f:
+            data = json.load(f)
+
+        if isinstance(data, dict):
+            events = data.get("traceEvents", [])
+        elif isinstance(data, list):
+            events = data
+        else:
+            events = []
+
+        return data, events
+
+    # -- category filtering -------------------------------------------------
+
+    def _filter_by_category(
+        self, events: List[Dict[str, Any]]
+    ) -> List[Tuple[str, float]]:
+        """
+        Filter events by category using case-insensitive substring matching.
+
+        Returns list of (name, duration_us) tuples.
+        """
+        allowed = self.config.categories
+        ignored = self.config.ignore_categories
+
+        result: List[Tuple[str, float]] = []
+        for ev in events:
+            cat = (ev.get("cat") or "").lower()
+
+            if ignored and any(ig.lower() in cat for ig in ignored):
+                continue
+
+            if allowed and not any(c.lower() in cat for c in allowed):
+                continue
+
+            name = ev.get("name", "<?>")
+            dur_us = ev.get("dur", 0.0)
+            result.append((name, dur_us))
+
+        return result
+
+    # -- clamped trace generation -------------------------------------------
+
+    def _generate_clamped_trace(
+        self,
+        data: Any,
+        events: List[Dict[str, Any]],
+        trace_file: Path,
+        output_dir: Optional[Path] = None,
+    ) -> Optional[Path]:
+        """
+        Generate a time-windowed (clamped) trace file.
+
+        No category filtering — all events within the window are included.
+        Events overlapping the window boundary are clamped to fit.
+        Matches gen_kstats_clamped_traces.py generate_clamped_trace().
+
+        Args:
+            output_dir: Directory to write the clamped trace into.
+                        Defaults to the same directory as *trace_file*.
+        """
+        start_pct = self.config.trace_start_pct
+        end_pct = self.config.trace_end_pct
+
+        t_min = float("inf")
+        t_max = float("-inf")
+        for e in events:
+            ts = e.get("ts")
+            if ts is None:
+                continue
+            dur = e.get("dur", 0)
+            t_min = min(t_min, ts)
+            t_max = max(t_max, ts + dur)
+
+        if t_min == float("inf"):
+            return None
+
+        span = t_max - t_min
+        t_start = t_min + span * (start_pct / 100.0)
+        t_end = t_min + span * (end_pct / 100.0)
+
+        filtered = []
+        for e in events:
+            ts = e.get("ts")
+            if ts is None:
+                continue
+            dur = e.get("dur", 0)
+            if (ts + dur) < t_start or ts > t_end:
+                continue
+
+            e_new = dict(e)
+            clamped_start = max(ts, t_start)
+            clamped_end = min(ts + dur, t_end)
+            e_new["ts"] = clamped_start
+            e_new["dur"] = clamped_end - clamped_start
+            filtered.append(e_new)
+
+        # Build output filename: <stem>_clamped_<start>_<end>.trace.json.gz
+        stem = trace_file.name
+        for suffix in (".json.gz", ".json"):
+            if stem.endswith(suffix):
+                stem = stem[: -len(suffix)]
+                break
+
+        dest = output_dir if output_dir else trace_file.parent
+        output_path = dest / f"{stem}_clamped_{start_pct}_{end_pct}.trace.json.gz"
+
+        if isinstance(data, dict) and "traceEvents" in data:
+            data_out = dict(data)
+            data_out["traceEvents"] = filtered
+        else:
+            data_out = filtered
+
+        with gzip.open(output_path, "wt") as f:
+            json.dump(data_out, f)
+
+        logger.info(
+            f"Wrote clamped trace ({len(filtered)}/{len(events)} events): "
+            f"{output_path}"
+        )
+        return output_path
+
+    # -- aggregation --------------------------------------------------------
+
+    @staticmethod
+    def _aggregate_stats(
+        events: List[Tuple[str, float]],
+    ) -> List[KernelStat]:
+        """Aggregate events by name, sorted by total duration descending."""
+        by_name: Dict[str, KernelStat] = {}
+        for name, dur_us in events:
+            if name not in by_name:
+                by_name[name] = KernelStat(name=name)
+            ks = by_name[name]
+            ks.total_duration_us += dur_us
+            ks.calls += 1
+            ks.durations_us.append(dur_us)
+
+        return sorted(by_name.values(), key=lambda k: -k.total_duration_us)
+
+    # -- merge ranks --------------------------------------------------------
+
+    @staticmethod
+    def _merge_ranks(rank_results: List[RankResult]) -> List[KernelStat]:
+        """Merge kernel stats across ranks."""
+        merged: Dict[str, KernelStat] = {}
+        for rr in rank_results:
+            for ks in rr.kernels:
+                if ks.name not in merged:
+                    merged[ks.name] = KernelStat(name=ks.name)
+                m = merged[ks.name]
+                m.total_duration_us += ks.total_duration_us
+                m.calls += ks.calls
+                m.durations_us.extend(ks.durations_us)
+
+        return sorted(merged.values(), key=lambda k: -k.total_duration_us)
+
+
+def _extract_rank(filename: str) -> Optional[int]:
+    """Extract rank number from a filename like ``...-rank-0.1234...``."""
+    m = re.search(r"-rank-(\d+)\.", filename)
+    return int(m.group(1)) if m else None

--- a/Magpie/modes/benchmark/inferencemax.py
+++ b/Magpie/modes/benchmark/inferencemax.py
@@ -19,7 +19,7 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 # InferenceMAX repository configuration
-INFERENCEMAX_REPO_URL = "https://github.com/haofrank/InferenceMAX.git"
+INFERENCEMAX_REPO_URL = "https://github.com/SemiAnalysisAI/InferenceX.git"
 # Default directory:
 _PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 INFERENCEMAX_DEFAULT_DIR = str(_PROJECT_ROOT / "InferenceMAX")

--- a/Magpie/modes/benchmark/result.py
+++ b/Magpie/modes/benchmark/result.py
@@ -140,6 +140,9 @@ class BenchmarkResult:
     # TraceLens analysis results
     tracelens_analysis: Optional[Dict[str, Any]] = None
     
+    # Gap analysis results
+    gap_analysis: Optional[Dict[str, Any]] = None
+    
     # Execution info
     workspace_dir: str = ""
     execution_time: float = 0.0
@@ -161,6 +164,7 @@ class BenchmarkResult:
             "kernel_summary": [k.to_dict() for k in self.kernel_summary],
             "top_bottlenecks": self.top_bottlenecks,
             "tracelens_analysis": self.tracelens_analysis,
+            "gap_analysis": self.gap_analysis,
             "workspace_dir": self.workspace_dir,
             "execution_time": self.execution_time,
             "errors": self.errors,
@@ -221,6 +225,28 @@ class BenchmarkResult:
                 for err in self.tracelens_analysis["errors"]:
                     lines.append(f"  Warning: {err}")
         
+        if self.gap_analysis:
+            lines.extend(["", "Gap Analysis:"])
+            ga = self.gap_analysis
+            cfg = ga.get("config", {})
+            start_pct = cfg.get("trace_start_pct", 0)
+            end_pct = cfg.get("trace_end_pct", 100)
+            lines.append(f"  Window: {start_pct}%-{end_pct}%")
+            cats = cfg.get("categories")
+            if cats:
+                lines.append(f"  Categories: {', '.join(cats)}")
+            top_kernels = ga.get("top_kernels", [])
+            if top_kernels:
+                for i, k in enumerate(top_kernels[:5], 1):
+                    lines.append(
+                        f"  {i}. {k['name']} - "
+                        f"{k.get('pct_total', 0):.1f}% "
+                        f"({k.get('self_cuda_total_us', 0):.2f}us, "
+                        f"{k.get('calls', 0)} calls)"
+                    )
+                if len(top_kernels) > 5:
+                    lines.append(f"  ... and {len(top_kernels) - 5} more")
+
         if self.errors:
             lines.extend([
                 "",

--- a/Magpie/scripts/benchmark/sglang_mi300x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi300x.sh
@@ -30,7 +30,7 @@ fi
 export SGLANG_USE_AITER=1
 export SGLANG_AITER_MLA_PERSIST=1
 
-SERVER_LOG=/workspace/server.log
+SERVER_LOG=${SERVER_LOG:-/workspace/server.log}
 PORT=${PORT:-8888}
 
 set -x

--- a/Magpie/scripts/benchmark/sglang_mi355x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi355x.sh
@@ -34,7 +34,7 @@ fi
 export SGLANG_USE_AITER=1
 export SGLANG_AITER_MLA_PERSIST=1
 
-SERVER_LOG=/workspace/server.log
+SERVER_LOG=${SERVER_LOG:-/workspace/server.log}
 PORT=${PORT:-8888}
 
 set -x

--- a/Magpie/scripts/benchmark/vllm_mi300x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi300x.sh
@@ -50,7 +50,8 @@ vllm serve $MODEL --port $PORT \
   --gpu-memory-utilization 0.95 \
   --max-model-len $MAX_MODEL_LEN \
   --trust-remote-code \
-  --disable-log-requests > $SERVER_LOG 2>&1 &
+  --disable-log-requests \
+  $EXTRA_VLLM_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 
@@ -67,7 +68,9 @@ run_benchmark_serving \
     --num-prompts $(( $CONC * 10 )) \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/
+    --result-dir /workspace/ \
+    --server-pid "$SERVER_PID" \
+    --trust-remote-code
 
 # After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then

--- a/Magpie/scripts/benchmark/vllm_mi300x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi300x.sh
@@ -41,7 +41,7 @@ export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1
 export VLLM_ROCM_USE_AITER_MHA=0
 
-SERVER_LOG=/workspace/server.log
+SERVER_LOG=${SERVER_LOG:-/workspace/server.log}
 PORT=${PORT:-8888}
 
 set -x

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -44,14 +44,6 @@ export VLLM_ROCM_USE_AITER_MHA=0
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
-# Extract --served-model-name from EXTRA_VLLM_ARGS so the benchmark client
-# uses the same model name the server exposes via the API.
-BENCH_MODEL="$MODEL"
-if [[ "$EXTRA_VLLM_ARGS" =~ --served-model-name[[:space:]]+([^[:space:]]+) ]]; then
-    BENCH_MODEL="${BASH_REMATCH[1]}"
-    echo "Detected --served-model-name in EXTRA_VLLM_ARGS, benchmark client will use: $BENCH_MODEL"
-fi
-
 set -x
 vllm serve $MODEL --port $PORT \
   --tensor-parallel-size=$TP \
@@ -66,14 +58,8 @@ SERVER_PID=$!
 # Wait for server to be ready
 wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-TOKENIZER_ARGS=""
-if [[ "$BENCH_MODEL" != "$MODEL" ]]; then
-    TOKENIZER_ARGS="--tokenizer $MODEL"
-fi
-
 run_benchmark_serving \
-    --model "$BENCH_MODEL" \
-    $TOKENIZER_ARGS \
+    --model "$MODEL" \
     --port "$PORT" \
     --backend vllm \
     --input-len "$ISL" \

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -41,7 +41,7 @@ export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1
 export VLLM_ROCM_USE_AITER_MHA=0
 
-SERVER_LOG=/workspace/server.log
+SERVER_LOG=${SERVER_LOG:-/workspace/server.log}
 PORT=${PORT:-8888}
 
 set -x

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -44,6 +44,14 @@ export VLLM_ROCM_USE_AITER_MHA=0
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
+# Extract --served-model-name from EXTRA_VLLM_ARGS so the benchmark client
+# uses the same model name the server exposes via the API.
+BENCH_MODEL="$MODEL"
+if [[ "$EXTRA_VLLM_ARGS" =~ --served-model-name[[:space:]]+([^[:space:]]+) ]]; then
+    BENCH_MODEL="${BASH_REMATCH[1]}"
+    echo "Detected --served-model-name in EXTRA_VLLM_ARGS, benchmark client will use: $BENCH_MODEL"
+fi
+
 set -x
 vllm serve $MODEL --port $PORT \
   --tensor-parallel-size=$TP \
@@ -58,8 +66,14 @@ SERVER_PID=$!
 # Wait for server to be ready
 wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
+TOKENIZER_ARGS=""
+if [[ "$BENCH_MODEL" != "$MODEL" ]]; then
+    TOKENIZER_ARGS="--tokenizer $MODEL"
+fi
+
 run_benchmark_serving \
-    --model "$MODEL" \
+    --model "$BENCH_MODEL" \
+    $TOKENIZER_ARGS \
     --port "$PORT" \
     --backend vllm \
     --input-len "$ISL" \
@@ -70,6 +84,7 @@ run_benchmark_serving \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/ \
     --server-pid "$SERVER_PID" \
+    --trust-remote-code
 
 # After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -10,7 +10,7 @@ Benchmark mode enables framework-level performance benchmarking for LLM inferenc
 ├─────────────────────────────────────────────────────────────────────┤
 │  ┌───────────────┐    ┌───────────────┐    ┌────────────────────┐   │
 │  │BenchmarkConfig│  → │ BenchmarkMode │ →  │  BenchmarkResult   │   │
-│  │  (YAML)       │    │               │    │  (JSON)            │   │
+│  │  (YAML)       │    │               │    │  (JSON + CSV)      │   │
 │  └───────────────┘    └───────────────┘    └────────────────────┘   │
 │                               │                                     │
 │                               ▼                                     │
@@ -22,12 +22,14 @@ Benchmark mode enables framework-level performance benchmarking for LLM inferenc
 │  │  └─────────────┘        └─────────────────────────────────┘  │   │
 │  └──────────────────────────────────────────────────────────────┘   │
 │                               │                                     │
-│                               ▼                                     │
-│  ┌──────────────────────────────────────────────────────────────┐   │
-│  │                   TraceLens Analysis (Host)                  │   │
-│  │  • TraceLens_generate_perf_report_pytorch                    │   │
-│  │  • TraceLens_generate_multi_rank_collective_report_pytorch   │   │
-│  └──────────────────────────────────────────────────────────────┘   │
+│                      ┌────────┴────────┐                            │
+│                      ▼                 ▼                            │
+│  ┌────────────────────────┐  ┌─────────────────────────────────┐   │
+│  │  Gap Analysis (Host)   │  │  TraceLens Analysis (Host)      │   │
+│  │  • Time window filter  │  │  • Perf report (per-rank)       │   │
+│  │  • Category filter     │  │  • Multi-rank collective report │   │
+│  │  • Kernel stats CSV    │  │                                 │   │
+│  └────────────────────────┘  └─────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -39,6 +41,12 @@ python -m Magpie benchmark --benchmark-config examples/benchmark_vllm.yaml
 
 # vLLM with TraceLens analysis
 python -m Magpie benchmark --benchmark-config examples/benchmark_vllm_tracelens.yaml
+
+# vLLM with gap analysis (kernel bottleneck report)
+python -m Magpie benchmark --benchmark-config examples/benchmark_vllm_kimi_k2.yaml
+
+# Standalone gap analysis on existing traces
+python -m Magpie benchmark gap-analysis --trace-dir results/benchmark_vllm_<timestamp>/
 
 # SGLang benchmark
 python -m Magpie benchmark --benchmark-config examples/benchmark_sglang.yaml
@@ -105,6 +113,19 @@ benchmark:
       perf_report_enabled: true      # Single-rank performance report
       multi_rank_report_enabled: true # Multi-rank collective report
       gpu_arch_config: null    # Optional: GPU arch config for roofline
+
+  # Gap analysis (kernel bottleneck report)
+  gap_analysis:
+    enabled: true              # Enable gap analysis after benchmark
+    trace_start_pct: 50        # Start of analysis window (0-100)
+    trace_end_pct: 80          # End of analysis window (0-100)
+    top_k: 20                  # Number of top kernels in report
+    min_duration_us: 0.0       # Filter out events shorter than this (us)
+    categories:                # Event category whitelist (default: [kernel, gpu])
+      - kernel
+      - gpu
+    ignore_categories:         # Event category blacklist (default: [gpu_user_annotation])
+      - gpu_user_annotation
       
   # Execution settings
   docker_image: null           # Optional: override auto-selected image
@@ -132,6 +153,7 @@ benchmark:
 | `MAX_MODEL_LEN` | Maximum model context length | - |
 | `GPU_MEM_UTIL` | GPU memory utilization | 0.95 |
 | `ENABLE_PROFILE` | Enable torch profiler | "false" |
+| `EXTRA_VLLM_ARGS` | Additional arguments passed to `vllm serve` | "" |
 
 ## Profiling Options
 
@@ -165,17 +187,69 @@ TraceLens provides automated analysis of torch profiler traces:
 - Communication pattern analysis
 - Load balancing metrics
 
+### Gap Analysis
+
+Gap analysis identifies GPU kernel bottlenecks from torch profiler traces. It applies a configurable time window to focus on the steady-state portion of the trace, then aggregates kernel durations by category.
+
+**Pipeline:**
+1. Apply time window (`trace_start_pct` – `trace_end_pct`) to isolate steady-state events
+2. Filter by category (case-insensitive substring matching on the event `cat` field)
+3. Aggregate stats per kernel name, rank by total duration
+
+**CSV output columns:** `Name, Calls, Self CUDA total (us), Avg time (us), % Total`
+
+**Defaults (no YAML needed):**
+- `categories`: `["kernel", "gpu"]`
+- `ignore_categories`: `["gpu_user_annotation"]`
+
+**Minimal config:**
+```yaml
+  gap_analysis:
+    enabled: true
+    trace_start_pct: 50
+    trace_end_pct: 80
+```
+
+#### Standalone CLI
+
+Run gap analysis on existing trace directories without re-running the benchmark:
+
+```bash
+# Basic usage (uses default categories and ignore_categories)
+python -m Magpie benchmark gap-analysis \
+    --trace-dir results/benchmark_vllm_<timestamp>/
+
+# With custom window and categories
+python -m Magpie benchmark gap-analysis \
+    --trace-dir results/benchmark_vllm_<timestamp>/torch_trace \
+    --start-pct 50 --end-pct 80 \
+    --top-k 15 \
+    --categories kernel gpu \
+    --ignore-categories gpu_user_annotation
+```
+
+The `--trace-dir` argument accepts either a benchmark workspace directory (auto-detects `torch_trace/` inside) or a direct path to the trace directory.
+
+Output is written to a `gap_analysis/` subfolder under the trace directory's parent.
+
 ## Output Structure
 
 ```
 results/benchmark_vllm_<timestamp>/
-├── benchmark_result.json      # Main benchmark results
-├── benchmark_summary.txt      # Human-readable summary
-├── server.log                 # Server logs
-├── client.log                 # Client logs
+├── benchmark_report.json      # Main benchmark results
+├── summary.txt                # Human-readable summary
+├── config.yaml                # Snapshot of benchmark configuration
+├── container_stdout.log       # Container stdout
+├── container_stderr.log       # Container stderr
+├── inferencemax_result.json   # Raw InferenceMAX output
 ├── torch_trace/               # Raw torch profiler traces
-│   ├── rank-0.*.pt.trace.json.gz
-│   ├── rank-1.*.pt.trace.json.gz
+│   ├── *-rank-0.*.pt.trace.json.gz
+│   ├── *-rank-1.*.pt.trace.json.gz
+│   └── ...
+├── gap_analysis/              # Gap analysis output (if enabled)
+│   ├── gap_analysis.csv       # Merged kernel stats across all ranks
+│   ├── gap_analysis_rank0.csv # Per-rank kernel stats
+│   ├── gap_analysis_rank1.csv
 │   └── ...
 ├── tracelens_rank0_csvs/      # Single-rank TraceLens analysis
 │   ├── gpu_timeline.csv
@@ -191,24 +265,28 @@ The `benchmark_result.json` contains:
 
 ```json
 {
-  "task_id": "benchmark_vllm_20260211_190617",
+  "success": true,
   "framework": "vllm",
-  "model": "deepseek-ai/DeepSeek-R1-0528",
-  "status": "success",
-  "metrics": {
-    "throughput_tps": 125.5,
-    "latency_p50_ms": 45.2,
-    "latency_p99_ms": 128.3,
-    "total_tokens": 50000,
-    "duration_seconds": 398.4
+  "model": "amd/Kimi-K2-Thinking-MXFP4",
+  "throughput": {
+    "request_throughput": 0.16,
+    "output_throughput": 1.13,
+    "total_token_throughput": 1192.76,
+    "completed_requests": 40
   },
-  "kernel_summary": [...],
-  "top_bottlenecks": [...],
-  "tracelens_analysis": {
-    "enabled": true,
-    "output_files": [...],
-    "errors": []
-  }
+  "latency": {
+    "ttft": { "mean_ms": 1185.44, "p99_ms": 1969.59 },
+    "tpot": { "mean_ms": 131.09, "p99_ms": 282.21 }
+  },
+  "gap_analysis": {
+    "config": { "trace_start_pct": 50, "trace_end_pct": 80, "categories": ["kernel", "gpu"] },
+    "csv_path": "results/.../gap_analysis/gap_analysis.csv",
+    "top_kernels": [
+      { "name": "rcclGenericKernel<...>", "calls": 19620, "self_cuda_total_us": 28999961.95, "pct_total": 44.0 },
+      { "name": "kernel_moe_mxgemm_2lds<...>", "calls": 9360, "self_cuda_total_us": 12495324.68, "pct_total": 18.9 }
+    ]
+  },
+  "tracelens_analysis": { "output_files": [...] }
 }
 ```
 
@@ -338,6 +416,7 @@ python -m Magpie benchmark --benchmark-config config.yaml --log-level DEBUG
 | `BenchmarkMode` | `benchmarker.py` | Main orchestrator |
 | `BenchmarkConfig` | `config.py` | Configuration dataclasses |
 | `TraceLensAnalyzer` | `tracelens.py` | TraceLens CLI integration |
+| `GapAnalyzer` | `gap_analysis.py` | Kernel bottleneck analysis |
 | `BenchmarkResult` | `result.py` | Result data structures |
 
 ### Execution Flow
@@ -346,9 +425,10 @@ python -m Magpie benchmark --benchmark-config config.yaml --log-level DEBUG
 2. **Docker Setup**: Prepare container with InferenceMAX scripts
 3. **Server Launch**: Start vLLM/SGLang server inside container
 4. **Client Execution**: Run benchmark client with profiling enabled
-5. **Trace Collection**: Copy torch profiler traces from container
-6. **TraceLens Analysis**: Run TraceLens CLI commands on host
-7. **Result Generation**: Aggregate metrics and generate reports
+5. **Trace Collection**: Torch profiler traces saved to workspace
+6. **TraceLens Analysis**: Run TraceLens CLI commands on host (if enabled)
+7. **Gap Analysis**: Analyze kernel bottlenecks within time window (if enabled)
+8. **Result Generation**: Aggregate metrics and generate reports
 
 ## Related
 

--- a/examples/benchmark_vllm.yaml
+++ b/examples/benchmark_vllm.yaml
@@ -30,6 +30,12 @@ benchmark:
     system_profiler:
       enabled: false
       
+  gap_analysis:
+    enabled: false
+    trace_start_pct: 50
+    trace_end_pct: 80
+    top_k: 20
+
   # Will auto-clone InferenceMAX if not specified
   # inferencemax_path: ""
   

--- a/examples/benchmark_vllm_gptoss_120b.yaml
+++ b/examples/benchmark_vllm_gptoss_120b.yaml
@@ -1,0 +1,37 @@
+# vLLM Benchmark Configuration for openai/gpt-oss-120b (FP4, MI355X)
+# ====================================================================
+#
+# Usage:
+#   python -m Magpie benchmark --benchmark-config examples/benchmark_vllm_gptoss_120b.yaml
+#
+# Script resolution (auto):
+#   framework=vllm + precision=fp4 + runner=mi355x -> gptoss_fp4_mi355x.sh
+
+benchmark:
+  framework: vllm
+  model: openai/gpt-oss-120b
+  precision: fp4
+
+  envs:
+    TP: 8
+    CONC: 32
+    ISL: 1024
+    OSL: 1024
+    RANDOM_RANGE_RATIO: 1
+    MAX_MODEL_LEN: 2248   # ISL + OSL + 200
+
+  profiler:
+    torch_profiler:
+      enabled: true
+    system_profiler:
+      enabled: false
+    tracelens:
+      enabled: false
+
+  docker_image: "vllm/vllm-openai-rocm:v0.15.1"
+  script: "gptoss_fp4_mi355x.sh"
+
+  gap_analysis:
+    enabled: true
+
+  timeout_seconds: 3600

--- a/examples/benchmark_vllm_gptoss_120b.yaml
+++ b/examples/benchmark_vllm_gptoss_120b.yaml
@@ -4,8 +4,7 @@
 # Usage:
 #   python -m Magpie benchmark --benchmark-config examples/benchmark_vllm_gptoss_120b.yaml
 #
-# Script resolution (auto):
-#   framework=vllm + precision=fp4 + runner=mi355x -> gptoss_fp4_mi355x.sh
+# Uses Magpie generic script vllm_mi355x.sh (compatible with vLLM v0.15.1)
 
 benchmark:
   framework: vllm
@@ -18,7 +17,12 @@ benchmark:
     ISL: 1024
     OSL: 1024
     RANDOM_RANGE_RATIO: 1
-    MAX_MODEL_LEN: 2248   # ISL + OSL + 200
+    MAX_MODEL_LEN: 2248  # ISL + OSL + 200
+    # MI355X performance flags (supplements vllm_mi355x.sh defaults)
+    VLLM_USE_AITER_TRITON_FUSED_SPLIT_QKV_ROPE: 1
+    VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD: 1
+    TRITON_HIP_PRESHUFFLE_SCALES: 1
+    VLLM_USE_AITER_TRITON_GEMM: 1
 
   profiler:
     torch_profiler:
@@ -29,7 +33,7 @@ benchmark:
       enabled: false
 
   docker_image: "vllm/vllm-openai-rocm:v0.15.1"
-  script: "gptoss_fp4_mi355x.sh"
+  benchmark_script: "vllm_mi355x.sh"
 
   gap_analysis:
     enabled: true

--- a/examples/benchmark_vllm_gptoss_120b.yaml
+++ b/examples/benchmark_vllm_gptoss_120b.yaml
@@ -18,7 +18,12 @@ benchmark:
     OSL: 1024
     RANDOM_RANGE_RATIO: 1
     MAX_MODEL_LEN: 2248  # ISL + OSL + 200
+    EXTRA_VLLM_ARGS: "--no-enable-prefix-caching --block-size 64"
+
     # MI355X performance flags (supplements vllm_mi355x.sh defaults)
+    VLLM_ROCM_USE_AITER: 1
+    VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: 1
+    VLLM_ROCM_USE_AITER_MHA: 0
     VLLM_USE_AITER_TRITON_FUSED_SPLIT_QKV_ROPE: 1
     VLLM_USE_AITER_TRITON_FUSED_ADD_RMSNORM_PAD: 1
     TRITON_HIP_PRESHUFFLE_SCALES: 1
@@ -38,4 +43,4 @@ benchmark:
   gap_analysis:
     enabled: true
 
-  timeout_seconds: 3600
+  timeout_seconds: 5400

--- a/examples/benchmark_vllm_kimi_k2.yaml
+++ b/examples/benchmark_vllm_kimi_k2.yaml
@@ -1,0 +1,29 @@
+benchmark:
+  framework: vllm
+  model: amd/Kimi-K2-Thinking-MXFP4
+  precision: mxfp4
+
+  envs:
+    TP: 4
+    CONC: 4
+    ISL: 8192
+    OSL: 8
+    RANDOM_RANGE_RATIO: 0.8
+    MAX_MODEL_LEN: 131072
+    EXTRA_VLLM_ARGS: "--block-size 1 --served-model-name kimi-k2-mxfp4 --enable-auto-tool-choice --tool-call-parser kimi_k2"
+    VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "0"
+    AMDGCN_USE_BUFFER_OPS: "1"
+
+  profiler:
+    torch_profiler:
+      enabled: true
+    tracelens:
+      enabled: false
+
+  docker_image: "rocm/vllm-private:mlperf_0.14_vllm"
+  timeout_seconds: 3600
+
+  gap_analysis:
+    enabled: true
+    trace_start_pct: 50
+    trace_end_pct: 80

--- a/examples/benchmark_vllm_kimi_k2.yaml
+++ b/examples/benchmark_vllm_kimi_k2.yaml
@@ -10,7 +10,7 @@ benchmark:
     OSL: 8
     RANDOM_RANGE_RATIO: 0.8
     MAX_MODEL_LEN: 131072
-    EXTRA_VLLM_ARGS: "--block-size 1 --served-model-name kimi-k2-mxfp4 --enable-auto-tool-choice --tool-call-parser kimi_k2"
+    EXTRA_VLLM_ARGS: "--block-size 1 --enable-auto-tool-choice --tool-call-parser kimi_k2"
     VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "0"
     AMDGCN_USE_BUFFER_OPS: "1"
 

--- a/examples/benchmark_vllm_kimi_k2.yaml
+++ b/examples/benchmark_vllm_kimi_k2.yaml
@@ -3,7 +3,7 @@ benchmark:
   model: amd/Kimi-K2-Thinking-MXFP4
   precision: mxfp4
 
-  envs:
+  envs:                             # environment variables
     TP: 4
     CONC: 4
     ISL: 8192
@@ -11,19 +11,19 @@ benchmark:
     RANDOM_RANGE_RATIO: 0.8
     MAX_MODEL_LEN: 131072
     EXTRA_VLLM_ARGS: "--block-size 1 --enable-auto-tool-choice --tool-call-parser kimi_k2"
-    VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "0"
-    AMDGCN_USE_BUFFER_OPS: "1"
 
   profiler:
     torch_profiler:
       enabled: true
+    system_profiler:
+      enabled: false
     tracelens:
       enabled: false
 
   docker_image: "rocm/vllm-private:mlperf_0.14_vllm"
   timeout_seconds: 3600
 
-  gap_analysis:
+  gap_analysis:                      # gap analysis configuration(only support vllm)
     enabled: true
     trace_start_pct: 50
     trace_end_pct: 80


### PR DESCRIPTION
- Add `gap_analysis` module to benchmark mode that analyzes torch profiler traces and identifies GPU kernel bottlenecks, producing per-rank and merged CSV reports with columns: `Name, Calls, Self CUDA total (us), Avg time (us), % Total`
- Support configurable time window (trace_start_pct/trace_end_pct) to focus on steady-state trace segments, and category filtering (defaults: categories: [kernel, gpu], ignore_categories: [gpu_user_annotation]) using case-insensitive substring matching
- Integrate as automatic post-benchmark step (when gap_analysis.enabled: true) **and** as standalone CLI (magpie benchmark gap-analysis --trace-dir <path>)
- switch to latest official InferenceX (since it support profling)