### PR TITLE
Handle vLLM 0.17 rank trace filenames

### DIFF
--- a/Magpie/modes/benchmark/gap_analysis.py
+++ b/Magpie/modes/benchmark/gap_analysis.py
@@ -259,29 +259,32 @@ class GapAnalyzer:
         """
         Discover per-rank trace files in *trace_dir*.
 
-        Rank traces match ``*-rank-N.*.json.gz`` or ``*-rank-N.*.json``.
-        Falls back to any ``.json.gz`` / ``.json`` if no rank pattern found.
+        Rank traces match vLLM-style ``*rankN*.json.gz`` or the older
+        ``*-rank-N.*.json.gz`` naming. Async coordinator traces such as
+        ``async_llm`` are excluded because they are not per-rank GPU traces.
+        Falls back to non-async ``.json.gz`` / ``.json`` if no rank pattern
+        is found.
         """
         rank_files: List[Tuple[int, Path]] = []
 
-        for gz in sorted(trace_dir.glob("*-rank-*.pt.trace.json.gz")):
-            rank = _extract_rank(gz.name)
-            if rank is not None:
-                rank_files.append((rank, gz))
-        if rank_files:
-            return sorted(rank_files, key=lambda x: x[0])
+        def _candidate_paths(pattern: str) -> List[Path]:
+            return sorted(
+                path for path in trace_dir.glob(pattern)
+                if "async_llm" not in path.name
+            )
 
-        for jf in sorted(trace_dir.glob("*-rank-*.pt.trace.json")):
-            rank = _extract_rank(jf.name)
-            if rank is not None:
-                rank_files.append((rank, jf))
-        if rank_files:
-            return sorted(rank_files, key=lambda x: x[0])
+        for pattern in ("*rank*.pt.trace.json.gz", "*rank*.pt.trace.json"):
+            for path in _candidate_paths(pattern):
+                rank = _extract_rank(path.name)
+                if rank is not None:
+                    rank_files.append((rank, path))
+            if rank_files:
+                return sorted(rank_files, key=lambda x: x[0])
 
-        # Fallback: any trace file (e.g. async_llm trace)
-        for idx, gz in enumerate(sorted(trace_dir.glob("*.json.gz"))):
+        # Fallback: any non-async trace file.
+        for idx, gz in enumerate(_candidate_paths("*.json.gz")):
             rank_files.append((idx, gz))
-        for idx, jf in enumerate(sorted(trace_dir.glob("*.json")), start=len(rank_files)):
+        for idx, jf in enumerate(_candidate_paths("*.json"), start=len(rank_files)):
             rank_files.append((idx, jf))
 
         return sorted(rank_files, key=lambda x: x[0])
@@ -545,6 +548,6 @@ class GapAnalyzer:
 
 
 def _extract_rank(filename: str) -> Optional[int]:
-    """Extract rank number from a filename like ``...-rank-0.1234...``."""
-    m = re.search(r"-rank-(\d+)\.", filename)
+    """Extract rank number from vLLM trace filenames."""
+    m = re.search(r"(?:-rank-|_rank)(\d+)(?:\.|_)", filename)
     return int(m.group(1)) if m else None


### PR DESCRIPTION
## Summary
- match both legacy `-rank-0` and current vLLM `rank0` torch profiler filenames
- exclude `async_llm` coordinator traces from per-rank gap analysis discovery
- keep the fallback path limited to non-async trace files

## Problem
With `vllm 0.17.0`, torch profiler outputs rank traces like:
- `dp0_pp0_tp0_dcp0_ep0_rank0....pt.trace.json.gz`
- `dp0_pp0_tp1_dcp0_ep1_rank1....pt.trace.json.gz`

and also emits a coordinator trace like:
- `...async_llm....pt.trace.json.gz`

`GapAnalyzer.detect_trace_files()` only matched the older `-rank-0` style. That meant rank detection failed, the code fell back to `*.json.gz`, and `async_llm` was incorrectly counted as an extra rank.

## Validation
Validated against a real `vllm 0.17.0` Kimi K2.5 trace directory from an MI355 run:
- before: fallback path picked up 5 traces including `async_llm`
- after: detector returns exactly 4 rank traces (`rank0..rank3`)

## Notes
I did not add a unit test in this patch because I was validating against the live trace artifacts first. The next clean step would be a small test covering both filename styles and the `async_llm` exclusion.
