### PR TITLE
Add `Metrix` as alternative HIP kernel profiling backend

### DIFF
--- a/Magpie/config.yaml
+++ b/Magpie/config.yaml
@@ -92,7 +92,11 @@ compiling:
 performance:
   # Timeout for profiling operations (seconds)
   timeout_seconds: 600
-  
+
+  # Backend selection for AMD GPUs: "rocprof_compute" (default) or "metrix"
+  # When unset, auto-selects based on kernel type (HIP -> rocprof_compute)
+  # backend: rocprof_compute
+
   # rocprof-compute settings (AMD GPU)
   # Two-stage profiler: profile (collect data) + analyze (generate metrics)
   rocprof_compute:
@@ -124,6 +128,16 @@ performance:
     args: ["--target-processes", "all"]
     metrics: []
 
+  # IntelliKit Metrix settings (AMD GPU)
+  # Human-readable GPU metrics via rocprofv3
+  # Activate by setting: backend: metrix
+  metrix:
+    profile: null              # Preset: "quick", "memory", "compute", or null for all
+    metrics: []                # Specific metrics, e.g. ["memory.l2_hit_rate"]
+    kernel_filter: null        # Regex to filter kernel names
+    num_replays: 1             # Number of profiling runs for statistics
+    timeout_seconds: 60        # Timeout per profiling run
+
 
 compare:
   # Per-backend weights (rocprof-compute for AMD, ncu for NVIDIA)
@@ -148,6 +162,13 @@ compare:
     lts__throughput.avg.pct_of_peak_sustained_elapsed: 0.10
     dram__throughput.avg.pct_of_peak_sustained_elapsed: 0.20
     duration_ns_total: 0.20
+  perf_weights_metrix:
+    memory.hbm_bandwidth_utilization: 0.20
+    memory.l2_hit_rate: 0.15
+    memory.l1_hit_rate: 0.10
+    memory.coalescing_efficiency: 0.10
+    compute.hbm_arithmetic_intensity: 0.15
+    duration_ns_total: 0.30
 
 benchmark:
   # Path to separate image mapping configuration file

--- a/Magpie/config.yaml
+++ b/Magpie/config.yaml
@@ -132,11 +132,11 @@ performance:
   # Human-readable GPU metrics via rocprofv3
   # Activate by setting: backend: metrix
   metrix:
-    profile: null              # Preset: "quick", "memory", "compute", or null for all
+    profile: null               # Preset: "quick", "memory", "compute", or null for all
     metrics: []                # Specific metrics, e.g. ["memory.l2_hit_rate"]
-    kernel_filter: null        # Regex to filter kernel names
+    kernel_filter: null         # Regex to filter kernel names
     num_replays: 1             # Number of profiling runs for statistics
-    timeout_seconds: 60        # Timeout per profiling run
+    timeout_seconds: 600       # Timeout per profiling run
 
 
 compare:

--- a/Magpie/config/__init__.py
+++ b/Magpie/config/__init__.py
@@ -29,7 +29,9 @@ from .performance import (
     PerformanceConfig,
     RocprofComputeConfig,
     NcuConfig,
+    MetrixConfig,
     ROCPROF_KEY_METRICS,
+    METRIX_KEY_METRICS,
     DEFAULT_ROCPROF_METRIC_BLOCKS,
 )
 
@@ -50,6 +52,8 @@ __all__ = [
     "PerformanceConfig",
     "RocprofComputeConfig",
     "NcuConfig",
+    "MetrixConfig",
     "ROCPROF_KEY_METRICS",
+    "METRIX_KEY_METRICS",
     "DEFAULT_ROCPROF_METRIC_BLOCKS",
 ]

--- a/Magpie/config/performance.py
+++ b/Magpie/config/performance.py
@@ -24,6 +24,7 @@ class PerfBackend(Enum):
 
     ROCPROF_COMPUTE = auto()  # rocprof-compute for HIP/AMD GPUs
     NCU = auto()  # NVIDIA Nsight Compute for CUDA
+    METRIX = auto()  # IntelliKit Metrix for HIP/AMD GPUs (uses rocprofv3)
     NONE = auto()  # No profiling
 
 
@@ -78,6 +79,83 @@ ROCPROF_KEY_METRICS = {
     "SALU": "Inst_SALU",
     "SMEM": "Inst_SMEM",
 }
+
+
+METRIX_KEY_METRICS = {
+    "memory.hbm_read_bandwidth": "HBM_Read_BW",
+    "memory.hbm_write_bandwidth": "HBM_Write_BW",
+    "memory.hbm_bandwidth_utilization": "HBM_BW_Util",
+    "memory.bytes_transferred_hbm": "HBM_Bytes",
+    "memory.bytes_transferred_l2": "L2_Bytes",
+    "memory.bytes_transferred_l1": "L1_Bytes",
+    "memory.l1_hit_rate": "L1_HitRate",
+    "memory.l2_hit_rate": "L2_HitRate",
+    "memory.l2_bandwidth": "L2_BW",
+    "memory.coalescing_efficiency": "Coalescing_Eff",
+    "memory.global_load_efficiency": "Global_Load_Eff",
+    "memory.global_store_efficiency": "Global_Store_Eff",
+    "memory.lds_bank_conflicts": "LDS_Conflicts",
+    "memory.atomic_latency": "Atomic_Latency",
+    "compute.total_flops": "Total_FLOPs",
+    "compute.hbm_gflops": "HBM_GFLOPS",
+    "compute.hbm_arithmetic_intensity": "HBM_Arith_Intensity",
+    "compute.l2_arithmetic_intensity": "L2_Arith_Intensity",
+    "compute.l1_arithmetic_intensity": "L1_Arith_Intensity",
+}
+
+
+@dataclass
+class MetrixConfig:
+    """
+    Configuration for IntelliKit Metrix profiler.
+
+    Metrix wraps rocprofv3 and provides human-readable GPU metrics.
+    CLI: ``metrix profile [options] -- <command>``
+
+    Attributes:
+        profile: Preset profile name ("quick", "memory", "compute") or None
+        metrics: Specific metric names to collect, e.g. ["memory.l2_hit_rate"]
+        kernel_filter: Regex to filter kernels by name
+        num_replays: Number of profiling runs for min/max/avg statistics
+        timeout_seconds: Timeout per profiling run in seconds
+        extra_args: Additional CLI arguments passed to ``metrix profile``
+    """
+
+    profile: Optional[str] = None
+    metrics: List[str] = field(default_factory=list)
+    kernel_filter: Optional[str] = None
+    num_replays: int = 1
+    timeout_seconds: int = 60
+    extra_args: List[str] = field(default_factory=list)
+
+    def get_profile_args(self, output_path: str) -> List[str]:
+        """Build ``metrix profile`` command arguments.
+
+        Args:
+            output_path: Path for the JSON output file.
+
+        Returns:
+            List of CLI arguments (without the leading ``metrix profile``).
+        """
+        args: List[str] = []
+
+        args.extend(["--output", output_path])
+        args.extend(["--num-replays", str(self.num_replays)])
+        args.extend(["--timeout", str(self.timeout_seconds)])
+        args.append("--aggregate")
+
+        if self.profile:
+            args.extend(["--profile", self.profile])
+
+        if self.metrics:
+            args.extend(["--metrics", ",".join(self.metrics)])
+
+        if self.kernel_filter:
+            args.extend(["--kernel", self.kernel_filter])
+
+        args.extend(self.extra_args)
+
+        return args
 
 
 @dataclass
@@ -241,6 +319,7 @@ class PerformanceConfig:
     profiler_args: List[str] = field(default_factory=list)  # Legacy
     rocprof_config: Optional[RocprofComputeConfig] = None
     ncu_config: Optional[NcuConfig] = None
+    metrix_config: Optional[MetrixConfig] = None
 
     def __post_init__(self):
         # Auto-select backend based on kernel type if not specified
@@ -261,6 +340,8 @@ class PerformanceConfig:
             self.rocprof_config = RocprofComputeConfig()
         if self.ncu_config is None:
             self.ncu_config = NcuConfig()
+        if self.metrix_config is None:
+            self.metrix_config = MetrixConfig()
 
     def _backend_for_gpu_arch(self) -> PerfBackend:
         """Select profiling backend based on detected GPU architecture.

--- a/Magpie/config/performance.py
+++ b/Magpie/config/performance.py
@@ -121,6 +121,7 @@ class MetrixConfig:
         extra_args: Additional CLI arguments passed to ``metrix profile``
     """
 
