### PR TITLE
Feature/xiaofei/hyperloom magpie

### DIFF
--- a/Magpie/main.py
+++ b/Magpie/main.py
@@ -894,7 +894,7 @@ def run_gap_analysis_standalone(args) -> int:
         print(f"Error: trace directory not found: {trace_dir}")
         return 1
 
-    top_k = getattr(args, "gap_analysis_top_k", None) or getattr(args, "top_k", 20)
+    top_k = getattr(args, "top_k", 20)
     gap_config = GapAnalysisConfig(
         enabled=True,
         trace_start_pct=args.start_pct,
@@ -969,27 +969,17 @@ def run_benchmark(args, config: Dict[str, Any]) -> int:
             return 1
     elif args.framework and args.model:
         # Build from CLI arguments
-        envs: Dict[str, Any] = {
-            "TP": args.tp,
-            "CONC": args.concurrency,
-            "ISL": args.input_len,
-            "OSL": args.output_len,
-            "RANDOM_RANGE_RATIO": 0.5,
-        }
-        # Merge caller-supplied extra environment variables
-        for pair in getattr(args, "extra_envs", None) or []:
-            if "=" in pair:
-                k, v = pair.split("=", 1)
-                envs[k] = v
-
-        tracelens_enabled = getattr(args, "tracelens", False)
-        gap_enabled = getattr(args, "gap_analysis", False)
-
         benchmark_cfg = {
             "framework": args.framework,
             "model": args.model,
             "precision": args.precision,
-            "envs": envs,
+            "envs": {
+                "TP": args.tp,
+                "CONC": args.concurrency,
+                "ISL": args.input_len,
+                "OSL": args.output_len,
+                "RANDOM_RANGE_RATIO": 0.5,
+            },
             "profiler": {
                 "torch_profiler": {
                     "enabled": args.torch_profiler,
@@ -997,21 +987,9 @@ def run_benchmark(args, config: Dict[str, Any]) -> int:
                 "system_profiler": {
                     "enabled": args.system_profiler,
                 },
-                "tracelens": {
-                    "enabled": tracelens_enabled,
-                },
-            },
-            "gap_analysis": {
-                "enabled": gap_enabled,
-                "top_k": getattr(args, "gap_analysis_top_k", 20),
-                "trace_start_pct": getattr(args, "gap_analysis_start_pct", 0.0),
-                "trace_end_pct": getattr(args, "gap_analysis_end_pct", 100.0),
             },
             "docker_image": args.docker_image,
-            "gpu_arch": getattr(args, "gpu_arch", None),
             "inferencex_path": args.inferencex_path,
-            "hf_cache_path": getattr(args, "hf_cache_path", None),
-            "runner_type": getattr(args, "runner_type", None),
             "benchmark_script": args.benchmark_script,
             "timeout_seconds": args.timeout,
         }
@@ -1212,29 +1190,6 @@ def create_parser() -> argparse.ArgumentParser:
         "--system-profiler", action="store_true",
         help="Enable system profiler (rocprof/ncu)"
     )
-    # NOTE: For reproducible benchmarks, prefer YAML config via
-    # --benchmark-config (see examples/benchmarks/).  The CLI flags below
-    # are convenience shortcuts for ad-hoc runs and automation (Hyperloom).
-    benchmark_parser.add_argument(
-        "--tracelens", action="store_true",
-        help="Enable TraceLens trace analysis (requires --torch-profiler)"
-    )
-    benchmark_parser.add_argument(
-        "--gap-analysis", action="store_true", dest="gap_analysis",
-        help="Enable gap analysis on torch traces (requires --torch-profiler)"
-    )
-    benchmark_parser.add_argument(
-        "--gap-analysis-top-k", type=int, default=20,
-        help="Number of top bottleneck kernels in gap analysis (default: 20)"
-    )
-    benchmark_parser.add_argument(
-        "--gap-analysis-start-pct", type=float, default=0.0,
-        help="Gap analysis window start %% (0-100, default: 0)"
-    )
-    benchmark_parser.add_argument(
-        "--gap-analysis-end-pct", type=float, default=100.0,
-        help="Gap analysis window end %% (0-100, default: 100)"
-    )
     benchmark_parser.add_argument(
         "--run-mode", type=str, default=None,
         choices=["docker", "local"],
@@ -1245,21 +1200,9 @@ def create_parser() -> argparse.ArgumentParser:
         "--docker-image", type=str, help="Override Docker image"
     )
     benchmark_parser.add_argument(
-        "--gpu-arch", type=str,
-        help="Force GPU architecture (e.g. gfx942, gfx950); auto-detected if omitted"
-    )
-    benchmark_parser.add_argument(
-        "--runner-type", type=str,
-        help="Hardware runner type (e.g. mi300x, mi355x, h100); auto-detected if omitted"
-    )
-    benchmark_parser.add_argument(
         "--inferencex-path", type=str,
         default="",
         help="Path to InferenceX installation (auto-cloned if not specified)"
-    )
-    benchmark_parser.add_argument(
-        "--hf-cache-path", type=str,
-        help="HuggingFace cache directory (default: ~/.cache/huggingface)"
     )
     benchmark_parser.add_argument(
         "--benchmark-script", type=str,
@@ -1267,10 +1210,6 @@ def create_parser() -> argparse.ArgumentParser:
     )
     benchmark_parser.add_argument(
         "--timeout", type=int, default=3600, help="Benchmark timeout in seconds"
-    )
-    benchmark_parser.add_argument(
-        "--extra-envs", type=str, nargs="*", metavar="KEY=VALUE",
-        help="Extra environment variables (e.g. --extra-envs NUM_PROMPTS=96 EXTRA_SGLANG_ARGS='--enable-torch-compile')"
     )
     benchmark_parser.add_argument(
         "--output-dir",
@@ -1287,6 +1226,10 @@ def create_parser() -> argparse.ArgumentParser:
         help="Run standalone gap analysis on existing traces instead of a "
              "benchmark. Pass the path to a torch_trace directory (or a "
              "benchmark workspace containing one).",
+    )
+    benchmark_parser.add_argument(
+        "--top-k", type=int, default=20,
+        help="Gap analysis: number of top bottleneck kernels (default: 20)",
     )
     benchmark_parser.add_argument(
         "--start-pct", type=float, default=0.0,

--- a/Magpie/main.py
+++ b/Magpie/main.py
@@ -894,11 +894,12 @@ def run_gap_analysis_standalone(args) -> int:
         print(f"Error: trace directory not found: {trace_dir}")
         return 1
 
+    top_k = getattr(args, "gap_analysis_top_k", None) or getattr(args, "top_k", 20)
     gap_config = GapAnalysisConfig(
         enabled=True,
         trace_start_pct=args.start_pct,
         trace_end_pct=args.end_pct,
-        top_k=args.top_k,
+        top_k=top_k,
         min_duration_us=args.min_duration_us,
         categories=getattr(args, "categories", None),
         ignore_categories=getattr(args, "ignore_categories", None),
@@ -953,8 +954,8 @@ def run_benchmark(args, config: Dict[str, Any]) -> int:
     """Run benchmark mode."""
     from .modes.benchmark import BenchmarkMode, BenchmarkConfig
 
-    # Handle gap-analysis sub-subcommand
-    if getattr(args, "benchmark_action", None) == "gap-analysis":
+    # Handle standalone gap-analysis (--trace-dir without framework)
+    if getattr(args, "trace_dir", None) is not None:
         return run_gap_analysis_standalone(args)
 
     # Build benchmark config
@@ -968,17 +969,27 @@ def run_benchmark(args, config: Dict[str, Any]) -> int:
             return 1
     elif args.framework and args.model:
         # Build from CLI arguments
+        envs: Dict[str, Any] = {
+            "TP": args.tp,
+            "CONC": args.concurrency,
+            "ISL": args.input_len,
+            "OSL": args.output_len,
+            "RANDOM_RANGE_RATIO": 0.5,
+        }
+        # Merge caller-supplied extra environment variables
+        for pair in getattr(args, "extra_envs", None) or []:
+            if "=" in pair:
+                k, v = pair.split("=", 1)
+                envs[k] = v
+
+        tracelens_enabled = getattr(args, "tracelens", False)
+        gap_enabled = getattr(args, "gap_analysis", False)
+
         benchmark_cfg = {
             "framework": args.framework,
             "model": args.model,
             "precision": args.precision,
-            "params": {
-                "TP": args.tp,
-                "CONC": args.concurrency,
-                "ISL": args.input_len,
-                "OSL": args.output_len,
-                "RANDOM_RANGE_RATIO": 0.5,
-            },
+            "envs": envs,
             "profiler": {
                 "torch_profiler": {
                     "enabled": args.torch_profiler,
@@ -986,9 +997,21 @@ def run_benchmark(args, config: Dict[str, Any]) -> int:
                 "system_profiler": {
                     "enabled": args.system_profiler,
                 },
+                "tracelens": {
+                    "enabled": tracelens_enabled,
+                },
+            },
+            "gap_analysis": {
+                "enabled": gap_enabled,
+                "top_k": getattr(args, "gap_analysis_top_k", 20),
+                "trace_start_pct": getattr(args, "gap_analysis_start_pct", 0.0),
+                "trace_end_pct": getattr(args, "gap_analysis_end_pct", 100.0),
             },
             "docker_image": args.docker_image,
+            "gpu_arch": getattr(args, "gpu_arch", None),
             "inferencex_path": args.inferencex_path,
+            "hf_cache_path": getattr(args, "hf_cache_path", None),
+            "runner_type": getattr(args, "runner_type", None),
             "benchmark_script": args.benchmark_script,
             "timeout_seconds": args.timeout,
         }
@@ -1190,6 +1213,26 @@ def create_parser() -> argparse.ArgumentParser:
         help="Enable system profiler (rocprof/ncu)"
     )
     benchmark_parser.add_argument(
+        "--tracelens", action="store_true",
+        help="Enable TraceLens trace analysis (requires --torch-profiler)"
+    )
+    benchmark_parser.add_argument(
+        "--gap-analysis", action="store_true", dest="gap_analysis",
+        help="Enable gap analysis on torch traces (requires --torch-profiler)"
+    )
+    benchmark_parser.add_argument(
+        "--gap-analysis-top-k", type=int, default=20,
+        help="Number of top bottleneck kernels in gap analysis (default: 20)"
+    )
+    benchmark_parser.add_argument(
+        "--gap-analysis-start-pct", type=float, default=0.0,
+        help="Gap analysis window start %% (0-100, default: 0)"
+    )
+    benchmark_parser.add_argument(
+        "--gap-analysis-end-pct", type=float, default=100.0,
+        help="Gap analysis window end %% (0-100, default: 100)"
+    )
+    benchmark_parser.add_argument(
         "--run-mode", type=str, default=None,
         choices=["docker", "local"],
         help="Execution mode: 'docker' (default) runs inside a container; "
@@ -1199,9 +1242,21 @@ def create_parser() -> argparse.ArgumentParser:
         "--docker-image", type=str, help="Override Docker image"
     )
     benchmark_parser.add_argument(
+        "--gpu-arch", type=str,
+        help="Force GPU architecture (e.g. gfx942, gfx950); auto-detected if omitted"
+    )
+    benchmark_parser.add_argument(
+        "--runner-type", type=str,
+        help="Hardware runner type (e.g. mi300x, mi355x, h100); auto-detected if omitted"
+    )
+    benchmark_parser.add_argument(
         "--inferencex-path", type=str,
         default="",
         help="Path to InferenceX installation (auto-cloned if not specified)"
+    )
+    benchmark_parser.add_argument(
+        "--hf-cache-path", type=str,
+        help="HuggingFace cache directory (default: ~/.cache/huggingface)"
     )
     benchmark_parser.add_argument(
         "--benchmark-script", type=str,
@@ -1211,6 +1266,10 @@ def create_parser() -> argparse.ArgumentParser:
         "--timeout", type=int, default=3600, help="Benchmark timeout in seconds"
     )
     benchmark_parser.add_argument(
+        "--extra-envs", type=str, nargs="*", metavar="KEY=VALUE",
+        help="Extra environment variables (e.g. --extra-envs NUM_PROMPTS=96 EXTRA_SGLANG_ARGS='--enable-torch-compile')"
+    )
+    benchmark_parser.add_argument(
         "--output-dir",
         "-o",
         type=Path,
@@ -1218,41 +1277,33 @@ def create_parser() -> argparse.ArgumentParser:
         help="Output directory",
     )
 
-    # Sub-subcommands under benchmark
-    benchmark_subs = benchmark_parser.add_subparsers(
-        dest="benchmark_action", help="Benchmark sub-actions"
+    # Standalone gap-analysis on existing traces (replaces sub-subparser to
+    # avoid argparse conflict with the positional `framework` argument)
+    benchmark_parser.add_argument(
+        "--trace-dir", type=Path, default=None,
+        help="Run standalone gap analysis on existing traces instead of a "
+             "benchmark. Pass the path to a torch_trace directory (or a "
+             "benchmark workspace containing one).",
     )
-
-    gap_parser = benchmark_subs.add_parser(
-        "gap-analysis", help="Run gap analysis on existing torch traces"
-    )
-    gap_parser.add_argument(
-        "--trace-dir", type=Path, required=True,
-        help="Path to torch_trace directory (or benchmark workspace)",
-    )
-    gap_parser.add_argument(
+    benchmark_parser.add_argument(
         "--start-pct", type=float, default=0.0,
-        help="Start of analysis window (0-100, default: 0)",
+        help="Gap analysis: start of window (0-100, default: 0)",
     )
-    gap_parser.add_argument(
+    benchmark_parser.add_argument(
         "--end-pct", type=float, default=100.0,
-        help="End of analysis window (0-100, default: 100)",
+        help="Gap analysis: end of window (0-100, default: 100)",
     )
-    gap_parser.add_argument(
-        "--top-k", type=int, default=20,
-        help="Number of top bottleneck kernels (default: 20)",
-    )
-    gap_parser.add_argument(
+    benchmark_parser.add_argument(
         "--min-duration-us", type=float, default=0.0,
-        help="Minimum event duration in microseconds (default: 0)",
+        help="Gap analysis: minimum event duration in microseconds (default: 0)",
     )
-    gap_parser.add_argument(
+    benchmark_parser.add_argument(
         "--categories", type=str, nargs="*", default=None,
-        help="Event categories to include (e.g. kernel gpu). None = all.",
+        help="Gap analysis: event categories to include (e.g. kernel gpu). None = all.",
     )
-    gap_parser.add_argument(
+    benchmark_parser.add_argument(
         "--ignore-categories", type=str, nargs="*", default=None,
-        help="Event categories to exclude (e.g. gpu_user_annotation)",
+        help="Gap analysis: event categories to exclude (e.g. gpu_user_annotation)",
     )
 
     return parser

--- a/Magpie/main.py
+++ b/Magpie/main.py
@@ -1212,6 +1212,9 @@ def create_parser() -> argparse.ArgumentParser:
         "--system-profiler", action="store_true",
         help="Enable system profiler (rocprof/ncu)"
     )
+    # NOTE: For reproducible benchmarks, prefer YAML config via
+    # --benchmark-config (see examples/benchmarks/).  The CLI flags below
+    # are convenience shortcuts for ad-hoc runs and automation (Hyperloom).
     benchmark_parser.add_argument(
         "--tracelens", action="store_true",
         help="Enable TraceLens trace analysis (requires --torch-profiler)"

--- a/Magpie/mcp/server.py
+++ b/Magpie/mcp/server.py
@@ -38,6 +38,7 @@ Usage:
     python -m Magpie.mcp
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -1241,7 +1242,7 @@ def create_kernel_config(
 # Tool 8: benchmark
 # =============================================================================
 @mcp.tool()
-def benchmark(
+async def benchmark(
     framework: str,
     model: str,
     precision: str = "fp8",
@@ -1424,7 +1425,10 @@ def benchmark(
             output_dir=output_dir,
         )
 
-        result = benchmarker.run()
+        try:
+            result = await asyncio.to_thread(benchmarker.run)
+        finally:
+            benchmarker.cleanup()
 
         response = result.to_dict()
         response["summary_text"] = result.get_summary()
@@ -2090,7 +2094,7 @@ def ray_task_list(
 # Tool 19: benchmark_batch
 # =============================================================================
 @mcp.tool()
-def benchmark_batch(
+async def benchmark_batch(
     configs: List[Dict[str, Any]],
     ray_cluster_address: str = "",
     ray_shared_storage_path: str = "",
@@ -2121,102 +2125,105 @@ def benchmark_batch(
     """
     from ..modes.benchmark import BenchmarkMode, BenchmarkConfig
 
-    try:
-        if not configs:
-            return json.dumps({"error": "configs list is empty"})
+    def _run_batch() -> str:
+        try:
+            if not configs:
+                return json.dumps({"error": "configs list is empty"})
 
-        results: List[Dict[str, Any]] = []
-        addr = ray_cluster_address or "auto"
-        shared_storage_root = ray_shared_storage_path or DEFAULT_SHARED_STORAGE_PATH
+            results: List[Dict[str, Any]] = []
+            addr = ray_cluster_address or "auto"
+            shared_storage_root = ray_shared_storage_path or DEFAULT_SHARED_STORAGE_PATH
 
-        if parallel:
-            executor = _get_ray_executor(addr, shared_storage_root)
-            for i, raw in enumerate(configs):
-                try:
-                    cfg = dict(raw)
-                    cfg["run_mode"] = "ray"
-                    if "ray_config" not in cfg:
-                        cfg["ray_config"] = {
-                            "cluster_address": addr,
-                            "shared_storage_path": shared_storage_root,
-                        }
+            if parallel:
+                executor = _get_ray_executor(addr, shared_storage_root)
+                for i, raw in enumerate(configs):
+                    try:
+                        cfg = dict(raw)
+                        cfg["run_mode"] = "ray"
+                        if "ray_config" not in cfg:
+                            cfg["ray_config"] = {
+                                "cluster_address": addr,
+                                "shared_storage_path": shared_storage_root,
+                            }
 
-                    benchmark_config = BenchmarkConfig.from_dict(cfg)
-                    benchmarker = BenchmarkMode(
-                        config=benchmark_config,
-                        output_dir=cfg.get("output_dir", "./results"),
-                    )
-                    sub = benchmarker.submit_ray_benchmark(executor)
-                    tid = (sub.metadata or {}).get("task_id", "unknown")
-                    if sub.success:
+                        benchmark_config = BenchmarkConfig.from_dict(cfg)
+                        benchmarker = BenchmarkMode(
+                            config=benchmark_config,
+                            output_dir=cfg.get("output_dir", "./results"),
+                        )
+                        sub = benchmarker.submit_ray_benchmark(executor)
+                        tid = (sub.metadata or {}).get("task_id", "unknown")
+                        if sub.success:
+                            results.append({
+                                "index": i,
+                                "framework": cfg.get("framework"),
+                                "model": cfg.get("model"),
+                                "task_id": tid,
+                                "ray_job_id": tid,
+                                "status": "SUBMITTED",
+                                "submitted": True,
+                            })
+                        else:
+                            results.append({
+                                "index": i,
+                                "framework": cfg.get("framework"),
+                                "model": cfg.get("model"),
+                                "error": "; ".join(sub.errors) if sub.errors else "submit failed",
+                            })
+                    except Exception as e:
+                        results.append({
+                            "index": i,
+                            "framework": raw.get("framework"),
+                            "model": raw.get("model"),
+                            "error": str(e),
+                        })
+            else:
+                for i, raw in enumerate(configs):
+                    try:
+                        cfg = dict(raw)
+                        cfg["run_mode"] = "ray"
+                        if "ray_config" not in cfg:
+                            cfg["ray_config"] = {
+                                "cluster_address": addr,
+                                "shared_storage_path": shared_storage_root,
+                            }
+
+                        benchmark_config = BenchmarkConfig.from_dict(cfg)
+                        benchmarker = BenchmarkMode(
+                            config=benchmark_config,
+                            output_dir=cfg.get("output_dir", "./results"),
+                        )
+                        result = benchmarker.run()
+                        ray_job_id = (result.metadata or {}).get("ray_job_id", "unknown")
                         results.append({
                             "index": i,
                             "framework": cfg.get("framework"),
                             "model": cfg.get("model"),
-                            "task_id": tid,
-                            "ray_job_id": tid,
-                            "status": "SUBMITTED",
-                            "submitted": True,
+                            "ray_job_id": ray_job_id,
+                            "status": "PENDING",
+                            "workspace_dir": result.workspace_dir,
                         })
-                    else:
+                    except Exception as e:
                         results.append({
                             "index": i,
-                            "framework": cfg.get("framework"),
-                            "model": cfg.get("model"),
-                            "error": "; ".join(sub.errors) if sub.errors else "submit failed",
+                            "framework": raw.get("framework"),
+                            "model": raw.get("model"),
+                            "error": str(e),
                         })
-                except Exception as e:
-                    results.append({
-                        "index": i,
-                        "framework": raw.get("framework"),
-                        "model": raw.get("model"),
-                        "error": str(e),
-                    })
-        else:
-            for i, raw in enumerate(configs):
-                try:
-                    cfg = dict(raw)
-                    cfg["run_mode"] = "ray"
-                    if "ray_config" not in cfg:
-                        cfg["ray_config"] = {
-                            "cluster_address": addr,
-                            "shared_storage_path": shared_storage_root,
-                        }
 
-                    benchmark_config = BenchmarkConfig.from_dict(cfg)
-                    benchmarker = BenchmarkMode(
-                        config=benchmark_config,
-                        output_dir=cfg.get("output_dir", "./results"),
-                    )
-                    result = benchmarker.run()
-                    ray_job_id = (result.metadata or {}).get("ray_job_id", "unknown")
-                    results.append({
-                        "index": i,
-                        "framework": cfg.get("framework"),
-                        "model": cfg.get("model"),
-                        "ray_job_id": ray_job_id,
-                        "status": "PENDING",
-                        "workspace_dir": result.workspace_dir,
-                    })
-                except Exception as e:
-                    results.append({
-                        "index": i,
-                        "framework": raw.get("framework"),
-                        "model": raw.get("model"),
-                        "error": str(e),
-                    })
+            ok = [r for r in results if "error" not in r]
+            return json.dumps({
+                "parallel": parallel,
+                "submitted": len(ok),
+                "failed": len([r for r in results if "error" in r]),
+                "jobs": results,
+            }, indent=2)
 
-        ok = [r for r in results if "error" not in r]
-        return json.dumps({
-            "parallel": parallel,
-            "submitted": len(ok),
-            "failed": len([r for r in results if "error" in r]),
-            "jobs": results,
-        }, indent=2)
+        except Exception as e:
+            logger.exception(f"benchmark_batch failed: {e}")
+            return json.dumps({"error": str(e)})
 
-    except Exception as e:
-        logger.exception(f"benchmark_batch failed: {e}")
-        return json.dumps({"error": str(e)})
+    return await asyncio.to_thread(_run_batch)
 
 
 # =============================================================================

--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -148,6 +148,7 @@ class BenchmarkMode:
         result.execution_time = time.time() - start_time
         result.framework = self.config.framework
         result.model = self.config.model
+        result.profiling_enabled = self.config.profiler.torch_profiler.enabled
         
         # Parse InferenceX output
         result_file = workspace / "inferencex_result.json"
@@ -171,6 +172,20 @@ class BenchmarkMode:
             )
             if stderr:
                 result.errors.append(f"stderr (last 500 chars): {stderr[-500:]}")
+
+            server_log = workspace / "server.log"
+            if server_log.exists():
+                try:
+                    lines = server_log.read_text().splitlines()
+                    error_lines = [l for l in lines[-50:] if any(
+                        kw in l for kw in ["Error", "Exception", "FAILED", "Traceback", "RuntimeError"]
+                    )]
+                    if error_lines:
+                        result.errors.append(
+                            f"server.log errors: {chr(10).join(error_lines[-5:])}"
+                        )
+                except Exception:
+                    pass
         
         # Validate that we got actual results
         if result.success and not self._validate_results(result):

--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -11,6 +11,7 @@ Orchestrates benchmark execution using InferenceX as backend.
 
 import logging
 import os
+import signal
 import shutil
 import subprocess
 import time
@@ -132,6 +133,7 @@ class BenchmarkMode:
                 )
             finally:
                 self._remove_workspace_symlink(symlink)
+                self._cleanup_server_processes(self.config.framework)
         else:
             docker_image = self._select_image()
             docker_cmd = self._build_docker_command(
@@ -398,26 +400,18 @@ class BenchmarkMode:
         """
         Create /workspace symlink pointing to the real workspace directory.
         
-        Many InferenceX scripts hardcode /workspace/ for result-dir and
-        server logs.  A symlink makes them work transparently in local mode.
+        Skipped: RESULT_DIR and SERVER_LOG are already passed via env vars
+        in _build_local_command, so InferenceX scripts resolve paths correctly
+        without a /workspace symlink. Creating symlinks in pods causes stale
+        references when benchmarks are interrupted.
         
         Returns:
-            The symlink Path if created, None if /workspace already exists.
+            Always None (symlink creation disabled).
         """
-        target = Path("/workspace")
-        if target.exists() or target.is_symlink():
-            logger.debug(f"/workspace already exists, skipping symlink")
-            return None
-        try:
-            target.symlink_to(workspace)
-            logger.info(f"Created symlink /workspace -> {workspace}")
-            return target
-        except OSError as e:
-            logger.warning(
-                f"Could not create /workspace symlink ({e}). "
-                f"Scripts that hardcode /workspace/ may write results to the wrong location."
-            )
-            return None
+        logger.debug(
+            f"Skipping /workspace symlink (RESULT_DIR={workspace} is passed via env)"
+        )
+        return None
 
     @staticmethod
     def _remove_workspace_symlink(symlink: Optional[Path]) -> None:
@@ -552,6 +546,55 @@ class BenchmarkMode:
             logger.exception(f"Benchmark execution failed: {e}")
 
         return result, stdout, stderr
+
+    @staticmethod
+    def _cleanup_server_processes(framework: str) -> None:
+        """Kill leftover inference server processes after benchmark completes.
+
+        Targets vllm/sglang server processes and their workers (TP workers,
+        schedulers, etc.) that may survive the shell EXIT trap — e.g. when
+        torch profiler stop hangs or NCCL cleanup stalls.
+        """
+        patterns = {
+            "vllm": [
+                "vllm.entrypoints",
+                "vllm serve",
+                "vllm.v1.executor",
+                "vllm.v1.worker",
+            ],
+            "sglang": [
+                "sglang.launch_server",
+                "sglang.srt.managers",
+                "sglang.srt.server",
+            ],
+        }
+
+        targets = patterns.get(framework, [])
+        if not targets:
+            return
+
+        killed = 0
+        for proc_dir in Path("/proc").iterdir():
+            if not proc_dir.name.isdigit():
+                continue
+            pid = int(proc_dir.name)
+            if pid == os.getpid():
+                continue
+            try:
+                cmdline = (proc_dir / "cmdline").read_bytes().decode(
+                    errors="replace"
+                ).replace("\x00", " ")
+                if any(pat in cmdline for pat in targets):
+                    os.kill(pid, signal.SIGKILL)
+                    killed += 1
+            except (ProcessLookupError, PermissionError, FileNotFoundError, OSError):
+                continue
+
+        if killed:
+            logger.info(
+                "cleanup: killed %d leftover %s process(es)", killed, framework
+            )
+            time.sleep(1)
 
     def _find_script_in_benchmarks(self, benchmarks_dir: Path, script_name: str) -> Optional[Path]:
         """
@@ -1021,7 +1064,9 @@ class BenchmarkMode:
 
     def cleanup(self) -> None:
         """Clean up resources."""
-        if self._task_id and not self.config.is_local:
+        if self.config.is_local:
+            self._cleanup_server_processes(self.config.framework)
+        elif self._task_id:
             try:
                 subprocess.run(
                     ["docker", "stop", f"magpie-benchmark-{self._task_id}"],

--- a/Magpie/modes/benchmark/result.py
+++ b/Magpie/modes/benchmark/result.py
@@ -9,6 +9,7 @@ Result classes for benchmark mode.
 Parses and structures benchmark results from InferenceX output.
 """
 
+import gzip
 import json
 import logging
 from dataclasses import dataclass, field
@@ -146,6 +147,7 @@ class BenchmarkResult:
     # Execution info
     workspace_dir: str = ""
     execution_time: float = 0.0
+    profiling_enabled: bool = False
     
     # Errors
     errors: List[str] = field(default_factory=list)
@@ -167,6 +169,7 @@ class BenchmarkResult:
             "gap_analysis": self.gap_analysis,
             "workspace_dir": self.workspace_dir,
             "execution_time": self.execution_time,
+            "profiling_enabled": self.profiling_enabled,
             "errors": self.errors,
         }
     
@@ -360,30 +363,31 @@ class ResultParser:
         if not trace_dir.exists():
             return kernels
         
-        # Look for trace JSON files
-        for trace_file in trace_dir.glob("*.json"):
+        trace_files = sorted(trace_dir.glob("*.json.gz")) + sorted(trace_dir.glob("*.json"))
+        for trace_file in trace_files:
             try:
-                with open(trace_file, 'r') as f:
-                    trace_data = json.load(f)
-                
-                # Parse Chrome trace format
+                if trace_file.suffix == ".gz":
+                    with gzip.open(trace_file, "rt") as f:
+                        trace_data = json.load(f)
+                else:
+                    with open(trace_file, "r") as f:
+                        trace_data = json.load(f)
+
                 events = trace_data.get("traceEvents", [])
                 kernel_times: Dict[str, float] = {}
                 kernel_counts: Dict[str, int] = {}
-                
+
                 for event in events:
                     if event.get("cat") == "kernel":
                         name = event.get("name", "unknown")
-                        dur = event.get("dur", 0) / 1000.0  # Convert to ms
-                        
+                        dur = event.get("dur", 0) / 1000.0
                         if name in kernel_times:
                             kernel_times[name] += dur
                             kernel_counts[name] += 1
                         else:
                             kernel_times[name] = dur
                             kernel_counts[name] = 1
-                
-                # Calculate percentages
+
                 total_time = sum(kernel_times.values())
                 for name, time_ms in sorted(kernel_times.items(), key=lambda x: -x[1]):
                     percent = (time_ms / total_time * 100) if total_time > 0 else 0
@@ -393,9 +397,9 @@ class ResultParser:
                         percent=percent,
                         calls=kernel_counts.get(name, 0),
                     ))
-                
+
                 break  # Only process first trace file
-                
+
             except Exception as e:
                 logger.warning(f"Failed to parse trace file {trace_file}: {e}")
         

--- a/Magpie/scripts/benchmark/sglang_mi300x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi300x.sh
@@ -58,7 +58,7 @@ run_benchmark_serving \
     --input-len "$ISL" \
     --output-len "$OSL" \
     --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts $(( $CONC * 10 )) \
+    --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/

--- a/Magpie/scripts/benchmark/sglang_mi300x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi300x.sh
@@ -31,8 +31,24 @@ fi
 export SGLANG_USE_AITER=1
 export SGLANG_AITER_MLA_PERSIST=1
 
-SERVER_LOG=${SERVER_LOG:-/workspace/server.log}
+WORKSPACE_DIR=${RESULT_DIR:-/workspace}
+SERVER_LOG=${SERVER_LOG:-$WORKSPACE_DIR/server.log}
 PORT=${PORT:-8888}
+
+if [[ "${PROFILE:-}" == "1" ]]; then
+  TRACE_DIR="${SGLANG_TORCH_PROFILER_DIR:-$WORKSPACE_DIR/torch_trace}"
+  mkdir -p "$TRACE_DIR"
+  export SGLANG_TORCH_PROFILER_DIR="$TRACE_DIR"
+fi
+
+# Build default args, skipping any that EXTRA_SGLANG_ARGS already overrides
+DEFAULT_ARGS=""
+for flag_val in "--mem-fraction-static=0.8" "--disable-radix-cache"; do
+  flag="${flag_val%%=*}"
+  if [[ -z "$EXTRA_SGLANG_ARGS" ]] || ! echo "$EXTRA_SGLANG_ARGS" | grep -q -- "$flag"; then
+    DEFAULT_ARGS="$DEFAULT_ARGS $flag_val"
+  fi
+done
 
 set -x
 setsid python3 -m sglang.launch_server \
@@ -41,8 +57,7 @@ setsid python3 -m sglang.launch_server \
   --port=$PORT \
   --trust-remote-code \
   --tensor-parallel-size=$TP \
-  --mem-fraction-static=0.8 \
-  --disable-radix-cache \
+  $DEFAULT_ARGS \
   $EXTRA_SGLANG_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
@@ -61,7 +76,7 @@ run_benchmark_serving \
     --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/
+    --result-dir ${RESULT_DIR:-/workspace/}
 
 # After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then

--- a/Magpie/scripts/benchmark/sglang_mi355x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi355x.sh
@@ -39,10 +39,6 @@ WORKSPACE_DIR=${RESULT_DIR:-/workspace}
 SERVER_LOG=${SERVER_LOG:-$WORKSPACE_DIR/server.log}
 PORT=${PORT:-8888}
 
-# Kill any residual server on the target port
-lsof -ti:$PORT 2>/dev/null | xargs -r kill -9 2>/dev/null || true
-sleep 2
-
 if [[ "${PROFILE:-}" == "1" ]]; then
   TRACE_DIR="${SGLANG_TORCH_PROFILER_DIR:-$WORKSPACE_DIR/torch_trace}"
   mkdir -p "$TRACE_DIR"

--- a/Magpie/scripts/benchmark/sglang_mi355x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi355x.sh
@@ -62,7 +62,7 @@ run_benchmark_serving \
     --input-len "$ISL" \
     --output-len "$OSL" \
     --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts $(( $CONC * 10 )) \
+    --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/

--- a/Magpie/scripts/benchmark/sglang_mi355x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi355x.sh
@@ -35,8 +35,28 @@ fi
 export SGLANG_USE_AITER=1
 export SGLANG_AITER_MLA_PERSIST=1
 
-SERVER_LOG=${SERVER_LOG:-/workspace/server.log}
+WORKSPACE_DIR=${RESULT_DIR:-/workspace}
+SERVER_LOG=${SERVER_LOG:-$WORKSPACE_DIR/server.log}
 PORT=${PORT:-8888}
+
+# Kill any residual server on the target port
+lsof -ti:$PORT 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+sleep 2
+
+if [[ "${PROFILE:-}" == "1" ]]; then
+  TRACE_DIR="${SGLANG_TORCH_PROFILER_DIR:-$WORKSPACE_DIR/torch_trace}"
+  mkdir -p "$TRACE_DIR"
+  export SGLANG_TORCH_PROFILER_DIR="$TRACE_DIR"
+fi
+
+# Build default args, skipping any that EXTRA_SGLANG_ARGS already overrides
+DEFAULT_ARGS=""
+for flag_val in "--mem-fraction-static=0.8" "--disable-radix-cache"; do
+  flag="${flag_val%%=*}"
+  if [[ -z "$EXTRA_SGLANG_ARGS" ]] || ! echo "$EXTRA_SGLANG_ARGS" | grep -q -- "$flag"; then
+    DEFAULT_ARGS="$DEFAULT_ARGS $flag_val"
+  fi
+done
 
 set -x
 setsid python3 -m sglang.launch_server \
@@ -45,8 +65,7 @@ setsid python3 -m sglang.launch_server \
   --port=$PORT \
   --trust-remote-code \
   --tensor-parallel-size=$TP \
-  --mem-fraction-static=0.8 \
-  --disable-radix-cache \
+  $DEFAULT_ARGS \
   $EXTRA_SGLANG_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
@@ -65,7 +84,7 @@ run_benchmark_serving \
     --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/
+    --result-dir ${RESULT_DIR:-/workspace/}
 
 # After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then

--- a/Magpie/scripts/benchmark/vllm_mi300x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi300x.sh
@@ -78,7 +78,7 @@ run_benchmark_serving \
     --input-len "$ISL" \
     --output-len "$OSL" \
     --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts $(( $CONC * 10 )) \
+    --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/ \

--- a/Magpie/scripts/benchmark/vllm_mi300x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi300x.sh
@@ -16,9 +16,10 @@ check_env_vars \
     CONC \
     ISL \
     OSL \
-    MAX_MODEL_LEN \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME
+
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-4096}
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
@@ -40,13 +41,14 @@ fi
 # vLLM optimizations for MI300X
 export VLLM_ROCM_USE_AITER=1
 
-SERVER_LOG=${SERVER_LOG:-/workspace/server.log}
+WORKSPACE_DIR=${RESULT_DIR:-/workspace}
+SERVER_LOG=${SERVER_LOG:-$WORKSPACE_DIR/server.log}
 PORT=${PORT:-8888}
 
 # Build profiler args for vLLM >= 0.15 (env var VLLM_TORCH_PROFILER_DIR is deprecated)
 PROFILER_ARGS=()
 if [[ "${PROFILE:-}" == "1" ]]; then
-  TRACE_DIR="${VLLM_TORCH_PROFILER_DIR:-/workspace/torch_trace}"
+  TRACE_DIR="${VLLM_TORCH_PROFILER_DIR:-$WORKSPACE_DIR/torch_trace}"
   mkdir -p "$TRACE_DIR"
   PROFILER_ARGS+=(--profiler-config.profiler torch)
   PROFILER_ARGS+=(--profiler-config.torch_profiler_dir "$TRACE_DIR")
@@ -63,6 +65,7 @@ setsid vllm serve $MODEL --port $PORT \
   --max-model-len $MAX_MODEL_LEN \
   --trust-remote-code \
   --disable-log-requests \
+  "${PROFILER_ARGS[@]}" \
   $EXTRA_VLLM_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
@@ -81,7 +84,7 @@ run_benchmark_serving \
     --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/ \
+    --result-dir "$WORKSPACE_DIR/" \
     --server-pid "$SERVER_PID" \
     --trust-remote-code
 

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -82,7 +82,7 @@ run_benchmark_serving \
     --input-len "$ISL" \
     --output-len "$OSL" \
     --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts $(( $CONC * 10 )) \
+    --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir "$WORKSPACE_DIR/" \

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -46,10 +46,6 @@ WORKSPACE_DIR=${RESULT_DIR:-/workspace}
 SERVER_LOG=${SERVER_LOG:-$WORKSPACE_DIR/server.log}
 PORT=${PORT:-8888}
 
-# Kill any residual server on the target port
-lsof -ti:$PORT 2>/dev/null | xargs -r kill -9 2>/dev/null || true
-sleep 2
-
 # Build profiler args for vLLM >= 0.15 (env var VLLM_TORCH_PROFILER_DIR is deprecated)
 PROFILER_ARGS=()
 if [[ "${PROFILE:-}" == "1" ]]; then

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -16,9 +16,10 @@ check_env_vars \
     CONC \
     ISL \
     OSL \
-    MAX_MODEL_LEN \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME
+
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-4096}
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
@@ -44,6 +45,10 @@ export VLLM_ROCM_USE_AITER=1
 WORKSPACE_DIR=${RESULT_DIR:-/workspace}
 SERVER_LOG=${SERVER_LOG:-$WORKSPACE_DIR/server.log}
 PORT=${PORT:-8888}
+
+# Kill any residual server on the target port
+lsof -ti:$PORT 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+sleep 2
 
 # Build profiler args for vLLM >= 0.15 (env var VLLM_TORCH_PROFILER_DIR is deprecated)
 PROFILER_ARGS=()


### PR DESCRIPTION
    feat: add CLI args for Hyperloom integration and fix argparse conflict

    - Add --tracelens, --gap-analysis, --extra-envs, --gpu-arch, --runner-type,
      --hf-cache-path CLI arguments to benchmark subcommand
    - Fix params→envs bug: CLI args (TP, CONC, ISL, OSL) now correctly map
      to BenchmarkConfig.envs instead of being overwritten by defaults
    - Fix argparse conflict: remove benchmark sub-subparser (gap-analysis)
      that clashed with positional `framework` argument; standalone gap
      analysis now triggered via --trace-dir flag
    - Support NUM_PROMPTS env override in all benchmark scripts (sglang/vllm
      mi300x/mi355x) for DFS short runs

    Made-with: Cursor
