### PR TITLE
Introduce relative and absolute tolerances in Accordo

### DIFF
--- a/Magpie/config.yaml
+++ b/Magpie/config.yaml
@@ -90,7 +90,9 @@ correctness:
   # Captures kernel output buffers and compares reference vs. optimized.
   # Activate by setting: backend: accordo
   accordo:
-    tolerance: 1.0e-6          # Absolute tolerance for np.allclose comparison
+    atol: 1.0e-6               # Absolute tolerance (np.allclose)
+    rtol: 0.0                  # Relative tolerance
+    equal_nan: false           # Treat NaN as equal when comparing
     timeout_seconds: 30        # Timeout per snapshot capture
 
 # =============================================================================

--- a/Magpie/config.yaml
+++ b/Magpie/config.yaml
@@ -91,7 +91,7 @@ correctness:
   # Activate by setting: backend: accordo
   accordo:
     atol: 1.0e-6               # Absolute tolerance (np.allclose)
-    rtol: 0.0                  # Relative tolerance
+    rtol: 1.0e-5               # Relative tolerance (torch.allclose-style default)
     equal_nan: false           # Treat NaN as equal when comparing
     timeout_seconds: 30        # Timeout per snapshot capture
 

--- a/Magpie/config/correctness.py
+++ b/Magpie/config/correctness.py
@@ -54,7 +54,9 @@ class AccordoConfig:
         kernel_name: GPU kernel function name to intercept.
         reference_binary: Command (or path) to the reference binary.
         optimized_binary: Command (or path) to the optimized binary.
-        tolerance: Absolute tolerance for ``np.allclose`` comparison.
+        atol: Absolute tolerance for ``np.allclose``.
+        rtol: Relative tolerance for ``np.allclose``.
+        equal_nan: If True, NaN compares equal.
         timeout_seconds: Timeout per snapshot capture in seconds.
                          *None* means inherit from the task-level timeout.
         kernel_args: Optional manual kernel args as ``[(name, type), ...]``.
@@ -67,7 +69,9 @@ class AccordoConfig:
     kernel_name: Optional[str] = None
     reference_binary: Optional[str] = None
     optimized_binary: Optional[str] = None
-    tolerance: float = 1e-6
+    atol: float = 1e-6
+    rtol: float = 0.0
+    equal_nan: bool = False
     timeout_seconds: Optional[int] = None
     kernel_args: Optional[List[Tuple[str, str]]] = None
     working_directory: Optional[str] = None
@@ -145,7 +149,9 @@ class CorrectnessConfig:
                 kernel_name=acc.get("kernel_name"),
                 reference_binary=acc.get("reference_binary"),
                 optimized_binary=acc.get("optimized_binary"),
-                tolerance=acc.get("tolerance", 1e-6),
+                atol=acc.get("atol", 1e-6),
+                rtol=acc.get("rtol", 0.0),
+                equal_nan=acc.get("equal_nan", False),
                 timeout_seconds=acc.get("timeout_seconds"),
                 kernel_args=acc.get("kernel_args"),
                 working_directory=acc.get("working_directory"),

--- a/Magpie/config/correctness.py
+++ b/Magpie/config/correctness.py
@@ -54,9 +54,9 @@ class AccordoConfig:
         kernel_name: GPU kernel function name to intercept.
         reference_binary: Command (or path) to the reference binary.
         optimized_binary: Command (or path) to the optimized binary.
-        atol: Absolute tolerance for ``np.allclose``.
-        rtol: Relative tolerance for ``np.allclose``.
-        equal_nan: If True, NaN compares equal.
+        atol: Absolute tolerance for ``np.allclose`` (default ``1e-6``).
+        rtol: Relative tolerance (default ``1e-5``, same as ``torch.allclose``).
+        equal_nan: If true, pass ``--equal-nan`` to ``accordo validate``; if false, omit it (CLI default).
         timeout_seconds: Timeout per snapshot capture in seconds.
                          *None* means inherit from the task-level timeout.
         kernel_args: Optional manual kernel args as ``[(name, type), ...]``.
@@ -70,7 +70,7 @@ class AccordoConfig:
     reference_binary: Optional[str] = None
     optimized_binary: Optional[str] = None
     atol: float = 1e-6
-    rtol: float = 0.0
+    rtol: float = 1e-5
     equal_nan: bool = False
     timeout_seconds: Optional[int] = None
     kernel_args: Optional[List[Tuple[str, str]]] = None
@@ -150,7 +150,7 @@ class CorrectnessConfig:
                 reference_binary=acc.get("reference_binary"),
                 optimized_binary=acc.get("optimized_binary"),
                 atol=acc.get("atol", 1e-6),