+    output_dir: Optional[str] = None
     profile: Optional[str] = None
     metrics: List[str] = field(default_factory=list)
     kernel_filter: Optional[str] = None
@@ -181,6 +182,7 @@ class RocprofComputeConfig:
         target_gpu: Target GPU architecture (e.g., "gfx942", auto-detected if None)
     """
 
+    output_dir: Optional[str] = None
     workload_dir: str = "./workloads"
     profile_args: List[str] = field(default_factory=list)
     analyze_args: List[str] = field(default_factory=list)
@@ -253,9 +255,10 @@ class RocprofComputeConfig:
         if self.metric_blocks:
             args.extend(["-b"] + self.metric_blocks)
 
-        # Save dataframes to CSV if output format is csv
         if output_dir and self.output_format == "csv":
-            args.extend(["--save-dfs", output_dir])
+            args.extend(["--output-format", "csv", "--output-name", output_dir])
+        elif self.output_format == "csv":
+            args.extend(["--output-format", "csv"])
 
         # Add custom analyze args (split to support single-string entries)
         args.extend(self._expand_args(self.analyze_args))

--- a/Magpie/core/executor.py
+++ b/Magpie/core/executor.py
@@ -602,6 +602,7 @@ def _execute_task_worker(task_dict: Dict[str, Any]) -> Dict[str, Any]:
                 profiler_args=mode_cfg.get("profiler_args", []),
                 rocprof_config=mode_cfg.get("rocprof_config", {}),
                 ncu_config=mode_cfg.get("ncu_config", {}),
+                metrix_config=mode_cfg.get("metrix_config", {}),
                 gpu_arch=mode_cfg.get("gpu_arch", None),
             )
             analyzer = AnalyzeMode(analyze_config)
@@ -624,10 +625,12 @@ def _execute_task_worker(task_dict: Dict[str, Any]) -> Dict[str, Any]:
                 profiler_args=mode_cfg.get("profiler_args", []),
                 rocprof_config=mode_cfg.get("rocprof_config", {}),
                 ncu_config=mode_cfg.get("ncu_config", {}),
+                metrix_config=mode_cfg.get("metrix_config", {}),
                 gpu_arch=mode_cfg.get("gpu_arch", None),
                 winner_strategy=compare_cfg.get("winner_strategy", "perf_score"),
                 perf_weights_rocprof=compare_cfg.get("perf_weights_rocprof", {}),
                 perf_weights_ncu=compare_cfg.get("perf_weights_ncu", {}),
+                perf_weights_metrix=compare_cfg.get("perf_weights_metrix", {}),
             )
             comparator = CompareMode(compare_config)
 

--- a/Magpie/core/scheduler.py
+++ b/Magpie/core/scheduler.py
@@ -150,6 +150,7 @@ class Scheduler:
         profiler_args: Optional[List[str]] = None,
         rocprof_config: Optional[Dict[str, Any]] = None,
         ncu_config: Optional[Dict[str, Any]] = None,
+        metrix_config: Optional[Dict[str, Any]] = None,
         baseline_index: int = 0,
         compare_config: Optional[Dict[str, Any]] = None,
         benchmark_config: Optional[Dict[str, Any]] = None,
@@ -185,6 +186,7 @@ class Scheduler:
             profiler_args=profiler_args or [],
             rocprof_config=rocprof_config or {},
             ncu_config=ncu_config or {},
+            metrix_config=metrix_config or {},
             baseline_index=baseline_index,
             compare_config=compare_config or {},
             benchmark_config=benchmark_config or {},
@@ -270,6 +272,7 @@ class Scheduler:
         profiler_args: Optional[List[str]] = None,
         rocprof_config: Optional[Dict[str, Any]] = None,
         ncu_config: Optional[Dict[str, Any]] = None,
+        metrix_config: Optional[Dict[str, Any]] = None,
     ) -> TaskResult:
         """
         Convenience method to run analyze mode.
@@ -283,6 +286,7 @@ class Scheduler:
             profiler_args: Additional arguments for the profiler (legacy)
             rocprof_config: rocprof-compute configuration dict
             ncu_config: ncu configuration dict
+            metrix_config: Metrix configuration dict
 
         Returns:
             TaskResult with analysis results
@@ -297,6 +301,7 @@ class Scheduler:
             profiler_args=profiler_args,
             rocprof_config=rocprof_config,
             ncu_config=ncu_config,
+            metrix_config=metrix_config,
         )
         return self.execute(task)
 
@@ -311,6 +316,7 @@ class Scheduler:
         profiler_args: Optional[List[str]] = None,
         rocprof_config: Optional[Dict[str, Any]] = None,
         ncu_config: Optional[Dict[str, Any]] = None,
+        metrix_config: Optional[Dict[str, Any]] = None,
         compare_config: Optional[Dict[str, Any]] = None,
     ) -> TaskResult:
         """
@@ -326,6 +332,7 @@ class Scheduler:
             profiler_args: Additional arguments for the profiler (legacy)
             rocprof_config: rocprof-compute configuration dict
             ncu_config: ncu configuration dict
+            metrix_config: Metrix configuration dict
 
         Returns:
             TaskResult with comparison results
@@ -341,6 +348,7 @@ class Scheduler:
             profiler_args=profiler_args,
             rocprof_config=rocprof_config,
             ncu_config=ncu_config,
+            metrix_config=metrix_config,
             compare_config=compare_config,
         )
         return self.execute(task)
@@ -461,6 +469,7 @@ class Scheduler:
         profiler_args: Optional[List[str]] = None,
         rocprof_config: Optional[Dict[str, Any]] = None,
         ncu_config: Optional[Dict[str, Any]] = None,
+        metrix_config: Optional[Dict[str, Any]] = None,
     ) -> List[TaskResult]:
         """
         Run multiple analyze tasks in parallel at Scheduler level.
@@ -495,6 +504,7 @@ class Scheduler:
                 profiler_args=profiler_args,
                 rocprof_config=rocprof_config,
                 ncu_config=ncu_config,
+                metrix_config=metrix_config,
             )
             tasks.append(task)
 
@@ -511,6 +521,7 @@ class Scheduler:
         profiler_args: Optional[List[str]] = None,
         rocprof_config: Optional[Dict[str, Any]] = None,
         ncu_config: Optional[Dict[str, Any]] = None,
