### PR TITLE
Add auto GPU selection for Benchmark mode

### DIFF
--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -30,7 +30,7 @@ from .workspace import WorkspaceManager
 from .result import BenchmarkResult, LatencyMetrics, ResultParser, ThroughputMetrics
 from .tracelens import TraceLensAnalyzer
 
-from ...utils.gpu import detect_gpu, GPUVendor
+from ...utils.gpu import detect_gpu, find_idle_gpus, GPUVendor
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +98,15 @@ class BenchmarkMode:
             result.errors.append(f"Please clone manually: git clone https://github.com/SemiAnalysisAI/InferenceX.git")
             return result
         
+        # 0b. Optionally pick idle GPU(s) and pin VISIBLE_DEVICES
+        try:
+            self._apply_gpu_selection()
+        except RuntimeError as e:
+            result = BenchmarkResult()
+            result.success = False
+            result.errors.append(str(e))
+            return result
+
         # 1. Copy Magpie generic scripts to InferenceX/benchmarks/
         self._prepare_benchmark_scripts()
         
@@ -219,7 +228,7 @@ class BenchmarkMode:
                 if self.config.gap_analysis.enabled:
                     gap_result = self._run_gap_analysis(torch_trace_dir, workspace)
                     result.gap_analysis = gap_result
-        
+
         # Save report
         self.workspace_mgr.save_report(result.to_dict())
         self.workspace_mgr.save_summary(result.get_summary())
@@ -228,6 +237,76 @@ class BenchmarkMode:
         
         return result
     
+    def _apply_gpu_selection(self) -> None:
+        """Resolve idle GPU(s) and inject the selection into config.envs.
+
+        No-op when ``self.config.gpu_selection.auto`` is False, when the
+        caller has already pinned ``HIP_VISIBLE_DEVICES`` /
+        ``CUDA_VISIBLE_DEVICES`` / ``ROCR_VISIBLE_DEVICES`` in the yaml,
+        or when run_mode is ``ray`` (Ray manages its own scheduling).
+        """
+        sel = self.config.gpu_selection
+        if not sel.auto:
+            return
+        if self.config.is_ray:
+            logger.info("gpu_selection.auto ignored under run_mode=ray")
+            return
+
+        # Honor manual override from yaml envs
+        envs_upper = {str(k).upper(): v for k, v in self.config.envs.items()}
+        for var in ("HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES",
+                    "ROCR_VISIBLE_DEVICES"):
+            if envs_upper.get(var) not in (None, ""):
+                logger.info(
+                    "gpu_selection.auto skipped: %s already set in envs (%s)",
+                    var, envs_upper.get(var),
+                )
+                return
+
+        # Determine how many GPUs we need
+        count = sel.count
+        if count is None:
+            try:
+                count = max(1, int(envs_upper.get("TP", 1)))
+            except (TypeError, ValueError):
+                count = 1
+
+        try:
+            chosen = find_idle_gpus(
+                count=count,
+                min_free_memory_gb=sel.min_free_memory_gb,
+                candidates=sel.candidates,
+            )
+        except RuntimeError as e:
+            raise RuntimeError(
+                f"gpu_selection.auto failed: {e}. "
+                "Free a GPU, raise gpu_selection.min_free_memory_gb, or set "
+                "HIP_VISIBLE_DEVICES manually in envs."
+            ) from e
+
+        if len(chosen) < count:
+            raise RuntimeError(
+                f"gpu_selection.auto: needed {count} idle GPU(s) but only "
+                f"found {len(chosen)} ({chosen})"
+            )
+
+        dev_str = ",".join(str(d) for d in chosen)
+
+        # AMD: set ROCR_VISIBLE_DEVICES (shares index space with rocm-smi);
+        #      launcher scripts remap HIP to the post-filter 0..N-1 range.
+        # NVIDIA: force PCI_BUS_ID order so CUDA_VISIBLE_DEVICES matches nvidia-smi.
+        vendor, _ = detect_gpu()
+        if vendor == GPUVendor.AMD:
+            self.config.envs["ROCR_VISIBLE_DEVICES"] = dev_str
+        else:
+            self.config.envs["CUDA_VISIBLE_DEVICES"] = dev_str
+            self.config.envs.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+
+        logger.info(
+            "gpu_selection.auto: pinned benchmark to physical GPU(s) %s "
+            "(vendor=%s)", dev_str, vendor.name,
+        )
+
     def _select_image(self) -> str:
         """Select Docker image based on configuration."""
         return self.image_selector.select_image(
@@ -1115,4 +1194,3 @@ class BenchmarkMode:
                 )
             except Exception:
                 pass