-                rtol=acc.get("rtol", 0.0),
+                rtol=acc.get("rtol", 1e-5),
                 equal_nan=acc.get("equal_nan", False),
                 timeout_seconds=acc.get("timeout_seconds"),
                 kernel_args=acc.get("kernel_args"),

--- a/Magpie/eval/correctness.py
+++ b/Magpie/eval/correctness.py
@@ -435,8 +435,11 @@ class Correctness:
                 success=False,
                 errors=(
                     "'accordo' CLI not found on PATH. Install IntelliKit Accordo "
-                    "(pip install intellikit[accordo] or "
-                    "pip install -e /path/to/intellikit/accordo)."
+                    '(pip install "git+https://github.com/AMDResearch/intellikit.git@'
+                    '0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=accordo" '
+                    "or git clone https://github.com/AMDResearch/intellikit.git && "
+                    "cd intellikit && git checkout "
+                    "0f2a15c9eba3717e984961e2bcf72a0aa3052713 && pip install -e accordo)."
                 ),
             )
 
@@ -458,7 +461,6 @@ class Correctness:
                 "'optimized_binary' to be set in accordo config.",
             )
 
-        tolerance = accordo_cfg.tolerance
         perf_timeout = getattr(
             self.pipeline_cfg.performance_config, "timeout_seconds", None
         )
@@ -476,11 +478,14 @@ class Correctness:
             "--kernel-name", kernel_name,
             "--ref-binary", ref_binary,
             "--opt-binary", opt_binary,
-            "--tolerance", str(tolerance),
+            "--atol", str(accordo_cfg.atol),
+            "--rtol", str(accordo_cfg.rtol),
             "--timeout", str(int(timeout)),
             "--working-dir", binary_working_dir,
             "--log-level", "INFO",
         ]
+        if accordo_cfg.equal_nan:
+            cmd.extend(["--equal-nan"])
 
         if accordo_cfg.kernel_args:
             args_str = ",".join(
@@ -549,7 +554,7 @@ class Correctness:
                     MetricResult(
                         name=f"accordo_array_{arr_name}",
                         success=True,
-                        threshold=tolerance,
+                        threshold=accordo_cfg.atol,
                     )
                 )
         else:
@@ -561,12 +566,19 @@ class Correctness:
                 )
             )
             for mismatch in output.get("mismatches", []):
+                argn = mismatch.get("arg_name", "?")
+                disp_idx = mismatch.get("dispatch_index")
+                mm_name = (
+                    f"accordo_mismatch_d{disp_idx}_{argn}"
+                    if disp_idx is not None
+                    else f"accordo_mismatch_{argn}"
+                )
                 metrics.append(
                     MetricResult(
-                        name=f"accordo_mismatch_{mismatch.get('arg_name', '?')}",
+                        name=mm_name,
                         success=False,
                         value=mismatch.get("max_difference"),
-                        threshold=tolerance,
+                        threshold=accordo_cfg.atol,
                     )
                 )
 

--- a/Magpie/eval/correctness.py
+++ b/Magpie/eval/correctness.py
@@ -436,10 +436,10 @@ class Correctness:
                 errors=(
                     "'accordo' CLI not found on PATH. Install IntelliKit Accordo "
                     '(pip install "git+https://github.com/AMDResearch/intellikit.git@'
-                    '0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=accordo" '
+                    '1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=accordo" '
                     "or git clone https://github.com/AMDResearch/intellikit.git && "
                     "cd intellikit && git checkout "
-                    "0f2a15c9eba3717e984961e2bcf72a0aa3052713 && pip install -e accordo)."
+                    "1511ed984c01f2254df3ca567153c5e7cb2ac9d9 && pip install -e accordo)."
                 ),
             )
 

--- a/Magpie/eval/performance.py
+++ b/Magpie/eval/performance.py
@@ -931,7 +931,7 @@ class Performance:
                 errors=(
                     "metrix not found. Install IntelliKit Metrix "
                     '(pip install "git+https://github.com/AMDResearch/intellikit.git@'
-                    '0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=metrix").'
+                    '1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=metrix").'
                 ),
             )
 

--- a/Magpie/eval/performance.py
+++ b/Magpie/eval/performance.py
@@ -928,8 +928,11 @@ class Performance:
         if metrix_path is None:
             return PerformanceResult(
                 success=False,
-                errors="metrix not found. Install IntelliKit Metrix "
-                "(pip install intellikit[metrix]).",
+                errors=(
+                    "metrix not found. Install IntelliKit Metrix "
+                    '(pip install "git+https://github.com/AMDResearch/intellikit.git@'
+                    '0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=metrix").'
+                ),
             )
 
         testcase_commands = kernel_cfg.get_testcase_commands()