+        metrix_config: Optional[Dict[str, Any]] = None,
     ) -> List[TaskResult]:
         """
         Run multiple compare tasks in parallel at Scheduler level.
@@ -544,6 +555,7 @@ class Scheduler:
                 profiler_args=profiler_args,
                 rocprof_config=rocprof_config,
                 ncu_config=ncu_config,
+                metrix_config=metrix_config,
             )
             tasks.append(task)
 

--- a/Magpie/core/task.py
+++ b/Magpie/core/task.py
@@ -61,6 +61,7 @@ class ModeConfig:
     profiler_args: List[str] = field(default_factory=list)
     rocprof_config: Dict[str, Any] = field(default_factory=dict)
     ncu_config: Dict[str, Any] = field(default_factory=dict)
+    metrix_config: Dict[str, Any] = field(default_factory=dict)
     baseline_index: int = 0  # For compare mode
     compare_config: Dict[str, Any] = field(default_factory=dict)
     benchmark_config: Dict[str, Any] = field(default_factory=dict)  # For benchmark mode
@@ -115,6 +116,7 @@ class Task:
                 "profiler_args": self.mode_config.profiler_args,
                 "rocprof_config": self.mode_config.rocprof_config,
                 "ncu_config": self.mode_config.ncu_config,
+                "metrix_config": self.mode_config.metrix_config,
                 "baseline_index": self.mode_config.baseline_index,
                 "compare_config": self.mode_config.compare_config,
                 "benchmark_config": self.mode_config.benchmark_config,

--- a/Magpie/eval/performance.py
+++ b/Magpie/eval/performance.py
@@ -331,21 +331,14 @@ class Performance:
         rocprof_cfg = self.perf_cfg.rocprof_config
         assert rocprof_cfg is not None
 
-        # Create workload directory
-        timestamp = int(time.time())
-        kernel_name = kernel_cfg.kernel_id or "kernel"
-        # Sanitize kernel name for directory
-        safe_kernel_name = "".join(
-            c if c.isalnum() or c in "-_" else "_" for c in kernel_name
-        )
-        workload_name = f"{safe_kernel_name}_{timestamp}"
-
-        # Use working directory as base for workload output
-        workload_base_dir = (
-            Path(working_dir or str(Path.cwd())) / rocprof_cfg.workload_dir
-        )
-        workload_base_dir.mkdir(parents=True, exist_ok=True)
-        workload_path = workload_base_dir / workload_name
+        workload_name = "rocprof_compute_output"
+        if rocprof_cfg.output_dir:
+            workload_dir = Path(rocprof_cfg.output_dir) / workload_name
+        else:
+            workload_dir = (
+                Path(working_dir or str(Path.cwd())) / rocprof_cfg.workload_dir / workload_name
+            )
+        workload_dir.mkdir(parents=True, exist_ok=True)
 
         all_outputs = []
         all_errors = []
@@ -353,10 +346,9 @@ class Performance:
         try:
             # ===== Stage 1: Profile =====
             for cmd_idx, testcase_cmd in enumerate(testcase_commands):
-                # Build rocprof-compute profile command
                 profile_args = rocprof_cfg.get_profile_args(
-                    workload_name=f"{workload_name}_run{cmd_idx}",
-                    output_dir=str(workload_base_dir),
+                    workload_name=workload_name,
+                    output_dir=str(workload_dir),
                 )
 
                 cmd = [
@@ -396,50 +388,22 @@ class Performance:
                         raw_output="\n".join(all_outputs),
                         errors=f"rocprof-compute profile failed on testcase {cmd_idx + 1}: {result.stderr or result.stdout}",
                         command=cmd_str,
-                        workload_dir=str(workload_path),
+                        workload_dir=str(workload_dir),
                     )
 
-            # Find the workload directory created by profile
-            # rocprof-compute creates a directory named like: workload_name/
-            actual_workload_dir = None
-            for d in workload_base_dir.iterdir():
-                if d.is_dir() and workload_name in d.name:
-                    actual_workload_dir = d
-                    break
-
-            if actual_workload_dir is None:
-                # Try to find any directory matching the pattern
-                for d in workload_base_dir.iterdir():
-                    if d.is_dir() and safe_kernel_name in d.name:
-                        actual_workload_dir = d
-                        break
-
-            if actual_workload_dir is None:
+            # v3.4.0 writes data directly to the -p path
+            if not (workload_dir / "pmc_perf.csv").exists():
                 return PerformanceResult(
                     success=False,
                     raw_output="\n".join(all_outputs),
-                    errors=f"Could not find workload directory in {workload_base_dir}",
-                    workload_dir=str(workload_base_dir),
+                    errors=f"No profiling data (pmc_perf.csv) found in {workload_dir}",
+                    workload_dir=str(workload_dir),
                 )
 
-            # rocprof-compute creates GPU-specific subdirectories (e.g., MI300X_A1/)
-            # Find the GPU subdirectory containing the profiling data
-            gpu_data_dir = None
-            for subdir in actual_workload_dir.iterdir():
-                if subdir.is_dir() and (subdir / "pmc_perf.csv").exists():
-                    gpu_data_dir = subdir
-                    break
-
-            # Use the GPU data directory for analysis if found, otherwise use workload dir
-            analyze_dir = gpu_data_dir if gpu_data_dir else actual_workload_dir
-
             # ===== Stage 2: Analyze =====
-            # Create output directory for CSV files
-            csv_output_dir = actual_workload_dir / "analysis"
-            csv_output_dir.mkdir(parents=True, exist_ok=True)
-
+            analysis_output_dir = workload_dir / "analysis"
             analyze_args = rocprof_cfg.get_analyze_args(
-                str(analyze_dir), output_dir=str(csv_output_dir)
+                str(workload_dir), output_dir="analysis"
             )
             analyze_cmd = [
                 "rocprof-compute",
@@ -456,7 +420,7 @@ class Performance:
                 capture_output=True,
                 text=True,
                 env=env,
-                cwd=working_dir,
+                cwd=str(workload_dir),
                 timeout=self.perf_cfg.timeout_seconds,
             )
 
@@ -470,13 +434,12 @@ class Performance:
                     raw_output="\n".join(all_outputs),
                     errors=f"rocprof-compute analyze failed: {analyze_result.stderr or analyze_result.stdout}",
                     command=analyze_cmd_str,
-                    workload_dir=str(actual_workload_dir),
+                    workload_dir=str(workload_dir),
                 )
 
             # ===== Parse Results =====
-            # Parse from both the GPU data directory (for raw metrics) and analysis output directory
             metrics, kernel_metrics = self._parse_rocprof_workload(
-                gpu_data_dir or actual_workload_dir, csv_output_dir
+                workload_dir, analysis_output_dir
             )
 
             return PerformanceResult(
@@ -486,25 +449,21 @@ class Performance:
                 else [MetricResult(name="profiling_complete", value=1.0, unit="bool")],
                 kernel_metrics=kernel_metrics,
                 raw_output="\n".join(all_outputs),
-                workload_dir=str(actual_workload_dir),
+                workload_dir=str(workload_dir),
             )
 
         except subprocess.TimeoutExpired:
             return PerformanceResult(
                 success=False,
                 errors=f"Profiling timed out after {self.perf_cfg.timeout_seconds}s",
-                workload_dir=str(workload_path)
-                if "workload_path" in locals()
-                else None,
+                workload_dir=str(workload_dir),
             )
         except Exception as e:
             logger.error(f"rocprof-compute failed: {e}", exc_info=True)
             return PerformanceResult(
                 success=False,
                 errors=str(e),
-                workload_dir=str(workload_path)
-                if "workload_path" in locals()
-                else None,
+                workload_dir=str(workload_dir),
             )
 
     def _parse_rocprof_workload(
@@ -984,13 +943,15 @@ class Performance:
         metrix_cfg = self.perf_cfg.metrix_config
         assert metrix_cfg is not None
 
-        # Prepare output directory
         timestamp = int(time.time())
         kernel_name = kernel_cfg.kernel_id or "kernel"
         safe_name = "".join(
             c if c.isalnum() or c in "-_" else "_" for c in kernel_name
         )
-        output_base = Path(working_dir or str(Path.cwd())) / "metrix_output"
+        if metrix_cfg.output_dir:
+            output_base = Path(metrix_cfg.output_dir) / "metrix_output"
+        else:
+            output_base = Path(working_dir or str(Path.cwd())) / "metrix_output"
         output_base.mkdir(parents=True, exist_ok=True)
         output_json = output_base / f"{safe_name}_{timestamp}.json"
 

--- a/Magpie/eval/performance.py
+++ b/Magpie/eval/performance.py
@@ -31,7 +31,7 @@ from ..config import (
     PerfBackend,
     PerformanceConfig,
 )
-from ..config.performance import ROCPROF_KEY_METRICS
+from ..config.performance import ROCPROF_KEY_METRICS, METRIX_KEY_METRICS
 from ..utils import get_updated_env
 
 if TYPE_CHECKING:
@@ -226,6 +226,8 @@ class Performance:
                 return self._run_rocprof_compute_on_testcase(kernel_cfg)
             elif backend == PerfBackend.NCU:
                 return self._run_ncu_on_testcase(kernel_cfg)
+            elif backend == PerfBackend.METRIX:
+                return self._run_metrix_on_testcase(kernel_cfg)
             else:
                 return None
 
@@ -953,3 +955,192 @@ class Performance:
             )
 
         return metrics
+
+    def _run_metrix_on_testcase(
+        self, kernel_cfg: KernelEvalConfig
+    ) -> PerformanceResult:
+        """
+        Run profiling using IntelliKit Metrix on the testcase command.
+
+        Metrix wraps rocprofv3 and produces human-readable GPU metrics.
+        CLI: ``metrix profile [options] -- <command>``
+        """
+        metrix_path = shutil.which("metrix")
+        if metrix_path is None:
+            return PerformanceResult(
+                success=False,
+                errors="metrix not found. Install IntelliKit Metrix "
+                "(pip install intellikit[metrix]).",
+            )
+
+        testcase_commands = kernel_cfg.get_testcase_commands()
+        if not testcase_commands:
+            return PerformanceResult(
+                success=False, errors="No testcase command available for profiling"
+            )
+
+        working_dir = kernel_cfg.working_dir
+        env = get_updated_env(kernel_cfg.env)
+        metrix_cfg = self.perf_cfg.metrix_config
+        assert metrix_cfg is not None
+
+        # Prepare output directory
+        timestamp = int(time.time())
+        kernel_name = kernel_cfg.kernel_id or "kernel"
+        safe_name = "".join(
+            c if c.isalnum() or c in "-_" else "_" for c in kernel_name
+        )
+        output_base = Path(working_dir or str(Path.cwd())) / "metrix_output"
+        output_base.mkdir(parents=True, exist_ok=True)
+        output_json = output_base / f"{safe_name}_{timestamp}.json"
+
+        all_outputs: List[str] = []
+        all_errors: List[str] = []
+
+        try:
+            for cmd_idx, testcase_cmd in enumerate(testcase_commands):
+                profile_args = metrix_cfg.get_profile_args(str(output_json))
+
+                cmd = [
+                    "metrix",
+                    "profile",
+                    *profile_args,
+                    "--",
+                    *testcase_cmd,
+                ]
+
+                cmd_str = " ".join(cmd)
+                logger.info(
+                    f"Running metrix on testcase {cmd_idx + 1}/"
+                    f"{len(testcase_commands)}"
+                )
+                logger.debug(f"Command: {cmd_str}")
+
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                    cwd=working_dir,
+                    timeout=self.perf_cfg.timeout_seconds,
+                )
+
+                all_outputs.append(result.stdout)
+                if result.stderr:
+                    all_errors.append(result.stderr)
+
+                if result.returncode != 0:
+                    return PerformanceResult(
+                        success=False,
+                        raw_output="\n".join(all_outputs),
+                        errors=(
+                            f"metrix profile failed on testcase {cmd_idx + 1}: "
+                            f"{result.stderr or result.stdout}"
+                        ),
+                        command=cmd_str,
+                    )
+
+            # Parse JSON output
+            if not output_json.exists():
+                return PerformanceResult(
+                    success=True,
+                    metrics=[
+                        MetricResult(
+                            name="profiling_complete", value=1.0, unit="bool"
+                        )
+                    ],
+                    raw_output="\n".join(all_outputs),
+                )
+
+            metrics, kernel_metrics = self._parse_metrix_json_output(output_json)
+
+            return PerformanceResult(
+                success=True,
+                metrics=metrics
+                if metrics
+                else [
+                    MetricResult(
+                        name="profiling_complete", value=1.0, unit="bool"
+                    )
+                ],
+                kernel_metrics=kernel_metrics,
+                raw_output="\n".join(all_outputs),
+                workload_dir=str(output_base),
+            )
+
+        except subprocess.TimeoutExpired:
+            return PerformanceResult(
+                success=False,
+                errors=f"Profiling timed out after {self.perf_cfg.timeout_seconds}s",
+            )
+        except Exception as e:
+            logger.error(f"metrix failed: {e}", exc_info=True)
+            return PerformanceResult(success=False, errors=str(e))
+
+    def _parse_metrix_json_output(
+        self, json_path: Path
+    ) -> tuple[List[MetricResult], List[KernelMetrics]]:
+        """Parse Metrix JSON output into Magpie metric structures.
+
+        Metrix JSON format (per dispatch/kernel)::
+
+            {
+              "<dispatch_key>": {
+                "duration_us": {"min": ..., "max": ..., "avg": ...},
+                "metrics": {
+                  "memory.l2_hit_rate": {"min": ..., "max": ..., "avg": ..., "count": ...},
+                  ...
+                }
+              }
+            }
+        """
+        import json as _json
+
+        metrics: List[MetricResult] = []
+        kernel_metrics: List[KernelMetrics] = []
+
+        try:
+            with open(json_path, "r") as f:
+                data = _json.load(f)
+        except Exception as e:
+            logger.warning(f"Failed to read metrix JSON output {json_path}: {e}")
+            return metrics, kernel_metrics
+
+        # Accumulate metrics across all dispatches for summary
+        metric_accum: Dict[str, List[float]] = {}
+
+        for dispatch_idx, (dispatch_key, dispatch_data) in enumerate(data.items()):
+            # Build KernelMetrics
+            kernel_name = dispatch_key
+            duration_ns: Optional[float] = None
+            dur_data = dispatch_data.get("duration_us")
+            if dur_data and dur_data.get("avg") is not None:
+                duration_ns = dur_data["avg"] * 1000.0  # us -> ns
+
+            km = KernelMetrics(
+                kernel_name=kernel_name,
+                dispatch_id=dispatch_idx,
+                duration_ns=duration_ns,
+                metrics=[],
+            )
+
+            for metric_name, stats in dispatch_data.get("metrics", {}).items():
+                avg_val = stats.get("avg")
+                if avg_val is None:
+                    continue
+                km.metrics.append(
+                    MetricResult(name=metric_name, value=avg_val, unit="")
+                )
+                metric_accum.setdefault(metric_name, []).append(avg_val)
+
+            kernel_metrics.append(km)
+
+        # Build summary metrics (average across all dispatches)
+        for metric_name, values in metric_accum.items():
+            avg = sum(values) / len(values) if values else 0.0
+            display_name = METRIX_KEY_METRICS.get(metric_name, metric_name)
+            metrics.append(
+                MetricResult(name=display_name, value=avg, unit="")
+            )
+
+        return metrics, kernel_metrics

--- a/Magpie/kernel_config.yaml.example
+++ b/Magpie/kernel_config.yaml.example
@@ -118,3 +118,27 @@ kernel:
 #       -o kernel.out
 #   
 #   testcase_command: "./kernel.out --test"
+
+# =============================================================================
+# Performance Backend Override (Optional)
+# =============================================================================
+# Add a top-level `performance:` section to override the framework-level
+# performance settings for this specific config.  This takes priority over
+# the global config.yaml settings.
+#
+# Supported keys:
+#   backend           - "rocprof_compute" (default for HIP), "ncu", or "metrix"
+#   timeout_seconds   - overall profiling timeout
+#   metrix            - IntelliKit Metrix specific options
+#   rocprof_compute   - rocprof-compute specific options
+#   ncu               - NVIDIA Nsight Compute specific options
+
+# Example: use Metrix for this kernel config
+# performance:
+#   backend: metrix
+#   metrix:
+#     profile: memory           # optional preset profile
+#     metrics: []               # extra metric names
+#     kernel_filter: null       # regex to filter kernel names
+#     num_replays: 3
+#     timeout_seconds: 120

--- a/Magpie/main.py
+++ b/Magpie/main.py
@@ -69,12 +69,19 @@ def parse_kernel_type(type_str: str) -> KernelType:
     return type_map.get(type_str.lower(), KernelType.HIP)
 
 
-def load_kernel_config(kernel_config_path: Path) -> List[KernelEvalConfig]:
+def load_kernel_config(
+    kernel_config_path: Path,
+) -> tuple[List[KernelEvalConfig], Dict[str, Any]]:
     """
     Load kernel configuration from YAML file.
 