-

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -362,6 +362,49 @@ class RayConfig:
 
 
 @dataclass
+class GpuSelectionConfig:
+    """
+    Auto-select idle GPU(s) before launching the benchmark.
+
+    When enabled, Magpie scans the host (rocm-smi / nvidia-smi) for GPUs
+    with no compute/KFD processes and at least ``min_free_memory_gb`` of
+    free VRAM, then injects ``HIP_VISIBLE_DEVICES`` /
+    ``CUDA_VISIBLE_DEVICES`` / ``ROCR_VISIBLE_DEVICES`` into the benchmark
+    environment so vLLM/SGLang only sees the chosen device(s).
+
+    Attributes:
+        auto: If True (default), perform the selection. Set to False to
+            keep the legacy behaviour where every GPU on the host is
+            visible and the framework picks device 0.
+        min_free_memory_gb: Reject a GPU whose free VRAM is below this
+            threshold. Default 8 GB (any almost-empty GPU is acceptable).
+        count: Number of GPUs to select. ``None`` means use ``envs.TP``.
+        candidates: Optional whitelist of physical GPU indices to consider.
+    """
+    auto: bool = True
+    min_free_memory_gb: float = 8.0
+    count: Optional[int] = None
+    candidates: Optional[List[int]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "auto": self.auto,
+            "min_free_memory_gb": self.min_free_memory_gb,
+            "count": self.count,
+            "candidates": self.candidates,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GpuSelectionConfig":
+        return cls(
+            auto=bool(data.get("auto", True)),
+            min_free_memory_gb=float(data.get("min_free_memory_gb", 1.0)),
+            count=data.get("count"),
+            candidates=data.get("candidates"),
+        )
+
+
+@dataclass
 class BenchmarkConfig:
     """
     Configuration for benchmark mode.
@@ -412,6 +455,9 @@ class BenchmarkConfig:
     runner_type: Optional[str] = None
     benchmark_script: Optional[str] = None
     
+    # GPU auto-selection (skip cards with running processes / low free VRAM)
+    gpu_selection: GpuSelectionConfig = field(default_factory=GpuSelectionConfig)
+
     # Ray remote execution configuration (used when run_mode="ray")
     ray_config: Optional[RayConfig] = None
     
@@ -445,6 +491,10 @@ class BenchmarkConfig:
         if isinstance(self.gap_analysis, dict):
             self.gap_analysis = GapAnalysisConfig.from_dict(self.gap_analysis)
         
+        # Convert gpu_selection dict to GpuSelectionConfig if needed
+        if isinstance(self.gpu_selection, dict):
+            self.gpu_selection = GpuSelectionConfig.from_dict(self.gpu_selection)
+
         # Convert ray_config dict to RayConfig if needed
         if isinstance(self.ray_config, dict):
             self.ray_config = RayConfig.from_dict(self.ray_config)
@@ -518,6 +568,7 @@ class BenchmarkConfig:
             "hf_cache_path": self.hf_cache_path,
             "runner_type": self.runner_type,
             "benchmark_script": self.benchmark_script,
+            "gpu_selection": self.gpu_selection.to_dict(),
         }
         if self.ray_config is not None:
             d["ray_config"] = self.ray_config.to_dict()
@@ -554,6 +605,7 @@ class BenchmarkConfig:
             hf_cache_path=data.get("hf_cache_path"),
             runner_type=data.get("runner_type"),
             benchmark_script=data.get("benchmark_script"),
+            gpu_selection=GpuSelectionConfig.from_dict(data.get("gpu_selection") or {}),
             ray_config=ray_config,
         )
 

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -421,7 +421,7 @@ class GpuSelectionConfig:
     def from_dict(cls, data: Dict[str, Any]) -> "GpuSelectionConfig":
         return cls(
             auto=bool(data.get("auto", True)),
-            min_free_memory_gb=float(data.get("min_free_memory_gb", 1.0)),
+            min_free_memory_gb=float(data.get("min_free_memory_gb", 8.0)),
             count=data.get("count"),
             candidates=data.get("candidates"),
         )

--- a/Magpie/scripts/benchmark/vllm_mi300x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi300x.sh
@@ -33,9 +33,11 @@ if [[ "$version" == "" || $version -lt 177 ]]; then
   export HSA_NO_SCRATCH_RECLAIM=1
 fi
 
-# Set HIP_VISIBLE_DEVICES to match ROCR_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
-if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
-    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+# ROCR_VISIBLE_DEVICES already re-indexes visible GPUs to 0..N-1, so HIP
+# must use the logical range, not the original physical ids.
+if [ -n "$ROCR_VISIBLE_DEVICES" ] && [ -z "$HIP_VISIBLE_DEVICES" ]; then
+    n=$(echo "$ROCR_VISIBLE_DEVICES" | awk -F, '{print NF}')
+    export HIP_VISIBLE_DEVICES=$(seq -s, 0 $((n-1)))
 fi
 
 # vLLM optimizations for MI300X

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -33,10 +33,11 @@ if [[ "$version" == "" || $version -lt 177 ]]; then
   export HSA_NO_SCRATCH_RECLAIM=1
 fi
 
-# Set HIP_VISIBLE_DEVICES only when the caller has not already provided
-# a logical remapping for the ROCR-filtered device list.
+# ROCR_VISIBLE_DEVICES already re-indexes visible GPUs to 0..N-1, so HIP
+# must use the logical range, not the original physical ids.
 if [ -n "$ROCR_VISIBLE_DEVICES" ] && [ -z "$HIP_VISIBLE_DEVICES" ]; then
-    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+    n=$(echo "$ROCR_VISIBLE_DEVICES" | awk -F, '{print NF}')
+    export HIP_VISIBLE_DEVICES=$(seq -s, 0 $((n-1)))
 fi
 
 # vLLM optimizations for MI355X

--- a/Magpie/utils/gpu.py
+++ b/Magpie/utils/gpu.py
@@ -813,13 +813,238 @@ def get_gpu_info() -> dict:
     }
 
     if vendor == GPUVendor.AMD:
-        info["profiler"] = "rocprof-compute"
+        info["profiler"] = "rocprofv3 & rocprof-compute"
         info["compiler"] = "hipcc"
     elif vendor == GPUVendor.NVIDIA:
         info["profiler"] = "ncu"
         info["compiler"] = "nvcc"
 
     return info
+
+
+def _amd_busy_gpu_ids() -> set:
+    """Return AMD GPU device IDs that currently have KFD compute processes.
+
+    Uses ``rocm-smi --showpidgpus`` which prints, for each running KFD PID,
+    the list of GPU indices it is using. When idle, rocm-smi reports
+    "No KFD PIDs currently running" and this returns an empty set.
+    """
+    busy: set = set()
+    try:
+        result = subprocess.run(
+            ["rocm-smi", "--showpidgpus"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode != 0:
+            return busy
+        out = result.stdout
+        if "No KFD PIDs currently running" in out:
+            return busy
+        for line in out.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if "device(s):" in line:
+                tail = line.split("device(s):", 1)[1].strip()
+                for tok in tail.split():
+                    if tok.isdigit():
+                        busy.add(int(tok))
+            elif line.startswith("PID "):
+                continue
+            else:
+                for tok in line.split():
+                    if tok.isdigit():
+                        busy.add(int(tok))
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    except Exception as e:
+        logger.debug(f"rocm-smi --showpidgpus parse failed: {e}")
+    return busy
+
+
+def _amd_gpu_memory_usage() -> Dict[int, Tuple[float, float]]:
+    """Return ``{device_id: (used_gb, total_gb)}`` for all AMD GPUs."""
+    usage: Dict[int, Tuple[float, float]] = {}
+    try:
+        result = subprocess.run(
+            ["rocm-smi", "--showmeminfo", "vram", "--csv"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode != 0:
+            return usage
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if not line or line.lower().startswith("device"):
+                continue
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) < 3:
+                continue
+            m = re.search(r"(\d+)", parts[0])
+            if not m:
+                continue
+            dev_id = int(m.group(1))
+            try:
+                total_b = int(parts[1])
+                used_b = int(parts[2])
+            except ValueError:
+                continue
+            usage[dev_id] = (used_b / (1024 ** 3), total_b / (1024 ** 3))
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    except Exception as e:
+        logger.debug(f"rocm-smi --showmeminfo parse failed: {e}")
+    return usage
+
+
+def _nvidia_busy_gpu_ids() -> set:
+    """Return set of NVIDIA GPU indices with active compute processes."""
+    busy: set = set()
+    uuid_to_idx: Dict[str, int] = {}
+    try:
+        r = subprocess.run(
+            ["nvidia-smi", "--query-gpu=index,uuid",
+             "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if r.returncode == 0:
+            for line in r.stdout.strip().splitlines():
+                parts = [p.strip() for p in line.split(",")]
+                if len(parts) >= 2 and parts[0].isdigit():
+                    uuid_to_idx[parts[1]] = int(parts[0])
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return busy
+
+    try:
+        r = subprocess.run(
+            ["nvidia-smi", "--query-compute-apps=gpu_uuid,pid",
+             "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if r.returncode == 0:
+            for line in r.stdout.strip().splitlines():
+                parts = [p.strip() for p in line.split(",")]
+                if not parts or not parts[0]:
+                    continue
+                idx = uuid_to_idx.get(parts[0])
+                if idx is not None:
+                    busy.add(idx)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return busy
+
+
+def _nvidia_gpu_memory_usage() -> Dict[int, Tuple[float, float]]:
+    """Return ``{device_id: (used_gb, total_gb)}`` for all NVIDIA GPUs."""
+    usage: Dict[int, Tuple[float, float]] = {}
+    try:
+        r = subprocess.run(
+            ["nvidia-smi",
+             "--query-gpu=index,memory.used,memory.total",
+             "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if r.returncode != 0:
+            return usage
+        for line in r.stdout.strip().splitlines():
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) < 3 or not parts[0].isdigit():
+                continue
+            dev_id = int(parts[0])
+            try:
+                used_mb = float(parts[1])
+                total_mb = float(parts[2])
+            except ValueError:
+                continue
+            usage[dev_id] = (used_mb / 1024.0, total_mb / 1024.0)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return usage
+
+
+def find_idle_gpus(
+    count: int = 1,
+    min_free_memory_gb: float = 1.0,
+    candidates: Optional[List[int]] = None,
+) -> List[int]:
+    """Return up to ``count`` GPU indices that look idle.
+
+    A GPU is considered idle when **both** are true:
+
+      * No compute / KFD process is currently running on it.
+      * Free VRAM is at least ``min_free_memory_gb``.
+
+    Args:
+        count: Number of idle GPUs to return.
+        min_free_memory_gb: Reject GPUs with less free VRAM than this.
+        candidates: Optional restricted device id pool. When ``None``,
+            all GPUs reported by ``get_gpu_count()`` are considered.
+
+    Returns:
+        Device ids ordered most-free first, possibly shorter than
+        ``count`` if not enough GPUs are idle.
+
+    Raises:
+        RuntimeError: when zero GPUs satisfy the criteria.
+    """
+    if count <= 0:
+        return []
+
+    vendor, _ = detect_gpu()
+    total = get_gpu_count()
+    if total == 0:
+        raise RuntimeError("find_idle_gpus: no GPUs detected on this host")
+
+    if candidates is None:
+        candidates = list(range(total))
+    else:
+        candidates = [d for d in candidates if 0 <= d < total]
+
+    if vendor == GPUVendor.AMD:
+        busy = _amd_busy_gpu_ids()
+        mem = _amd_gpu_memory_usage()
+    elif vendor == GPUVendor.NVIDIA:
+        busy = _nvidia_busy_gpu_ids()
+        mem = _nvidia_gpu_memory_usage()
+    else:
+        raise RuntimeError("find_idle_gpus: unsupported GPU vendor")
+
+    scored: List[Tuple[float, int]] = []
+    rejected: List[str] = []
+    for dev_id in candidates:
+        if dev_id in busy:
+            rejected.append(f"GPU {dev_id}: has running compute process")
+            continue
+        used_gb, total_gb = mem.get(dev_id, (0.0, 0.0))
+        free_gb = max(0.0, total_gb - used_gb)
+        if total_gb > 0 and free_gb < min_free_memory_gb:
+            rejected.append(
+                f"GPU {dev_id}: only {free_gb:.1f} GB free "
+                f"(< {min_free_memory_gb:.1f} GB threshold)"
+            )
+            continue
+        scored.append((free_gb, dev_id))
+
+    scored.sort(key=lambda x: (-x[0], x[1]))
+    chosen = [dev_id for _, dev_id in scored[:count]]
+
+    if not chosen:
+        msg = "find_idle_gpus: no idle GPU available"
+        if rejected:
+            msg += " (" + "; ".join(rejected) + ")"
+        raise RuntimeError(msg)
+
+    if len(chosen) < count:
+        logger.warning(
+            "find_idle_gpus: requested %d but only %d idle (%s); rejected: %s",
+            count, len(chosen), chosen, rejected,
+        )
+
+    logger.info(
+        "find_idle_gpus: selected %s (free GB: %s)",
+        chosen,
+        [f"{free:.1f}" for free, _ in scored[:count]],
+    )
+    return chosen
 
 
 def get_gpu_count() -> int:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A lightweight, general-purpose framework for evaluating GPU kernel correctness a
 - **Heterogeneous Hardware**: AMD (HIP) and NVIDIA (CUDA) GPUs
 - **Execution Environments**: Local, Sandbox Container, and Remote Ray Cluster
 - **Hardware Control**: Hardware-aware kernel evaluation under controlled execution settings
+- **Auto GPU Selection**: Benchmark mode picks idle GPU(s) before launching (AMD + NVIDIA)
 - **Trace Analysis**: TraceLens integration for performance profiling analysis
 - **MCP Server**: Model Context Protocol integration for AI agents
 - **Structured Reports**: JSON output for pipeline integration

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -135,6 +135,14 @@ benchmark:
     ignore_categories:         # Event category blacklist (default: [gpu_user_annotation])
       - gpu_user_annotation
       
+  # Auto-pick idle GPU(s) before launching (enabled by default).
+  # See "Automatic GPU Selection" below for details.
+  gpu_selection:
+    auto: true                 # Default: true. Set false to disable.
+    min_free_memory_gb: 8.0    # Reject GPUs with less free VRAM
+    count: null                # Number of GPUs; null -> use envs.TP
+    candidates: null           # Optional whitelist of physical GPU ids
+
   # Execution settings
   run_mode: docker             # "docker" (default) or "local" (host / in-container)
   docker_image: null           # Optional: override auto-selected image
@@ -163,6 +171,44 @@ benchmark:
 | `GPU_MEM_UTIL` | GPU memory utilization | 0.95 |
 | `ENABLE_PROFILE` | Enable torch profiler | "false" |
 | `EXTRA_VLLM_ARGS` | Additional arguments passed to `vllm serve` | "" |
+
+## Automatic GPU Selection
+
+Before launching the benchmark, Magpie scans the host (`rocm-smi` / `nvidia-smi`),
+picks the least-busy GPU(s) with enough free VRAM, and pins the run via
+vendor-specific environment variables:
+
+- **AMD**: `ROCR_VISIBLE_DEVICES=<ids>` (the launcher script remaps
+  `HIP_VISIBLE_DEVICES` to the post-filter logical range `0..N-1`).
+- **NVIDIA**: `CUDA_VISIBLE_DEVICES=<ids>` + `CUDA_DEVICE_ORDER=PCI_BUS_ID`.
+
+GPU ids use the same index space as `rocm-smi` / `nvidia-smi`. By default the
+selector asks for `envs.TP` idle GPUs; override with `gpu_selection.count`.
+
+**Config knobs** (all optional; `gpu_selection` block is enabled by default):
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `auto` | `true` | Set `false` to disable and let the framework see every GPU |
+| `min_free_memory_gb` | `8.0` | Reject GPUs with less free VRAM than this |
+| `count` | `null` | Number of GPUs to pin; `null` → `envs.TP` |
+| `candidates` | `null` | Optional whitelist of physical GPU ids to consider |
+
+**Manual override**: setting `HIP_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` /
+`ROCR_VISIBLE_DEVICES` in `envs:` pins to specific cards and skips auto-selection:
+
+```yaml
+  envs:
+    TP: 1
+    ROCR_VISIBLE_DEVICES: "3"    # AMD: pin to rocm-smi GPU[3]
+    # CUDA_VISIBLE_DEVICES: "3"  # NVIDIA alternative
+    # CUDA_DEVICE_ORDER: PCI_BUS_ID
+```
+
+**Ray mode** (`run_mode: ray`): `gpu_selection` is ignored — Ray schedules
+devices itself via `num_gpus`. To restrict the cluster to specific cards,
+export `ROCR_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` in the shell before
+starting `ray start`.
 
 ## Profiling Options
 
@@ -408,6 +454,13 @@ Large models (e.g., DeepSeek-R1) may need longer timeouts:
 ```yaml
 timeout_seconds: 7200  # 2 hours
 ```
+
+**5. `gpu_selection.auto failed: ...`**
+
+Not enough idle GPUs on the host. Either free a GPU, lower
+`gpu_selection.min_free_memory_gb`, narrow `gpu_selection.candidates`, or pin
+manually via `envs.ROCR_VISIBLE_DEVICES` (AMD) / `envs.CUDA_VISIBLE_DEVICES`
+(NVIDIA). See [Automatic GPU Selection](#automatic-gpu-selection).
 
 ### Debug Mode
 

--- a/docs/ray-magpie.md
+++ b/docs/ray-magpie.md
@@ -203,6 +203,14 @@ Logic is in `Magpie/remote/tasks.py` (`_get_local_gpu_count`, `_configure_tp_iso
 
 After the task starts, `_clear_hidden_gpus` removes Ray-imposed **empty** visibility env vars so **child processes** see the node GPUs again (`Magpie/remote/tasks.py`).
 
+> **`gpu_selection` is disabled under Ray.** The benchmark YAML's
+> `gpu_selection` block (auto idle-GPU picker) is a no-op when
+> `run_mode: ray` — Ray schedules devices itself via `num_gpus`, and a
+> driver-side `rocm-smi` / `nvidia-smi` scan does not reflect worker nodes.
+> To restrict the cluster to specific cards, export
+> `ROCR_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` in the shell **before**
+> starting `ray start` on each node.
+
 ---
 
 ## 9. Asynchronous benchmark submit (MCP / advanced)

--- a/examples/benchmarks/benchmark_vllm_dsr1.yaml
+++ b/examples/benchmarks/benchmark_vllm_dsr1.yaml
@@ -37,6 +37,14 @@ benchmark:
     trace_end_pct: 80
     top_k: 20
 
+  # Optional: auto-pick idle GPU(s) before launching. Enabled by default;
+  # uncomment to override (see docs/benchmark.md#automatic-gpu-selection).
+  # gpu_selection:
+  #   auto: true
+  #   min_free_memory_gb: 8.0
+  #   count: null              # null -> use envs.TP
+  #   candidates: [0, 1, 2, 3] # whitelist physical GPU ids (rocm-smi/nvidia-smi)
+
   # Will auto-clone InferenceX if not specified
   # inferencex_path: ""
   

--- a/examples/benchmarks/benchmark_vllm_gptoss_20b.yaml
+++ b/examples/benchmarks/benchmark_vllm_gptoss_20b.yaml
@@ -9,8 +9,6 @@
 #
 # Usage (Local - run directly on host, e.g. inside a pod):
 #   python -m Magpie benchmark --benchmark-config examples/benchmark_vllm_gptoss_20b.yaml --run-mode local
-#
-# Uses Magpie generic script vllm_mi355x.sh (compatible with vLLM v0.15.1)
 
 benchmark:
   framework: vllm
@@ -27,7 +25,7 @@ benchmark:
     EXTRA_VLLM_ARGS: "--no-enable-prefix-caching --block-size 64"
     VLLM_LOGGING_LEVEL: "WARNING"
 
-    # MI355X performance flags (supplements vllm_mi355x.sh defaults)
+    # MI300X performance flags (supplements vllm_mi3  x.sh defaults)
     VLLM_ROCM_USE_AITER: 1
     VLLM_ROCM_USE_AITER_MHA: 0
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: 1


### PR DESCRIPTION
## Summary

Benchmark mode now auto-picks idle GPU(s) via `rocm-smi` / `nvidia-smi`
and pins the run with the right env vars:

- **AMD**: `ROCR_VISIBLE_DEVICES`; launcher remaps `HIP_VISIBLE_DEVICES`
  to the post-filter `0..N-1` range.
- **NVIDIA**: `CUDA_VISIBLE_DEVICES` + `CUDA_DEVICE_ORDER=PCI_BUS_ID`.

Enabled by default; existing configs need no changes.

## Opt-out / override

- Disable: `gpu_selection: { auto: false }`
- Manual pin: set `ROCR_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` in `envs:`
- `run_mode: ray` → skipped (Ray schedules GPUs itself)

See `docs/benchmark.md#automatic-gpu-selection` for details.