--- a/Magpie/main.py
+++ b/Magpie/main.py
@@ -239,7 +239,7 @@ def _get_correctness_config(config: Dict[str, Any]) -> Dict[str, Any]:
     acc_cfg = corr_cfg.get("accordo", {})
     accordo_settings = {
         "atol": acc_cfg.get("atol", 1e-6),
-        "rtol": acc_cfg.get("rtol", 0.0),
+        "rtol": acc_cfg.get("rtol", 1e-5),
         "equal_nan": acc_cfg.get("equal_nan", False),
         "timeout_seconds": acc_cfg.get("timeout_seconds", 30),
     }

--- a/Magpie/main.py
+++ b/Magpie/main.py
@@ -238,7 +238,9 @@ def _get_correctness_config(config: Dict[str, Any]) -> Dict[str, Any]:
 
     acc_cfg = corr_cfg.get("accordo", {})
     accordo_settings = {
-        "tolerance": acc_cfg.get("tolerance", 1e-6),
+        "atol": acc_cfg.get("atol", 1e-6),
+        "rtol": acc_cfg.get("rtol", 0.0),
+        "equal_nan": acc_cfg.get("equal_nan", False),
         "timeout_seconds": acc_cfg.get("timeout_seconds", 30),
     }
 

--- a/Magpie/mcp/server.py
+++ b/Magpie/mcp/server.py
@@ -221,7 +221,9 @@ def analyze(
     accordo_kernel_name: str = "",
     accordo_reference_binary: str = "",
     accordo_optimized_binary: str = "",
-    accordo_tolerance: float = 1e-6,
+    accordo_atol: float = 1e-6,
+    accordo_rtol: float = 1e-5,
+    accordo_equal_nan: bool = False,
     accordo_timeout_seconds: int = 30,
 ) -> str:
     """
@@ -240,7 +242,9 @@ def analyze(
         accordo_kernel_name: Kernel function name for Accordo validation (required when correctness_backend="accordo")
         accordo_reference_binary: Reference binary for Accordo comparison
         accordo_optimized_binary: Optimized binary for Accordo comparison
-        accordo_tolerance: Tolerance for Accordo np.allclose comparison (default: 1e-6)
+        accordo_atol: Absolute tolerance for Accordo np.allclose (default: 1e-6)
+        accordo_rtol: Relative tolerance (default: 1e-5, torch-style)
+        accordo_equal_nan: If True, NaN compares equal
         accordo_timeout_seconds: Timeout per snapshot capture in seconds (default: 30)
 
     Returns:
@@ -315,7 +319,9 @@ def analyze(
                         "kernel_name": accordo_kernel_name or None,
                         "reference_binary": accordo_reference_binary or None,
                         "optimized_binary": accordo_optimized_binary or None,
-                        "tolerance": accordo_tolerance,
+                        "atol": accordo_atol,
+                        "rtol": accordo_rtol,
+                        "equal_nan": accordo_equal_nan,
                         "timeout_seconds": accordo_timeout_seconds,
                         "working_directory": working_dir or None,
                     }
@@ -548,7 +554,9 @@ def compare(
     accordo_kernel_name: str = "",
     accordo_reference_binary: str = "",
     accordo_optimized_binary: str = "",
-    accordo_tolerance: float = 1e-6,
+    accordo_atol: float = 1e-6,
+    accordo_rtol: float = 1e-5,
+    accordo_equal_nan: bool = False,
     accordo_timeout_seconds: int = 30,
 ) -> str:
     """