+    The YAML may optionally contain a ``performance:`` section that
+    overrides the framework-level performance settings (e.g. backend,
+    metrix config).
+
     Returns:
-        List of KernelEvalConfig objects
+        Tuple of (list of KernelEvalConfig, performance overrides dict).
+        The overrides dict is empty when no ``performance:`` section exists.
     """
     data = load_yaml(kernel_config_path)
     configs = []
@@ -92,7 +99,10 @@ def load_kernel_config(kernel_config_path: Path) -> List[KernelEvalConfig]:
             if cfg:
                 configs.append(cfg)
 
-    return configs
+    # Performance overrides (optional section in kernel config)
+    perf_overrides = data.get("performance", {})
+
+    return configs, perf_overrides
 
 
 def _parse_command_list(cmd_entry) -> Optional[List]:
@@ -221,17 +231,22 @@ def _get_performance_config(
         kernel_type: Kernel type to determine which profiler args to use
 
     Returns:
-        Dict with timeout_seconds, profiler_args, and rocprof_config/ncu_config
+        Dict with timeout_seconds, profiler_args, rocprof_config, ncu_config,
+        and metrix_config.
     """
     perf_cfg = config.get("performance", {})
 
     # Get timeout
     timeout = perf_cfg.get("timeout_seconds", 300.0)
 
+    # Explicit backend override (e.g. "metrix" for AMD GPUs)
+    backend_str = perf_cfg.get("backend")
+
     # Get profiler args and config based on kernel type
     profiler_args = []
     rocprof_config = {}
     ncu_config = {}
+    metrix_config = {}
 
     if kernel_type in (KernelType.HIP, KernelType.TRITON):
         rocprof_cfg = perf_cfg.get("rocprof_compute", {})
@@ -243,6 +258,18 @@ def _get_performance_config(
             "output_format": rocprof_cfg.get("output_format", "csv"),
             "profile_args": rocprof_cfg.get("profile_args", []),
             "analyze_args": rocprof_cfg.get("analyze_args", []),
+        }
+
+        # Metrix config (available for HIP/Triton on AMD)
+        mtx_cfg = perf_cfg.get("metrix", {})
+        metrix_config = {
+            "profile": mtx_cfg.get("profile"),
+            "metrics": mtx_cfg.get("metrics", []),
+            "kernel_filter": mtx_cfg.get("kernel_filter"),
+            "num_replays": mtx_cfg.get("num_replays", 1),
+            "timeout_seconds": mtx_cfg.get("timeout_seconds", 60),
+            "extra_args": mtx_cfg.get("extra_args", []),
+            "backend": backend_str,
         }
 
     if kernel_type in (KernelType.CUDA, KernelType.TRITON):
@@ -258,7 +285,64 @@ def _get_performance_config(
         "profiler_args": profiler_args,
         "rocprof_config": rocprof_config,
         "ncu_config": ncu_config,
+        "metrix_config": metrix_config,
     }
+
+
+def _apply_perf_overrides(
+    perf_settings: Dict[str, Any],
+    overrides: Dict[str, Any],
+    kernel_type: "KernelType",
+) -> Dict[str, Any]:
+    """Merge kernel-config-level ``performance:`` overrides into *perf_settings*.
+
+    Supported override keys (all optional):
+      - ``backend``: ``"metrix"`` | ``"rocprof_compute"`` | ``"ncu"``
+      - ``timeout_seconds``: int
+      - ``metrix``: dict of Metrix-specific settings
+      - ``rocprof_compute`` / ``ncu``: dict of backend-specific settings
+    """
+    settings = dict(perf_settings)
+
+    backend_str = overrides.get("backend")
+
+    if "timeout_seconds" in overrides:
+        settings["timeout_seconds"] = int(overrides["timeout_seconds"])
+
+    # Metrix overrides
+    if "metrix" in overrides or backend_str == "metrix":
+        mtx = overrides.get("metrix", {})
+        settings["metrix_config"] = {
+            "profile": mtx.get("profile"),
+            "metrics": mtx.get("metrics", []),
+            "kernel_filter": mtx.get("kernel_filter"),
+            "num_replays": mtx.get("num_replays", 1),
+            "timeout_seconds": mtx.get(
+                "timeout_seconds", settings.get("timeout_seconds", 600)
+            ),
+            "backend": backend_str or "metrix",
+        }
+
+    # rocprof_compute overrides
+    if "rocprof_compute" in overrides:
+        rpc = overrides["rocprof_compute"]
+        existing = settings.get("rocprof_config", {})
+        existing.update(rpc)
+        settings["rocprof_config"] = existing
+
+    # ncu overrides
+    if "ncu" in overrides:
+        ncu = overrides["ncu"]
+        existing = settings.get("ncu_config", {})
+        existing.update(ncu)
+        settings["ncu_config"] = existing
+
+    # Propagate explicit backend into metrix_config even if only backend was set
+    if backend_str and backend_str != "metrix":
+        settings.setdefault("metrix_config", {})
+        settings["metrix_config"]["backend"] = None
+
+    return settings
 
 
 def _get_compare_config(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -314,10 +398,11 @@ def run_analyze(args, config: Dict[str, Any]) -> int:
     """Run analyze mode."""
     # Load kernel configs
     kernel_configs = []
+    perf_overrides: Dict[str, Any] = {}
 
     if args.kernel_config:
         # Load from kernel config file
-        kernel_configs = load_kernel_config(args.kernel_config)
+        kernel_configs, perf_overrides = load_kernel_config(args.kernel_config)
         if not kernel_configs:
             logger.error(f"No kernels found in {args.kernel_config}")
             return 1
@@ -358,6 +443,10 @@ def run_analyze(args, config: Dict[str, Any]) -> int:
     compile_settings = _get_compiling_config(config)
     perf_settings = _get_performance_config(config, kernel_type)
 
+    # Apply per-config performance overrides (from kernel config YAML)
+    if perf_overrides:
+        perf_settings = _apply_perf_overrides(perf_settings, perf_overrides, kernel_type)
+
     # Create scheduler
     scheduler_config = _get_scheduler_config(config, args)
     scheduler = Scheduler(scheduler_config)
@@ -376,17 +465,31 @@ def run_analyze(args, config: Dict[str, Any]) -> int:
             profiler_args=perf_settings["profiler_args"],
             rocprof_config=perf_settings["rocprof_config"],
             ncu_config=perf_settings["ncu_config"],
+            metrix_config=perf_settings["metrix_config"],
         )
 
         # Print and save results
         if result.success and result.results:
+            # Create workspace directory
+            label = kernel_configs[0].kernel_id if kernel_configs else ""
+            ws_path = _create_workspace(args.output_dir, "analyze", label)
+            _save_config_snapshot(ws_path, kernel_configs)
+
+            summary_lines = []
             for kernel_cfg, state in zip(kernel_configs, result.results):
-                # Reconstruct EvaluationState if needed
                 if isinstance(state, dict):
                     state = _dict_to_eval_state(state)
                 _print_result(kernel_cfg, state)
+                summary_lines.append(
+                    f"Kernel: {kernel_cfg.kernel_id}  "
+                    f"Correctness: {state.correctness_state.name}  "
+                    f"Performance: {state.performance_state.name}  "
+                    f"Score: {state.score:.2f}"
+                )
 
-            _save_results(result.results, args.output_dir, "analyze")
+            _save_results(result.results, ws_path, "analyze")
+            _save_summary(ws_path, "\n".join(summary_lines))
+            print(f"\nWorkspace: {ws_path}")
         else:
             logger.error(f"Analysis failed: {result.errors}")
             return 1
@@ -412,9 +515,10 @@ def run_compare(args, config: Dict[str, Any]) -> int:
     """Run compare mode."""
     # Load kernel configs
     kernel_configs = []
+    perf_overrides: Dict[str, Any] = {}
 
     if args.kernel_config:
-        kernel_configs = load_kernel_config(args.kernel_config)
+        kernel_configs, perf_overrides = load_kernel_config(args.kernel_config)
     elif args.kernels:
         kernel_type = parse_kernel_type(args.type)
 
@@ -445,6 +549,10 @@ def run_compare(args, config: Dict[str, Any]) -> int:
     perf_settings = _get_performance_config(config, kernel_type)
     compare_settings = _get_compare_config(config)
 
+    # Apply per-config performance overrides (from kernel config YAML)
+    if perf_overrides:
+        perf_settings = _apply_perf_overrides(perf_settings, perf_overrides, kernel_type)
+
     # Create scheduler
     scheduler_config = _get_scheduler_config(config, args)
     scheduler = Scheduler(scheduler_config)
@@ -464,6 +572,7 @@ def run_compare(args, config: Dict[str, Any]) -> int:
             profiler_args=perf_settings["profiler_args"],
             rocprof_config=perf_settings["rocprof_config"],
             ncu_config=perf_settings["ncu_config"],
+            metrix_config=perf_settings["metrix_config"],
             compare_config=compare_settings,
         )
 
@@ -471,19 +580,35 @@ def run_compare(args, config: Dict[str, Any]) -> int:
         if result.success and result.results:
             comparison = result.results
 