@@ -569,7 +577,9 @@ def compare(
         accordo_kernel_name: Kernel function name for Accordo validation (required when correctness_backend="accordo")
         accordo_reference_binary: Reference binary for Accordo comparison
         accordo_optimized_binary: Optimized binary for Accordo comparison
-        accordo_tolerance: Tolerance for Accordo np.allclose comparison (default: 1e-6)
+        accordo_atol: Absolute tolerance for Accordo (default: 1e-6)
+        accordo_rtol: Relative tolerance (default: 1e-5, torch-style)
+        accordo_equal_nan: If True, NaN compares equal
         accordo_timeout_seconds: Timeout per snapshot capture in seconds (default: 30)
 
     Returns:
@@ -656,7 +666,9 @@ def compare(
                         "kernel_name": accordo_kernel_name or None,
                         "reference_binary": accordo_reference_binary or None,
                         "optimized_binary": accordo_optimized_binary or None,
-                        "tolerance": accordo_tolerance,
+                        "atol": accordo_atol,
+                        "rtol": accordo_rtol,
+                        "equal_nan": accordo_equal_nan,
                         "timeout_seconds": accordo_timeout_seconds,
                         "working_directory": first_wd,
                     }

--- a/examples/ck_gemm_add_accordo.yaml
+++ b/examples/ck_gemm_add_accordo.yaml
@@ -4,7 +4,7 @@
 #   git clone https://github.com/ROCm/composable_kernel.git
 #   export CK_HOME=/path/to/composable_kernel
 #   Rebuild with debug info: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ... && make test_gemm_add_xdl -j8
-#   pip install "git+https://github.com/AMDResearch/intellikit.git@0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=accordo"
+#   pip install "git+https://github.com/AMDResearch/intellikit.git@1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=accordo"
 # Note:
 #   CK binaries must be compiled with debug info (-g / RelWithDebInfo) so Accordo
 #   can extract kernel arguments via kernelDB. Release builds will fail with

--- a/examples/ck_gemm_add_accordo.yaml
+++ b/examples/ck_gemm_add_accordo.yaml
@@ -4,7 +4,7 @@
 #   git clone https://github.com/ROCm/composable_kernel.git
 #   export CK_HOME=/path/to/composable_kernel
 #   Rebuild with debug info: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ... && make test_gemm_add_xdl -j8
-#   pip install intellikit[accordo]
+#   pip install "git+https://github.com/AMDResearch/intellikit.git@0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=accordo"
 # Note:
 #   CK binaries must be compiled with debug info (-g / RelWithDebInfo) so Accordo
 #   can extract kernel arguments via kernelDB. Release builds will fail with
@@ -33,4 +33,4 @@ correctness:
     kernel_name: "DeviceGemmMultipleD_Xdl_CShuffle"
     reference_binary: "bin/test_gemm_add_xdl"
     optimized_binary: "bin/test_gemm_add_xdl"
-    tolerance: 1.0e-4
+    atol: 1.0e-4

--- a/examples/ck_grouped_gemm_compare_accordo.yaml
+++ b/examples/ck_grouped_gemm_compare_accordo.yaml
@@ -5,7 +5,7 @@
 #   git clone https://github.com/ROCm/composable_kernel.git
 #   export CK_HOME=/path/to/composable_kernel
 #   Rebuild with debug info: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ... && make -j8
-#   pip install "git+https://github.com/AMDResearch/intellikit.git@0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=accordo"
+#   pip install "git+https://github.com/AMDResearch/intellikit.git@1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=accordo"
 # Note:
 #   CK binaries must be compiled with debug info (-g / RelWithDebInfo) so Accordo
 #   can extract kernel arguments via kernelDB.

--- a/examples/ck_grouped_gemm_compare_accordo.yaml
+++ b/examples/ck_grouped_gemm_compare_accordo.yaml
@@ -5,7 +5,7 @@
 #   git clone https://github.com/ROCm/composable_kernel.git
 #   export CK_HOME=/path/to/composable_kernel
 #   Rebuild with debug info: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ... && make -j8
-#   pip install intellikit[accordo]
+#   pip install "git+https://github.com/AMDResearch/intellikit.git@0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=accordo"
 # Note:
 #   CK binaries must be compiled with debug info (-g / RelWithDebInfo) so Accordo
 #   can extract kernel arguments via kernelDB.
@@ -36,4 +36,4 @@ correctness:
     kernel_name: "DeviceGroupedGemm_Xdl_CShuffle"
     reference_binary: "bin/example_grouped_gemm_xdl_bf16"
     optimized_binary: "bin/example_grouped_gemm_xdl_fp16"
-    tolerance: 1.0e-3
+    atol: 1.0e-3

--- a/examples/simple_hip_test/analyze_accordo.yaml
+++ b/examples/simple_hip_test/analyze_accordo.yaml
@@ -2,7 +2,7 @@
 # ================================================
 # Prereq:
 #   cd examples/simple_hip_test && hipcc -g -O2 -o vector_add vector_add.hip
-#   pip install "git+https://github.com/AMDResearch/intellikit.git@0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=accordo"
+#   pip install "git+https://github.com/AMDResearch/intellikit.git@1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=accordo"
 # Note:
 #   Binaries must be compiled with -g so Accordo can extract kernel arguments.
 #   First run builds the Accordo interception library (~2-3 min one-time cost).

--- a/examples/simple_hip_test/analyze_accordo.yaml
+++ b/examples/simple_hip_test/analyze_accordo.yaml
@@ -2,7 +2,7 @@
 # ================================================
 # Prereq:
 #   cd examples/simple_hip_test && hipcc -g -O2 -o vector_add vector_add.hip
-#   pip install intellikit[accordo]
+#   pip install "git+https://github.com/AMDResearch/intellikit.git@0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=accordo"
 # Note:
 #   Binaries must be compiled with -g so Accordo can extract kernel arguments.
 #   First run builds the Accordo interception library (~2-3 min one-time cost).
@@ -28,4 +28,4 @@ correctness:
     kernel_name: "vector_add(float const*, float const*, float*, int)"
     reference_binary: "./vector_add"
     optimized_binary: "./vector_add"
-    tolerance: 1.0e-6
+    atol: 1.0e-6

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,13 @@ mcp>=1.0.0
 # see https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html
 
 # Optional: IntelliKit Metrix (AMD GPU human-readable profiling metrics)
-# pip install git+https://github.com/AMDResearch/intellikit.git#subdirectory=metrix
-# or from local source: pip install -e /path/to/intellikit/metrix
+# pip install "git+https://github.com/AMDResearch/intellikit.git@0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=metrix"
+# or clone and install editable:
+#   git clone https://github.com/AMDResearch/intellikit.git && cd intellikit
+#   git checkout 0f2a15c9eba3717e984961e2bcf72a0aa3052713 && pip install -e metrix
 
 # Optional: IntelliKit Accordo (AMD GPU kernel correctness validation via HSA interception)
-# pip install git+https://github.com/AMDResearch/intellikit.git#subdirectory=accordo
-# or from local source: pip install -e /path/to/intellikit/accordo
+# pip install "git+https://github.com/AMDResearch/intellikit.git@0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=accordo"
+# or clone and install editable:
+#   git clone https://github.com/AMDResearch/intellikit.git && cd intellikit
+#   git checkout 0f2a15c9eba3717e984961e2bcf72a0aa3052713 && pip install -e accordo

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,9 @@ mcp>=1.0.0
 # see https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html
 
 # Optional: IntelliKit Metrix (AMD GPU human-readable profiling metrics)
-# pip install intellikit[metrix]
+# pip install git+https://github.com/AMDResearch/intellikit.git#subdirectory=metrix
 # or from local source: pip install -e /path/to/intellikit/metrix
 
 # Optional: IntelliKit Accordo (AMD GPU kernel correctness validation via HSA interception)
-# pip install intellikit[accordo]
+# pip install git+https://github.com/AMDResearch/intellikit.git#subdirectory=accordo
 # or from local source: pip install -e /path/to/intellikit/accordo

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,13 +20,13 @@ mcp>=1.0.0
 # see https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html
 
 # Optional: IntelliKit Metrix (AMD GPU human-readable profiling metrics)
-# pip install "git+https://github.com/AMDResearch/intellikit.git@0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=metrix"
+# pip install "git+https://github.com/AMDResearch/intellikit.git@1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=metrix"
 # or clone and install editable:
 #   git clone https://github.com/AMDResearch/intellikit.git && cd intellikit
-#   git checkout 0f2a15c9eba3717e984961e2bcf72a0aa3052713 && pip install -e metrix
+#   git checkout 1511ed984c01f2254df3ca567153c5e7cb2ac9d9 && pip install -e metrix
 
 # Optional: IntelliKit Accordo (AMD GPU kernel correctness validation via HSA interception)
-# pip install "git+https://github.com/AMDResearch/intellikit.git@0f2a15c9eba3717e984961e2bcf72a0aa3052713#subdirectory=accordo"
+# pip install "git+https://github.com/AMDResearch/intellikit.git@1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=accordo"
 # or clone and install editable:
 #   git clone https://github.com/AMDResearch/intellikit.git && cd intellikit
-#   git checkout 0f2a15c9eba3717e984961e2bcf72a0aa3052713 && pip install -e accordo
+#   git checkout 1511ed984c01f2254df3ca567153c5e7cb2ac9d9 && pip install -e accordo


### PR DESCRIPTION
This PR:

- Replaces legacy tolerance with atol, rtol, and equal_nan in AccordoConfig, YAML, framework defaults (main.py, config.yaml), and MCP analyze/compare overrides. New accordo APIs follow PyTorch and NumPy APIs.
- Invokes accordo validate with --atol, --rtol, and optional --equal-nan.
- Documents pinned IntelliKit at commit 1511ed984c01f2254df3ca567153c5e7cb2ac9d9 in requirements.txt (Metrix and Accordo), with git clone, checkout, and pip install -e accordo/metrix alternates.


Tested on the simple_hip_test example.