+            # Create workspace directory
+            ws_path = _create_workspace(args.output_dir, "compare")
+            _save_config_snapshot(ws_path, kernel_configs)
+
+            # Create per-kernel subdirectories
+            for i, cfg in enumerate(kernel_configs):
+                kid = cfg.kernel_id or f"kernel_{i}"
+                safe_kid = "".join(
+                    c if c.isalnum() or c in "-_" else "_" for c in kid
+                )
+                kernel_dir = ws_path / "kernels" / f"kernel_{i}_{safe_kid}"
+                (kernel_dir / "performance").mkdir(parents=True, exist_ok=True)
+
             print(f"\n{'=' * 60}")
             print("COMPARISON RESULTS")
             print(f"{'=' * 60}")
 
+            summary_text = ""
             if isinstance(comparison, dict):
-                print(comparison.get("summary", "No summary available"))
+                summary_text = comparison.get("summary", "No summary available")
             elif hasattr(comparison, "summary"):
-                print(comparison.summary)
+                summary_text = comparison.summary
+            print(summary_text)
 
             print(f"{'=' * 60}\n")
 
-            # Save results
-            _save_comparison(comparison, args.output_dir)
+            _save_comparison(comparison, ws_path)
+            _save_summary(ws_path, summary_text)
+            print(f"Workspace: {ws_path}")
         else:
             logger.error(f"Comparison failed: {result.errors}")
             return 1
@@ -540,14 +665,59 @@ def _print_result(kernel_cfg: KernelEvalConfig, result: EvaluationState) -> None
     print(f"{'=' * 60}")
 
 
-def _save_results(results: List, output_dir: Path, mode: str) -> None:
-    """Save results to file."""
+def _create_workspace(
+    base_dir: Path, mode: str, label: str = ""
+) -> Path:
+    """Create a timestamped workspace directory for analyze/compare results.
+
+    Structure:
+        <base_dir>/<mode>_<label>_<timestamp>/
+            performance/
+            config.yaml  (written later)
+    """
+    from datetime import datetime
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    safe_label = "".join(c if c.isalnum() or c in "-_" else "_" for c in label) if label else ""
+    parts = [mode, safe_label, timestamp] if safe_label else [mode, timestamp]
+    ws_name = "_".join(parts)
+
+    ws_path = (base_dir / ws_name).resolve()
+    ws_path.mkdir(parents=True, exist_ok=True)
+    (ws_path / "performance").mkdir(exist_ok=True)
+
+    logger.info(f"Created {mode} workspace: {ws_path}")
+    return ws_path
+
+
+def _save_config_snapshot(
+    ws_path: Path, kernel_configs: List, extra: Optional[Dict[str, Any]] = None
+) -> None:
+    """Save a YAML config snapshot into the workspace."""
+    snapshot: Dict[str, Any] = {"kernels": []}
+    for cfg in kernel_configs:
+        if hasattr(cfg, "to_dict"):
+            snapshot["kernels"].append(cfg.to_dict())
+        else:
+            snapshot["kernels"].append(str(cfg))
+    if extra:
+        snapshot.update(extra)
+
+    config_file = ws_path / "config.yaml"
+    try:
+        with open(config_file, "w") as f:
+            yaml.dump(snapshot, f, default_flow_style=False)
+    except Exception as e:
+        logger.warning(f"Failed to save config snapshot: {e}")
+
+
+def _save_results(results: List, ws_path: Path, mode: str) -> None:
+    """Save analysis/compare results into the workspace as a JSON report."""
     import json
     from datetime import datetime
 
-    output_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_file = output_dir / f"{mode}_results_{timestamp}.json"
+    report_file = ws_path / f"{mode}_report.json"
 
     serialized_results: List[Any] = []
     for r in results:
@@ -558,26 +728,34 @@ def _save_results(results: List, output_dir: Path, mode: str) -> None:
         else:
             serialized_results.append(str(r))
 
-    with open(output_file, "w") as f:
+    with open(report_file, "w") as f:
         json.dump(
             {"mode": mode, "timestamp": timestamp, "results": serialized_results},
             f,
             indent=2,
         )
 
-    logger.info(f"Results saved to {output_file}")
+    logger.info(f"Results saved to {report_file}")
 
 
-def _save_comparison(comparison: Any, output_dir: Path) -> None:
-    """Save comparison to file."""
+def _save_summary(ws_path: Path, text: str) -> None:
+    """Write a human-readable summary into the workspace."""
+    summary_file = ws_path / "summary.txt"
+    try:
+        with open(summary_file, "w") as f:
+            f.write(text)
+    except Exception as e:
+        logger.warning(f"Failed to write summary: {e}")
+
+
+def _save_comparison(comparison: Any, ws_path: Path) -> None:
+    """Save comparison results into the workspace as a JSON report."""
     import json
     from datetime import datetime
 
-    output_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_file = output_dir / f"compare_results_{timestamp}.json"
+    report_file = ws_path / "compare_report.json"
 
-    # Extract comparison data
     if isinstance(comparison, dict):
         comparison_data = comparison
     elif hasattr(comparison, "to_dict"):
@@ -585,8 +763,7 @@ def _save_comparison(comparison: Any, output_dir: Path) -> None:
     else:
         comparison_data = {"result": str(comparison)}
 
-    # Use same format as analyze: mode, timestamp, results
-    with open(output_file, "w") as f:
+    with open(report_file, "w") as f:
         json.dump(
             {
                 "mode": "compare",
@@ -603,7 +780,7 @@ def _save_comparison(comparison: Any, output_dir: Path) -> None:
             indent=2,
         )
 
-    logger.info(f"Comparison saved to {output_file}")
+    logger.info(f"Comparison saved to {report_file}")
 
 
 def load_benchmark_config(benchmark_config_path: Path) -> Dict[str, Any]:

--- a/Magpie/main.py
+++ b/Magpie/main.py
@@ -447,6 +447,15 @@ def run_analyze(args, config: Dict[str, Any]) -> int:
     if perf_overrides:
         perf_settings = _apply_perf_overrides(perf_settings, perf_overrides, kernel_type)
 
+    # Create workspace before profiling so profiler writes directly there
+    label = kernel_configs[0].kernel_id if kernel_configs else ""
+    ws_path = _create_workspace(args.output_dir, "analyze", label)
+    _save_config_snapshot(ws_path, kernel_configs)
+
+    perf_dir = str(ws_path / "performance")
+    perf_settings["rocprof_config"]["output_dir"] = perf_dir
+    perf_settings["metrix_config"]["output_dir"] = perf_dir
+
     # Create scheduler
     scheduler_config = _get_scheduler_config(config, args)
     scheduler = Scheduler(scheduler_config)
@@ -470,25 +479,12 @@ def run_analyze(args, config: Dict[str, Any]) -> int:
 
         # Print and save results
         if result.success and result.results:
-            # Create workspace directory
-            label = kernel_configs[0].kernel_id if kernel_configs else ""
-            ws_path = _create_workspace(args.output_dir, "analyze", label)
-            _save_config_snapshot(ws_path, kernel_configs)
-
-            summary_lines = []
             for kernel_cfg, state in zip(kernel_configs, result.results):
                 if isinstance(state, dict):
                     state = _dict_to_eval_state(state)
                 _print_result(kernel_cfg, state)
-                summary_lines.append(
-                    f"Kernel: {kernel_cfg.kernel_id}  "
-                    f"Correctness: {state.correctness_state.name}  "
-                    f"Performance: {state.performance_state.name}  "
-                    f"Score: {state.score:.2f}"
-                )
 
             _save_results(result.results, ws_path, "analyze")
-            _save_summary(ws_path, "\n".join(summary_lines))
             print(f"\nWorkspace: {ws_path}")
         else:
             logger.error(f"Analysis failed: {result.errors}")
@@ -553,6 +549,14 @@ def run_compare(args, config: Dict[str, Any]) -> int:
     if perf_overrides:
         perf_settings = _apply_perf_overrides(perf_settings, perf_overrides, kernel_type)
 
+    # Create workspace before profiling so profiler writes directly there
+    ws_path = _create_workspace(args.output_dir, "compare")
+    _save_config_snapshot(ws_path, kernel_configs)
+
+    perf_dir = str(ws_path / "performance")
+    perf_settings["rocprof_config"]["output_dir"] = perf_dir
+    perf_settings["metrix_config"]["output_dir"] = perf_dir
+
     # Create scheduler
     scheduler_config = _get_scheduler_config(config, args)
     scheduler = Scheduler(scheduler_config)
@@ -580,19 +584,6 @@ def run_compare(args, config: Dict[str, Any]) -> int:
         if result.success and result.results:
             comparison = result.results
 
-            # Create workspace directory
-            ws_path = _create_workspace(args.output_dir, "compare")
-            _save_config_snapshot(ws_path, kernel_configs)
-
-            # Create per-kernel subdirectories
-            for i, cfg in enumerate(kernel_configs):
-                kid = cfg.kernel_id or f"kernel_{i}"
-                safe_kid = "".join(
-                    c if c.isalnum() or c in "-_" else "_" for c in kid
-                )
-                kernel_dir = ws_path / "kernels" / f"kernel_{i}_{safe_kid}"
-                (kernel_dir / "performance").mkdir(parents=True, exist_ok=True)
-
             print(f"\n{'=' * 60}")
             print("COMPARISON RESULTS")
             print(f"{'=' * 60}")
@@ -607,7 +598,6 @@ def run_compare(args, config: Dict[str, Any]) -> int:
             print(f"{'=' * 60}\n")
 
             _save_comparison(comparison, ws_path)
-            _save_summary(ws_path, summary_text)
             print(f"Workspace: {ws_path}")
         else:
             logger.error(f"Comparison failed: {result.errors}")
@@ -736,16 +726,6 @@ def _save_results(results: List, ws_path: Path, mode: str) -> None:
         )
 
     logger.info(f"Results saved to {report_file}")
-
-
-def _save_summary(ws_path: Path, text: str) -> None:
-    """Write a human-readable summary into the workspace."""
-    summary_file = ws_path / "summary.txt"
-    try:
-        with open(summary_file, "w") as f:
-            f.write(text)
-    except Exception as e:
-        logger.warning(f"Failed to write summary: {e}")
 
 
 def _save_comparison(comparison: Any, ws_path: Path) -> None:

--- a/Magpie/mcp/server.py
+++ b/Magpie/mcp/server.py
@@ -113,15 +113,18 @@ def _get_scheduler_config_from_yaml(environment: str = "local") -> "SchedulerCon
 def _get_perf_settings_from_yaml() -> Dict[str, Any]:
     """Read performance profiler settings from framework config.yaml.
 
-    Returns dict with timeout_seconds, profiler_args, rocprof_config, ncu_config.
+    Returns dict with timeout_seconds, profiler_args, rocprof_config,
+    ncu_config, and metrix_config.
     Both rocprof and ncu configs are always populated so that cross-platform
     kernels (Triton) get the correct settings regardless of which GPU is used.
     """
     config = _load_framework_config()
     perf_cfg = config.get("performance", {})
 
+    backend_str = perf_cfg.get("backend")
     rocprof_cfg = perf_cfg.get("rocprof_compute", {})
     ncu_cfg = perf_cfg.get("ncu", {})
+    mtx_cfg = perf_cfg.get("metrix", {})
 
     return {
         "timeout_seconds": perf_cfg.get("timeout_seconds", 300.0),
@@ -138,6 +141,15 @@ def _get_perf_settings_from_yaml() -> Dict[str, Any]:
         "ncu_config": {
             "args": ncu_cfg.get("args", []),
             "metrics": ncu_cfg.get("metrics", []),
+        },
+        "metrix_config": {
+            "profile": mtx_cfg.get("profile"),
+            "metrics": mtx_cfg.get("metrics", []),
+            "kernel_filter": mtx_cfg.get("kernel_filter"),
+            "num_replays": mtx_cfg.get("num_replays", 1),
+            "timeout_seconds": mtx_cfg.get("timeout_seconds", 60),
+            "extra_args": mtx_cfg.get("extra_args", []),
+            "backend": backend_str,
         },
     }
 
@@ -191,6 +203,7 @@ def analyze(
     compile_command: str = "",
     check_performance: bool = True,
     environment: str = "local",
+    performance_backend: str = "",
 ) -> str:
     """
     Analyze a GPU kernel for correctness and performance.
@@ -203,6 +216,7 @@ def analyze(
         compile_command: Custom compile command (optional)
         check_performance: Run performance profiling (default: True)
         environment: Execution environment "local" or "container"
+        performance_backend: Profiling backend override: "metrix", "rocprof_compute", or "ncu" (default: auto)
 
     Returns:
         JSON with comprehensive analysis results including:
@@ -259,6 +273,14 @@ def analyze(
 
         try:
             perf_settings = _get_perf_settings_from_yaml()
+
+            # Apply per-call backend override
+            if performance_backend:
+                from ..main import _apply_perf_overrides
+                perf_settings = _apply_perf_overrides(
+                    perf_settings, {"backend": performance_backend}, ktype
+                )
+
             task_result = scheduler.run_analyze(
                 kernel_configs=[kernel_config],
                 check_performance=check_performance,
@@ -266,12 +288,12 @@ def analyze(
                 profiler_args=perf_settings["profiler_args"],
                 rocprof_config=perf_settings["rocprof_config"],
                 ncu_config=perf_settings["ncu_config"],
+                metrix_config=perf_settings["metrix_config"],
             )
 
             if task_result.success and task_result.results:
                 result = task_result.results[0]
                 formatted = _format_analysis_result(result, kernel_config, ktype)
-                # Add kernel config to output
                 formatted["kernel_config"] = kernel_config_dict
                 return json.dumps(formatted, indent=2)
             else:
@@ -480,6 +502,7 @@ def compare(
     baseline_index: int = 0,
     check_performance: bool = True,
     environment: str = "local",
+    performance_backend: str = "",
 ) -> str:
     """
     Compare multiple GPU kernels for performance and correctness.
@@ -494,6 +517,7 @@ def compare(
         baseline_index: Index of baseline kernel for comparison (default: 0)
         check_performance: Run performance profiling (default: True)
         environment: Execution environment "local" or "container"
+        performance_backend: Profiling backend override: "metrix", "rocprof_compute", or "ncu" (default: auto)
 
     Returns:
         JSON with comparison results, ranking, and summary
@@ -561,6 +585,14 @@ def compare(
 
         try:
             perf_settings = _get_perf_settings_from_yaml()
+
+            # Apply per-call backend override
+            if performance_backend:
+                from ..main import _apply_perf_overrides
+                perf_settings = _apply_perf_overrides(
+                    perf_settings, {"backend": performance_backend}, ktype
+                )
+
             task_result = scheduler.run_compare(
                 kernel_configs=kernel_configs,
                 baseline_index=baseline_index,
@@ -569,6 +601,7 @@ def compare(
                 profiler_args=perf_settings["profiler_args"],
                 rocprof_config=perf_settings["rocprof_config"],
                 ncu_config=perf_settings["ncu_config"],
+                metrix_config=perf_settings["metrix_config"],
             )
 
             if task_result.success and task_result.results:

--- a/Magpie/modes/analyze_eval/analyzer.py
+++ b/Magpie/modes/analyze_eval/analyzer.py
@@ -104,6 +104,7 @@ class AnalyzeMode:
         rocprof_cfg = None
         if self.config.rocprof_config:
             rocprof_cfg = RocprofComputeConfig(
+                output_dir=self.config.rocprof_config.get("output_dir"),
                 workload_dir=self.config.rocprof_config.get(
                     "workload_dir", "./workloads"
                 ),
@@ -128,6 +129,7 @@ class AnalyzeMode:
         explicit_backend = None
         if self.config.metrix_config:
             metrix_cfg = MetrixConfig(
+                output_dir=self.config.metrix_config.get("output_dir"),
                 profile=self.config.metrix_config.get("profile"),
                 metrics=self.config.metrix_config.get("metrics", []),
                 kernel_filter=self.config.metrix_config.get("kernel_filter"),

--- a/Magpie/modes/analyze_eval/analyzer.py
+++ b/Magpie/modes/analyze_eval/analyzer.py
@@ -27,7 +27,7 @@ from ...config import (
     CorrectnessMode,
     PerformanceConfig,
 )
-from ...config.performance import RocprofComputeConfig, NcuConfig
+from ...config.performance import RocprofComputeConfig, NcuConfig, MetrixConfig, PerfBackend
 from ...eval import Evaluator, EvaluationState
 
 logger = logging.getLogger(__name__)
@@ -57,6 +57,7 @@ class AnalyzeConfig:
     profiler_args: List[str] = field(default_factory=list)
     rocprof_config: Dict[str, Any] = field(default_factory=dict)
     ncu_config: Dict[str, Any] = field(default_factory=dict)
+    metrix_config: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         if self.gpu_arch is None:
@@ -122,6 +123,21 @@ class AnalyzeMode:
                 metrics=self.config.ncu_config.get("metrics", []),
             )
 
+        # Build metrix config if provided
+        metrix_cfg = None
+        explicit_backend = None
+        if self.config.metrix_config:
+            metrix_cfg = MetrixConfig(
+                profile=self.config.metrix_config.get("profile"),
+                metrics=self.config.metrix_config.get("metrics", []),
+                kernel_filter=self.config.metrix_config.get("kernel_filter"),
+                num_replays=self.config.metrix_config.get("num_replays", 1),
+                timeout_seconds=self.config.metrix_config.get("timeout_seconds", 60),
+                extra_args=self.config.metrix_config.get("extra_args", []),
+            )
+            if self.config.metrix_config.get("backend") == "metrix":
+                explicit_backend = PerfBackend.METRIX
+
         # Build pipeline config for analyze mode
         pipeline_cfg = PipelineConfig(
             mode=EvalMode.ANALYZE,
@@ -135,12 +151,14 @@ class AnalyzeMode:
             ),
             performance_config=PerformanceConfig(
                 enabled=self.config.check_performance,
+                backend=explicit_backend,
                 kernel_type=kernel_cfg.kernel_type,
                 gpu_arch=self.config.gpu_arch,
                 timeout_seconds=self.config.timeout_seconds,
                 profiler_args=self.config.profiler_args,
                 rocprof_config=rocprof_cfg,
                 ncu_config=ncu_cfg,
+                metrix_config=metrix_cfg,
             ),
         )
 

--- a/Magpie/modes/compare_eval/comparator.py
+++ b/Magpie/modes/compare_eval/comparator.py
@@ -155,6 +155,7 @@ class CompareMode:
             rocprof_cfg = None
             if self.config.rocprof_config:
                 rocprof_cfg = RocprofComputeConfig(
+                    output_dir=self.config.rocprof_config.get("output_dir"),
                     workload_dir=self.config.rocprof_config.get(
                         "workload_dir", "./workloads"
                     ),
@@ -182,6 +183,7 @@ class CompareMode:
             explicit_backend = None
             if self.config.metrix_config:
                 metrix_cfg = MetrixConfig(
+                    output_dir=self.config.metrix_config.get("output_dir"),
                     profile=self.config.metrix_config.get("profile"),
                     metrics=self.config.metrix_config.get("metrics", []),
                     kernel_filter=self.config.metrix_config.get("kernel_filter"),

--- a/Magpie/modes/compare_eval/comparator.py
+++ b/Magpie/modes/compare_eval/comparator.py
@@ -27,7 +27,7 @@ from ...config import (
     CorrectnessMode,
     PerformanceConfig,
 )
-from ...config.performance import RocprofComputeConfig, NcuConfig
+from ...config.performance import RocprofComputeConfig, NcuConfig, MetrixConfig, PerfBackend
 from ...eval import Evaluator, EvaluationState, BaseKind
 
 logger = logging.getLogger(__name__)
@@ -70,11 +70,13 @@ class CompareConfig:
     profiler_args: List[str] = field(default_factory=list)
     rocprof_config: Dict[str, Any] = field(default_factory=dict)
     ncu_config: Dict[str, Any] = field(default_factory=dict)
+    metrix_config: Dict[str, Any] = field(default_factory=dict)
     # Winner selection strategy: "correctness_first" or "perf_score"
     winner_strategy: str = "perf_score"
     # Per-backend scoring weights
     perf_weights_rocprof: Dict[str, float] = field(default_factory=dict)
     perf_weights_ncu: Dict[str, float] = field(default_factory=dict)
+    perf_weights_metrix: Dict[str, float] = field(default_factory=dict)
     # Metrics where lower values are better (e.g., duration)
     perf_lower_is_better: List[str] = field(
         default_factory=lambda: ["duration_ns_total", "LDS_Conflicts"]
@@ -175,6 +177,21 @@ class CompareMode:
                     metrics=self.config.ncu_config.get("metrics", []),
                 )
 
+            # Build metrix config if provided
+            metrix_cfg = None
+            explicit_backend = None
+            if self.config.metrix_config:
+                metrix_cfg = MetrixConfig(
+                    profile=self.config.metrix_config.get("profile"),
+                    metrics=self.config.metrix_config.get("metrics", []),
+                    kernel_filter=self.config.metrix_config.get("kernel_filter"),
+                    num_replays=self.config.metrix_config.get("num_replays", 1),
+                    timeout_seconds=self.config.metrix_config.get("timeout_seconds", 60),
+                    extra_args=self.config.metrix_config.get("extra_args", []),
+                )
+                if self.config.metrix_config.get("backend") == "metrix":
+                    explicit_backend = PerfBackend.METRIX
+
             # Build pipeline config
             pipeline_cfg = PipelineConfig(
                 mode=EvalMode.COMPARE,
@@ -186,12 +203,14 @@ class CompareMode:
                 correctness_config=CorrectnessConfig(mode=corr_mode),
                 performance_config=PerformanceConfig(
                     enabled=self.config.check_performance,
+                    backend=explicit_backend,
                     kernel_type=cfg.kernel_type,
                     gpu_arch=self.config.gpu_arch,
                     timeout_seconds=self.config.timeout_seconds,
                     profiler_args=self.config.profiler_args,
                     rocprof_config=rocprof_cfg,
                     ncu_config=ncu_cfg,
+                    metrix_config=metrix_cfg,
                 ),
             )
 
@@ -248,6 +267,14 @@ class CompareMode:
 
     def _get_perf_weights(self, kernel_type: KernelType) -> Dict[str, float]:
         """Select per-backend weights, with sane fallbacks."""
+        # If metrix backend is explicitly selected, prefer metrix weights
+        is_metrix = (
+            self.config.metrix_config
+            and self.config.metrix_config.get("backend") == "metrix"
+        )
+        if is_metrix and self.config.perf_weights_metrix:
+            return self.config.perf_weights_metrix
+
         if kernel_type == KernelType.CUDA:
             if self.config.perf_weights_ncu:
                 return self.config.perf_weights_ncu

--- a/examples/ck_gemm_add.yaml
+++ b/examples/ck_gemm_add.yaml
@@ -20,3 +20,10 @@ kernel:
   #   - ["cmake", "--build", "${CK_HOME}/build", "--target", "test_gemm_add", "-j8"]
   testcase_command: "bin/test_gemm_add"
   working_dir: "${CK_HOME}/build"
+
+# Optional: override the profiling backend for this config
+# Uncomment to use IntelliKit Metrix instead of the default rocprof-compute
+# performance:
+#   backend: metrix
+#   metrix:
+#     num_replays: 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ mcp>=1.0.0
 # py-spy>=0.3.14
 # memory-profiler>=0.61.0
 
-# Optional: ROCm/HIP profiling integration
+# Optional: ROCm/HIP profiling integration >= 3.40
 # see https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/install/core-install.html
 
 # Optional: CUDA profiling integration


### PR DESCRIPTION
Integrate @[intellikit/metrix](https://github.com/AMDResearch/intellikit/tree/main/metrix) as a configurable profiling backend for HIP kernels alongside the existing rocprof-compute. Users can select the backend via config.yaml (performance.backend: metrix), per-kernel YAML config (performance.backend), or the MCP performance_backend parameter.
Changes:

- Add MetrixConfig dataclass and PerfBackend.METRIX enum for Metrix CLI (metrix profile) integration with JSON output parsing
- Thread metrix_config through the full pipeline: Scheduler -> Executor -> AnalyzeMode/CompareMode -> Performance
- Support per-kernel performance: overrides in kernel config YAML (backend, profile, metrics, etc.)
- Add performance_backend runtime override to MCP analyze and compare tools
- Organize CLI analyze/compare results into structured workspace directories (results/analyze_<name>_<timestamp>/) with config snapshots, performance data, and JSON reports
- Add Metrix-specific comparison weights (`perf_weights_metrix`) in config.yaml
- Update rocprof-compute integration for v3.4.0 compatibility (`--output-format csv` replacing `--save-dfs`)