### PR TITLE
add find_kernel_sources for gap_analysis

### DIFF
--- a/Magpie/main.py
+++ b/Magpie/main.py
@@ -929,7 +929,16 @@ def run_gap_analysis_standalone(args) -> int:
         print("No kernel events found in traces.")
         return 1
 
-    csv_path = result.to_csv(gap_dir / "gap_analysis.csv")
+    # Get kernel source options
+    find_kernel_sources = getattr(args, "find_kernel_sources", False)
+    kernel_source_repos = getattr(args, "kernel_source_repos", None)
+    
+    csv_path = result.to_csv(
+        gap_dir / "gap_analysis.csv",
+        find_kernel_sources=find_kernel_sources,
+        kernel_source_repos=kernel_source_repos,
+        auto_clone_repos=True,  # Default to auto-clone
+    )
     if len(result.rank_results) > 1 and not getattr(args, "no_rank_csv", False):
         result.to_rank_csv(gap_dir)
 
@@ -1262,6 +1271,14 @@ def create_parser() -> argparse.ArgumentParser:
     benchmark_parser.add_argument(
         "--no-rank-csv", action="store_true",
         help="Gap analysis: skip generating per-rank CSV files",
+    )
+    benchmark_parser.add_argument(
+        "--find-kernel-sources", action="store_true",
+        help="Gap analysis: find kernel source files and test commands (AMD kernels)",
+    )
+    benchmark_parser.add_argument(
+        "--kernel-source-repos", type=str, nargs="*", default=None,
+        help="Gap analysis: repository paths to search for kernel sources",
     )
 
     return parser

--- a/Magpie/modes/benchmark/gap_analysis.py
+++ b/Magpie/modes/benchmark/gap_analysis.py
@@ -106,28 +106,108 @@ class GapAnalysisResult:
             "errors": self.errors,
         }
 
-    def to_csv(self, output_path: Path) -> Path:
-        """Write merged kernel stats to CSV."""
+    def to_csv(
+        self, 
+        output_path: Path,
+        find_kernel_sources: bool = False,
+        kernel_source_repos: Optional[List[str]] = None,
+        auto_clone_repos: bool = True,
+        repos_base_dir: Optional[str] = None,
+    ) -> Path:
+        """
+        Write merged kernel stats to CSV.
+        
+        Args:
+            output_path: Path to write CSV
+            find_kernel_sources: If True, enrich with kernel source information
+            kernel_source_repos: List of repository paths to search for sources.
+                If None and auto_clone_repos is True, repos are cloned on-demand.
+            auto_clone_repos: Whether to auto-clone missing repos (default: True)
+            repos_base_dir: Base directory for auto-cloned repos
+        """
         output_path = Path(output_path)
+        
+        # Initialize kernel finder if needed
+        kernel_finder = None
+        repo_paths = {}
+        if find_kernel_sources:
+            try:
+                from Magpie.tools.amd_kernel_finder import KernelSourceFinder
+                kernel_finder = KernelSourceFinder(
+                    repos=kernel_source_repos or [],
+                    auto_clone=auto_clone_repos,
+                    repos_base_dir=repos_base_dir,
+                )
+                repo_paths = kernel_finder.get_repo_paths()
+            except ImportError as e:
+                logger.warning(f"Could not import amd_kernel_finder: {e}")
+        
         with open(output_path, "w", newline="") as f:
             writer = csv.writer(f)
-            writer.writerow([
+            
+            # Write repo path mappings as comment rows if kernel sources enabled
+            if find_kernel_sources and repo_paths:
+                # Find common prefix to make paths relative
+                import pathlib
+                all_repo_paths = [pathlib.Path(p) for p in repo_paths.values() if p]
+                if all_repo_paths:
+                    # Try to find common parent directory
+                    try:
+                        common_parent = pathlib.Path(all_repo_paths[0]).parent
+                        for p in all_repo_paths[1:]:
+                            while not str(p).startswith(str(common_parent)):
+                                common_parent = common_parent.parent
+                                if common_parent == pathlib.Path("/"):
+                                    break
+                    except:
+                        common_parent = pathlib.Path("/")
+                    
+                    f.write("# Repository Path Mappings:\n")
+                    if common_parent != pathlib.Path("/"):
+                        f.write(f"# Base directory: {common_parent}\n")
+                    for var_name, actual_path in sorted(repo_paths.items()):
+                        if actual_path and common_parent != pathlib.Path("/"):
+                            try:
+                                rel_path = pathlib.Path(actual_path).relative_to(common_parent)
+                                f.write(f"# {var_name}=./{rel_path}\n")
+                            except ValueError:
+                                f.write(f"# {var_name}={actual_path}\n")
+                        else:
+                            f.write(f"# {var_name}={actual_path}\n")
+                    f.write("#\n")
+            
+            # Build headers
+            headers = [
                 "Name", "Calls", "Self CUDA total (us)",
                 "Avg time (us)", "% Total", "Input Shapes",
-            ])
+            ]
+            if find_kernel_sources:
+                from Magpie.tools.amd_kernel_finder import KernelSourceInfo
+                headers.extend(KernelSourceInfo.csv_headers())
+            
+            writer.writerow(headers)
+            
             for k in self.merged_kernels:
                 pct = (
                     k.total_duration_us / self.total_duration_us * 100.0
                     if self.total_duration_us > 0 else 0.0
                 )
-                writer.writerow([
+                row = [
                     k.name,
                     k.calls,
                     f"{k.total_duration_us:.2f}",
                     f"{k.avg_us:.2f}",
                     f"{pct:.2f}",
                     k.unique_shapes,
-                ])
+                ]
+                
+                # Add kernel source info if enabled
+                if find_kernel_sources and kernel_finder:
+                    source_info = kernel_finder.search(k.name)
+                    row.extend(source_info.to_list())
+                
+                writer.writerow(row)
+                
         logger.info(f"Wrote gap analysis CSV: {output_path}")
         return output_path
 

--- a/Magpie/tools/amd_kernel_finder/__init__.py
+++ b/Magpie/tools/amd_kernel_finder/__init__.py
@@ -1,0 +1,36 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""
+AMD Kernel Source Finder - Find source code and tests for AMD GPU kernels.
+
+This module provides tools to identify kernel source locations and test cases
+from profiler kernel names on AMD GPUs (ROCm/HIP), supporting:
+- Triton JIT kernels (on ROCm)
+- Tensile GEMM kernels (rocBLAS)
+- Composable Kernel (CK) tiles
+- hipBLASLt WMMA kernels
+- ATen native kernels (HIP backend)
+- HIP C++ kernels
+
+Features:
+- Dynamic kernel indexing for fast lookups
+- Auto-cloning of missing repositories on-demand
+- Python-native search fallback when ripgrep unavailable
+- Repository structure auto-discovery
+"""
+
+from .finder import KernelSourceFinder
+from .models import KernelSourceInfo, KernelKind
+from .indexer import KernelIndex
+from .repo_manager import RepoManager
+
+__all__ = [
+    "KernelSourceFinder",
+    "KernelSourceInfo",
+    "KernelKind",
+    "KernelIndex",
+    "RepoManager",
+]

--- a/Magpie/tools/amd_kernel_finder/finder.py
+++ b/Magpie/tools/amd_kernel_finder/finder.py
@@ -1,0 +1,303 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""
+Main kernel source finder - combines parser, searcher, and enrichment.
+
+Supports:
+- Dynamic kernel indexing for faster lookups
+- Auto-cloning missing repositories
+- Python-native search fallback when ripgrep unavailable
+- Repository structure auto-discovery
+"""
+
+import csv
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from .models import KernelKind, KernelSourceInfo
+from .parser import KernelNameParser
+from .searcher import KernelSourceSearcher
+from .repo_config import GITHUB_URL_TEMPLATES, RepoDiscovery
+from .indexer import KernelIndex
+from .repo_manager import RepoManager
+
+logger = logging.getLogger(__name__)
+
+
+class KernelSourceFinder:
+    """Find kernel source code and tests from profiler kernel names."""
+    
+    def __init__(
+        self,
+        repos: List[str] = None,
+        auto_clone: bool = True,
+        repos_base_dir: str = None,
+        use_index: bool = True,
+        auto_install_ripgrep: bool = True,
+    ):
+        """
+        Initialize the kernel source finder.
+        
+        Args:
+            repos: List of repository paths to search. If None, repos are 
+                   auto-cloned on demand based on detected kernel types.
+            auto_clone: If True, automatically clone missing repos when needed.
+            repos_base_dir: Base directory for auto-cloned repos.
+            use_index: If True, build dynamic kernel index for faster lookups.
+            auto_install_ripgrep: If True, try to install ripgrep if missing.
+        """
+        self.repos = repos or []
+        self.auto_clone = auto_clone
+        self.use_index = use_index
+        
+        self.parser = KernelNameParser()
+        self.repo_manager = RepoManager(base_dir=repos_base_dir) if auto_clone else None
+        self.index = KernelIndex() if use_index else None
+        
+        # Searcher will be initialized after repos are resolved
+        self._searcher: Optional[KernelSourceSearcher] = None
+        self._auto_install_ripgrep = auto_install_ripgrep
+        self._repos_initialized = False
+    
+    def _ensure_repos(self, kernel_names: List[str] = None) -> None:
+        """Ensure repositories are available, cloning on-demand if needed."""
+        if self._repos_initialized:
+            return
+        
+        # If explicit repos provided, use them
+        if self.repos:
+            self._searcher = KernelSourceSearcher(
+                self.repos,
+                auto_install_ripgrep=self._auto_install_ripgrep,
+            )
+            if self.use_index and self.index:
+                self.index.build(self.repos)
+            self._repos_initialized = True
+            return
+        
+        # Auto-clone mode: determine needed repos from kernel names
+        if self.auto_clone and self.repo_manager and kernel_names:
+            needed_repos = self.repo_manager.get_repos_for_kernels(kernel_names)
+            logger.info(f"Auto-detecting repos for kernels: {needed_repos}")
+            
+            cloned_paths = []
+            for repo_name in needed_repos:
+                try:
+                    path = self.repo_manager.ensure_repo(repo_name, shallow=True)
+                    cloned_paths.append(path)
+                except Exception as e:
+                    logger.warning(f"Failed to clone {repo_name}: {e}")
+            
+            self.repos = cloned_paths
+        
+        # Initialize searcher and index
+        self._searcher = KernelSourceSearcher(
+            self.repos,
+            auto_install_ripgrep=self._auto_install_ripgrep,
+        )
+        
+        if self.use_index and self.index and self.repos:
+            self.index.build(self.repos)
+        
+        self._repos_initialized = True
+    
+    @property
+    def searcher(self) -> KernelSourceSearcher:
+        """Get searcher, initializing repos if needed."""
+        if self._searcher is None:
+            self._ensure_repos()
+        return self._searcher
+    
+    def search(self, kernel_name: str) -> KernelSourceInfo:
+        """
+        Search for source and test information for a kernel.
+        
+        Args:
+            kernel_name: Kernel name from profiler
+            
+        Returns:
+            KernelSourceInfo with all found information
+        """
+        # Ensure repos initialized for single kernel search
+        self._ensure_repos([kernel_name])
+        
+        # Parse the kernel name
+        parsed = self.parser.parse(kernel_name)
+        category = self.parser.classify_category(kernel_name)
+        
+        # Try index lookup first for fast results
+        source_match = None
+        if self.use_index and self.index:
+            index_result = self.index.lookup(kernel_name)
+            if index_result:
+                from .models import SourceMatch
+                source_match = SourceMatch(
+                    file_path=index_result.file_path,
+                    symbol=index_result.symbol or index_result.name,
+                    repo_var=f"${index_result.repo_name.upper().replace('-', '_')}_DIR",
+                    repo_name=index_result.repo_name,
+                )
+        
+        # Fall back to searcher if index miss
+        if not source_match:
+            source_match = self.searcher.search_source(parsed)
+        
+        # Search for test
+        test_match = self.searcher.search_test(parsed, source_match)
+        
+        # Build upstream URL
+        upstream_url = ""
+        if source_match and source_match.repo_name in GITHUB_URL_TEMPLATES:
+            upstream_url = GITHUB_URL_TEMPLATES[source_match.repo_name].format(
+                path=source_match.file_path
+            )
+        
+        # Build notes with more details
+        notes = self._build_notes(parsed)
+        
+        return KernelSourceInfo(
+            kind=parsed.kind.value,
+            category=category.value,
+            source_repo=source_match.repo_name if source_match else "",
+            source_file=source_match.display_path if source_match else "",
+            source_symbol=source_match.symbol if source_match else parsed.function_name,
+            upstream_url=upstream_url,
+            test_file=test_match.display_path if test_match else "",
+            test_cmd=test_match.test_cmd if test_match else "",
+            notes=notes,
+        )
+    
+    def _build_notes(self, parsed) -> str:
+        """Build notes from parsed information."""
+        notes = []
+        
+        extra = parsed.extra or {}
+        
+        # Add dtype info
+        if parsed.dtype:
+            notes.append(f"dtype={parsed.dtype}")
+        
+        # Tensile GEMM specific
+        if parsed.kind == KernelKind.TENSILE_GEMM:
+            trans_info = []
+            if extra.get('trans_a'):
+                trans_info.append(f"A={extra['trans_a']}")
+            if extra.get('trans_b'):
+                trans_info.append(f"B={extra['trans_b']}")
+            if trans_info:
+                notes.append(f"Transpose: {', '.join(trans_info)}")
+            if 'tile_m' in extra:
+                notes.append(f"tile={extra['tile_m']}x{extra['tile_n']}x{extra['tile_k']}")
+            if 'mfma' in extra:
+                notes.append(f"MFMA={extra['mfma']}")
+            if 'workgroup' in extra:
+                notes.append(f"WG={extra['workgroup']}")
+        
+        # CK tile specific
+        if parsed.kind == KernelKind.CK_TILE:
+            if extra.get('fused_add'):
+                notes.append("Fused residual add")
+            if extra.get('fused_quant'):
+                notes.append("Fused quantization")
+            if 'block_shape' in extra:
+                notes.append(f"block={extra['block_shape']}")
+        
+        # HIP kernels
+        if parsed.kind == KernelKind.HIP_CPP:
+            if 'wvSplitK' in parsed.original_name or 'wvSpltK' in parsed.original_name:
+                notes.append("WMMA Split-K GEMM kernel")
+            if parsed.namespace:
+                notes.append(f"namespace={parsed.namespace}")
+        
+        # Inductor generated
+        if parsed.kind == KernelKind.INDUCTOR:
+            notes.append("torch.compile generated")
+        
+        # Triton config
+        if parsed.kind == KernelKind.TRITON_JIT and parsed.config:
+            # Extract key config details
+            config_parts = parsed.config.split('_')
+            if len(config_parts) >= 2:
+                notes.append(f"config: {parsed.config[:60]}")
+        
+        return "; ".join(notes)
+    
+    def get_repo_paths(self) -> Dict[str, str]:
+        """Get mapping of repo variable names to actual paths."""
+        return self.searcher.get_repo_paths()
+    
+    def enrich_csv(self, input_path: str, output_path: str = None) -> str:
+        """
+        Enrich a gap_analysis CSV with kernel source information.
+        
+        Args:
+            input_path: Path to input gap_analysis.csv
+            output_path: Path for output (defaults to overwriting input)
+            
+        Returns:
+            Path to the output file
+        """
+        input_path = Path(input_path)
+        if output_path is None:
+            output_path = input_path
+        else:
+            output_path = Path(output_path)
+        
+        # Read existing data
+        rows = []
+        headers = []
+        
+        with open(input_path, 'r', newline='') as f:
+            reader = csv.reader(f)
+            headers = next(reader)
+            for row in reader:
+                rows.append(row)
+        
+        # Extract all kernel names for auto-clone detection
+        kernel_names = [row[0] for row in rows if row]
+        
+        # Initialize repos based on all kernel names (triggers on-demand clone)
+        self._ensure_repos(kernel_names)
+        
+        # Get repo paths for metadata
+        repo_paths = self.get_repo_paths()
+        
+        # Add new headers
+        new_headers = headers + KernelSourceInfo.csv_headers()
+        
+        # Enrich each row
+        enriched_rows = []
+        for row in rows:
+            kernel_name = row[0] if row else ""
+            source_info = self.search(kernel_name)
+            enriched_rows.append(row + source_info.to_list())
+        
+        # Write output (no metadata rows - clean CSV)
+        with open(output_path, 'w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(new_headers)
+            writer.writerows(enriched_rows)
+        
+        logger.info(f"Enriched CSV written to {output_path}")
+        return str(output_path)
+    
+    def enrich_kernel_stats(self, kernel_stats: List) -> List:
+        """
+        Enrich a list of KernelStat objects with source information.
+        
+        Args:
+            kernel_stats: List of KernelStat dataclass instances
+            
+        Returns:
+            Same list with source_info populated
+        """
+        for stat in kernel_stats:
+            source_info = self.search(stat.name)
+            stat.source_info = source_info
+        
+        return kernel_stats

--- a/Magpie/tools/amd_kernel_finder/indexer.py
+++ b/Magpie/tools/amd_kernel_finder/indexer.py
@@ -1,0 +1,254 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""
+Dynamic kernel index for fast source lookups.
+
+Scans repositories for kernel definitions and builds a searchable index,
+replacing hardcoded mappings with dynamically discovered kernel locations.
+"""
+
+import json
+import logging
+import re
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List, Optional
+import hashlib
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class KernelDefinition:
+    """A kernel definition found in source code."""
+    
+    name: str
+    file_path: str
+    repo_name: str
+    repo_path: str
+    kind: str
+    line_number: int = 0
+    symbol: str = ""
+    
+    def to_dict(self) -> dict:
+        return asdict(self)
+    
+    @classmethod
+    def from_dict(cls, d: dict) -> "KernelDefinition":
+        return cls(**d)
+
+
+class KernelIndex:
+    """
+    Dynamic index of kernel definitions.
+    
+    Scans repositories for kernel definitions and builds a searchable index.
+    Supports caching to avoid rescanning.
+    """
+    
+    KERNEL_PATTERNS = {
+        "triton_jit": [
+            (r"@triton\.jit[^\n]*\s*\ndef\s+(\w+)", "py"),
+            (r"@triton\.autotune[^\n]*\s*@triton\.jit[^\n]*\s*\ndef\s+(\w+)", "py"),
+        ],
+        "hip_cpp": [
+            (r"__global__\s+void\s+(\w+)\s*[<(]", "cpp,cu,hip"),
+        ],
+        "ck_tile": [
+            (r"template\s*<[^>]*>\s*__global__\s+void\s+kentry", "hpp,cpp"),
+        ],
+    }
+    
+    FILE_EXTENSIONS = {
+        "triton_jit": [".py"],
+        "hip_cpp": [".cpp", ".cu", ".hip", ".hpp"],
+        "ck_tile": [".hpp", ".cpp"],
+        "aten_native": [".cu", ".cpp"],
+    }
+    
+    SKIP_DIRS = {
+        ".git", "__pycache__", "node_modules", "build", "dist",
+        ".tox", ".eggs", "venv", ".venv",
+    }
+    
+    def __init__(self, cache_dir: str = None):
+        self.index: Dict[str, KernelDefinition] = {}
+        self.name_to_keys: Dict[str, List[str]] = {}
+        
+        if cache_dir:
+            self.cache_dir = Path(cache_dir)
+        else:
+            self.cache_dir = Path.home() / ".cache" / "magpie" / "kernel_index"
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+    
+    def build(self, repos: List[str], force_rebuild: bool = False) -> None:
+        """Build index from repositories."""
+        for repo_path in repos:
+            repo_path = str(repo_path)
+            if not Path(repo_path).exists():
+                logger.warning(f"Repo path does not exist: {repo_path}")
+                continue
+            
+            cache_file = self._get_cache_file(repo_path)
+            if not force_rebuild and cache_file.exists():
+                if self._load_cache(cache_file, repo_path):
+                    logger.info(f"Loaded index from cache for {repo_path}")
+                    continue
+            
+            logger.info(f"Scanning repository: {repo_path}")
+            self._scan_repo(repo_path)
+            self._save_cache(cache_file, repo_path)
+        
+        self._build_name_index()
+        logger.info(f"Index built with {len(self.index)} kernel definitions")
+    
+    def _get_cache_file(self, repo_path: str) -> Path:
+        path_hash = hashlib.md5(repo_path.encode()).hexdigest()[:12]
+        repo_name = Path(repo_path).name
+        return self.cache_dir / f"{repo_name}_{path_hash}.json"
+    
+    def _load_cache(self, cache_file: Path, repo_path: str) -> bool:
+        try:
+            with open(cache_file, 'r') as f:
+                data = json.load(f)
+            
+            cached_mtime = data.get("mtime", 0)
+            current_mtime = Path(repo_path).stat().st_mtime
+            
+            if abs(current_mtime - cached_mtime) > 86400:
+                logger.info(f"Cache expired for {repo_path}")
+                return False
+            
+            for key, def_dict in data.get("definitions", {}).items():
+                self.index[key] = KernelDefinition.from_dict(def_dict)
+            
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to load cache: {e}")
+            return False
+    
+    def _save_cache(self, cache_file: Path, repo_path: str) -> None:
+        try:
+            repo_defs = {
+                k: v.to_dict() for k, v in self.index.items()
+                if v.repo_path == repo_path
+            }
+            
+            data = {
+                "mtime": Path(repo_path).stat().st_mtime,
+                "definitions": repo_defs,
+            }
+            
+            with open(cache_file, 'w') as f:
+                json.dump(data, f, indent=2)
+            
+            logger.info(f"Saved {len(repo_defs)} definitions to cache")
+        except Exception as e:
+            logger.warning(f"Failed to save cache: {e}")
+    
+    def _scan_repo(self, repo_path: str) -> None:
+        repo_path = Path(repo_path)
+        repo_name = self._detect_repo_name(repo_path)
+        
+        files_to_scan: Dict[str, List[Path]] = {}
+        
+        for kind, extensions in self.FILE_EXTENSIONS.items():
+            files_to_scan[kind] = []
+            for ext in extensions:
+                for file_path in repo_path.rglob(f"*{ext}"):
+                    if any(skip in file_path.parts for skip in self.SKIP_DIRS):
+                        continue
+                    files_to_scan[kind].append(file_path)
+        
+        for kind, patterns in self.KERNEL_PATTERNS.items():
+            for pattern, file_types in patterns:
+                allowed_exts = [f".{ft}" for ft in file_types.split(",")]
+                
+                for file_path in files_to_scan.get(kind, []):
+                    if file_path.suffix not in allowed_exts:
+                        continue
+                    
+                    self._scan_file(file_path, pattern, kind, repo_name, str(repo_path))
+    
+    def _scan_file(self, file_path: Path, pattern: str, kind: str,
+                   repo_name: str, repo_path: str) -> None:
+        try:
+            content = file_path.read_text(errors='ignore')
+            
+            for match in re.finditer(pattern, content, re.MULTILINE):
+                name = match.group(1) if match.groups() else None
+                if not name:
+                    continue
+                
+                line_num = content[:match.start()].count('\n') + 1
+                rel_path = str(file_path.relative_to(repo_path))
+                key = f"{repo_name}:{rel_path}:{name}"
+                
+                self.index[key] = KernelDefinition(
+                    name=name,
+                    file_path=rel_path,
+                    repo_name=repo_name,
+                    repo_path=repo_path,
+                    kind=kind,
+                    line_number=line_num,
+                    symbol=match.group(0)[:200],
+                )
+        except Exception as e:
+            logger.debug(f"Error scanning {file_path}: {e}")
+    
+    def _detect_repo_name(self, repo_path: Path) -> str:
+        if (repo_path / "projects" / "composablekernel").exists():
+            return "rocm-libraries"
+        if (repo_path / "python" / "triton").exists():
+            return "triton"
+        if (repo_path / "vllm").exists() and (repo_path / "csrc").exists():
+            return "vllm"
+        if (repo_path / "aten").exists():
+            return "pytorch"
+        return repo_path.name
+    
+    def _build_name_index(self) -> None:
+        self.name_to_keys.clear()
+        for key, defn in self.index.items():
+            name = defn.name
+            if name not in self.name_to_keys:
+                self.name_to_keys[name] = []
+            self.name_to_keys[name].append(key)
+    
+    def lookup(self, kernel_name: str) -> Optional[KernelDefinition]:
+        """Look up a kernel by name."""
+        function_name = self._extract_function_name(kernel_name)
+        
+        if function_name in self.name_to_keys:
+            keys = self.name_to_keys[function_name]
+            if keys:
+                return self.index[keys[0]]
+        
+        for name, keys in self.name_to_keys.items():
+            if function_name.startswith(name) or name.startswith(function_name):
+                return self.index[keys[0]]
+        
+        return None
+    
+    def _extract_function_name(self, kernel_name: str) -> str:
+        name = kernel_name.replace(".kd", "")
+        parts = name.split("_")
+        
+        for i, part in enumerate(parts):
+            if part and (part[0].isupper() or part.isdigit() or
+                        part in ("bf16", "fp16", "fp32", "int8")):
+                return "_".join(parts[:i])
+        
+        return name
+    
+    def get_all_definitions(self, kind: str = None) -> List[KernelDefinition]:
+        if kind:
+            return [d for d in self.index.values() if d.kind == kind]
+        return list(self.index.values())
+    
+    def clear(self) -> None:
+        self.index.clear()
+        self.name_to_keys.clear()

--- a/Magpie/tools/amd_kernel_finder/models.py
+++ b/Magpie/tools/amd_kernel_finder/models.py
@@ -1,0 +1,141 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""
+Data models for kernel source finder.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, List
+
+
+class KernelKind(Enum):
+    """Classification of kernel types."""
+    TRITON_JIT = "triton_jit"
+    TENSILE_GEMM = "tensile_gemm"
+    CK_TILE = "ck_tile"
+    ATEN_NATIVE = "aten_native"
+    HIP_CPP = "hip_cpp"
+    INDUCTOR = "inductor"
+    ANNOTATION = "annotation"
+    UNKNOWN = "unknown"
+
+
+class KernelCategory(Enum):
+    """Classification of kernel operation categories."""
+    ATTENTION = "attention"
+    GEMM = "gemm"
+    MOE_GEMM = "moe_gemm"
+    LAYERNORM = "layernorm"
+    SOFTMAX = "softmax"
+    COPY = "copy"
+    ELEMENTWISE = "elementwise"
+    INDEXING = "indexing"
+    REDUCE = "reduce"
+    ROUTER = "router"
+    KV_CACHE = "kv_cache"
+    BLIT = "blit"
+    ANNOTATION = "annotation"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class KernelSourceInfo:
+    """Kernel source and test information."""
+    
+    # Classification
+    kind: str = ""
+    category: str = ""
+    
+    # Source location
+    source_repo: str = ""
+    source_file: str = ""
+    source_symbol: str = ""
+    upstream_url: str = ""
+    
+    # Test information
+    test_file: str = ""
+    test_cmd: str = ""
+    
+    # Additional context
+    notes: str = ""
+    
+    def to_list(self) -> List[str]:
+        """Convert to list of values for CSV output."""
+        return [
+            self.kind,
+            self.category,
+            self.source_repo,
+            self.source_file,
+            self.source_symbol,
+            self.upstream_url,
+            self.test_file,
+            self.test_cmd,
+            self.notes,
+        ]
+    
+    @staticmethod
+    def csv_headers() -> List[str]:
+        """Return CSV header names for source info columns."""
+        return [
+            "kind",
+            "category", 
+            "source_repo",
+            "source_file",
+            "source_symbol",
+            "upstream_url",
+            "test_file",
+            "test_cmd",
+            "notes",
+        ]
+
+
+@dataclass
+class ParsedKernelName:
+    """Parsed information from a kernel name."""
+    
+    original_name: str
+    kind: KernelKind
+    function_name: str = ""
+    config: str = ""
+    namespace: str = ""
+    dtype: str = ""
+    tile_sizes: Optional[dict] = None
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class SourceMatch:
+    """A matched source file location."""
+    
+    file_path: str
+    symbol: str = ""
+    line_number: Optional[int] = None
+    repo_name: str = ""
+    repo_var: str = ""  # e.g., $TRITON_DIR
+    
+    @property
+    def display_path(self) -> str:
+        """Return path with repo variable prefix."""
+        if self.repo_var:
+            return f"{self.repo_var}/{self.file_path}"
+        return self.file_path
+
+
+@dataclass 
+class TestMatch:
+    """A matched test file and command."""
+    
+    test_file: str
+    test_cmd: str
+    repo_var: str = ""
+    
+    @property
+    def display_path(self) -> str:
+        """Return test path with repo variable prefix."""
+        if self.repo_var:
+            return f"{self.repo_var}/{self.test_file}"
+        return self.test_file

--- a/Magpie/tools/amd_kernel_finder/parser.py
+++ b/Magpie/tools/amd_kernel_finder/parser.py
@@ -1,0 +1,329 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""
+Kernel name parser - extract structured information from profiler kernel names.
+"""
+
+import re
+from typing import Optional
+
+from .models import KernelKind, KernelCategory, ParsedKernelName
+
+
+class KernelNameParser:
+    """Parse kernel names from profiler output."""
+    
+    # Patterns for classification
+    TRITON_PATTERN = re.compile(r'^[_a-zA-Z][\w]*\.kd$|\.k\.d$')
+    TENSILE_PATTERN = re.compile(r'^Cijk_')
+    CK_PATTERN = re.compile(r'^_ZN7ck_tile|ck_tile::')
+    ATEN_PATTERN = re.compile(r'void at::native::')
+    INDUCTOR_PATTERN = re.compile(r'triton_\w+_fused_')
+    HIPBLASLT_PATTERN = re.compile(r'wvSplitK|wvSpltK|DeviceGemmWmma')
+    
+    # Category keywords
+    CATEGORY_KEYWORDS = {
+        KernelCategory.ATTENTION: ['attention', 'fmha', 'Fmha', 'unified_attention', 'paged_attention'],
+        KernelCategory.GEMM: ['Cijk_', 'gemm', 'Gemm', 'wvSplitK', 'wvSpltK', 'DeviceGemmWmma', 'matmul'],
+        KernelCategory.MOE_GEMM: ['matmul_ogs', '_ogs_', 'moe'],
+        KernelCategory.LAYERNORM: ['rmsnorm', 'layernorm', 'Rmsnorm', 'Layernorm', 'rms_norm'],
+        KernelCategory.SOFTMAX: ['softmax', 'Softmax'],
+        KernelCategory.COPY: ['copy', 'Copy', 'direct_copy'],
+        KernelCategory.ELEMENTWISE: ['elementwise', 'Fill', 'FillFunctor', 'vectorized_elementwise', 'silu_and_mul', 'gelu'],
+        KernelCategory.INDEXING: ['index', 'Index', 'gather', 'scatter'],
+        KernelCategory.REDUCE: ['reduce', 'Reduce', 'argmax', 'argmin', 'sum_bitmatrix'],
+        KernelCategory.ROUTER: ['topk', 'bitmatrix', 'routing', 'ragged_tensor'],
+        KernelCategory.KV_CACHE: ['reshape_and_cache', 'cache'],
+        KernelCategory.BLIT: ['rocclr_copy', 'Blit', 'blit', '__amd_rocclr'],
+        KernelCategory.ANNOTATION: ['execute_context', 'CompiledFxGraph', '## Call'],
+    }
+    
+    def parse(self, name: str) -> ParsedKernelName:
+        """Parse a kernel name and extract structured information."""
+        kind = self._classify_kind(name)
+        
+        if kind == KernelKind.TRITON_JIT:
+            return self._parse_triton(name)
+        elif kind == KernelKind.TENSILE_GEMM:
+            return self._parse_tensile(name)
+        elif kind == KernelKind.CK_TILE:
+            return self._parse_ck_tile(name)
+        elif kind == KernelKind.ATEN_NATIVE:
+            return self._parse_aten(name)
+        elif kind == KernelKind.HIP_CPP:
+            return self._parse_hip(name)
+        elif kind == KernelKind.INDUCTOR:
+            return self._parse_inductor(name)
+        elif kind == KernelKind.ANNOTATION:
+            return ParsedKernelName(
+                original_name=name,
+                kind=kind,
+                function_name=name,
+            )
+        else:
+            return ParsedKernelName(
+                original_name=name,
+                kind=kind,
+                function_name=name,
+            )
+    
+    def _classify_kind(self, name: str) -> KernelKind:
+        """Classify the kernel type based on name pattern."""
+        # Check for annotations first
+        if name.startswith('execute_context') or name.startswith('## Call'):
+            return KernelKind.ANNOTATION
+        
+        # Check for Tensile GEMM
+        if self.TENSILE_PATTERN.match(name):
+            return KernelKind.TENSILE_GEMM
+        
+        # Check for hipBLASLt WMMA kernels (before general HIP check)
+        if self.HIPBLASLT_PATTERN.search(name):
+            return KernelKind.HIP_CPP
+        
+        # Check for CK tile (handles both mangled and readable names)
+        if self.CK_PATTERN.search(name):
+            return KernelKind.CK_TILE
+        
+        # Check for ATen native
+        if self.ATEN_PATTERN.search(name):
+            return KernelKind.ATEN_NATIVE
+        
+        # Check for inductor generated
+        if self.INDUCTOR_PATTERN.search(name):
+            return KernelKind.INDUCTOR
+        
+        # Check for Triton JIT (ends with .kd or .k.d)
+        if name.endswith('.kd') or name.endswith('.k.d'):
+            # Check if it looks like a HIP/CUDA kernel (has void prefix)
+            if name.startswith('void '):
+                return KernelKind.HIP_CPP
+            return KernelKind.TRITON_JIT
+        
+        # Check for other HIP/CUDA kernels
+        if 'void ' in name and '[clone .kd]' in name:
+            return KernelKind.HIP_CPP
+        
+        return KernelKind.UNKNOWN
+    
+    def classify_category(self, name: str) -> KernelCategory:
+        """Classify the operation category based on kernel name."""
+        for category, keywords in self.CATEGORY_KEYWORDS.items():
+            for keyword in keywords:
+                if keyword in name:
+                    return category
+        return KernelCategory.UNKNOWN
+    
+    def _parse_triton(self, name: str) -> ParsedKernelName:
+        """Parse Triton JIT kernel name."""
+        # Remove .kd suffix
+        base = name[:-3] if name.endswith('.kd') else name
+        
+        # Common patterns:
+        # _matmul_ogs_NNT_bf16xbf16xmxfp4_32x256x128x1_swiglu
+        # kernel_unified_attention_3d
+        # _reduce
+        
+        parts = base.split('_')
+        function_name = base
+        config = ""
+        dtype = ""
+        
+        # Try to find where config starts (dtype patterns)
+        dtype_patterns = ['bf16', 'fp16', 'fp32', 'fp8', 'mxfp4', 'int8']
+        for i, part in enumerate(parts):
+            for dt in dtype_patterns:
+                if dt in part.lower():
+                    function_name = '_'.join(parts[:i])
+                    config = '_'.join(parts[i:])
+                    dtype = dt
+                    break
+            if config:
+                break
+        
+        # If no config found, function name is the whole base
+        if not function_name:
+            function_name = base
+        
+        return ParsedKernelName(
+            original_name=name,
+            kind=KernelKind.TRITON_JIT,
+            function_name=function_name,
+            config=config,
+            dtype=dtype,
+        )
+    
+    def _parse_tensile(self, name: str) -> ParsedKernelName:
+        """Parse Tensile GEMM kernel name."""
+        # Example: Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT32x64x256_MI16x16x1_...
+        
+        extra = {}
+        
+        # Extract transpose info
+        if 'Alik' in name:
+            extra['trans_a'] = 'T'
+        if 'Bljk' in name:
+            extra['trans_b'] = 'N'
+        
+        # Extract tile sizes: MT<M>x<N>x<K>
+        mt_match = re.search(r'MT(\d+)x(\d+)x(\d+)', name)
+        if mt_match:
+            extra['tile_m'] = int(mt_match.group(1))
+            extra['tile_n'] = int(mt_match.group(2))
+            extra['tile_k'] = int(mt_match.group(3))
+        
+        # Extract MFMA: MI<m>x<n>x<k>
+        mi_match = re.search(r'MI(\d+)x(\d+)x(\d+)', name)
+        if mi_match:
+            extra['mfma'] = f"{mi_match.group(1)}x{mi_match.group(2)}x{mi_match.group(3)}"
+        
+        # Extract workgroup: WG<x>_<y>_<z>
+        wg_match = re.search(r'WG(\d+)_(\d+)_(\d+)', name)
+        if wg_match:
+            extra['workgroup'] = f"{wg_match.group(1)}x{wg_match.group(2)}x{wg_match.group(3)}"
+        
+        return ParsedKernelName(
+            original_name=name,
+            kind=KernelKind.TENSILE_GEMM,
+            function_name="Tensile GEMM",
+            extra=extra,
+        )
+    
+    def _parse_ck_tile(self, name: str) -> ParsedKernelName:
+        """Parse Composable Kernel tile name."""
+        # Example: _ZN7ck_tile6kentryILi1ENS_12Rmsnorm2dFwd...
+        
+        extra = {}
+        
+        # Extract operation name
+        op_patterns = [
+            (r'Rmsnorm2dFwd', 'Rmsnorm2dFwd'),
+            (r'Fmha', 'Fmha'),
+            (r'Softmax', 'Softmax'),
+            (r'Gemm', 'Gemm'),
+        ]
+        
+        op_name = "Unknown CK Op"
+        for pattern, op in op_patterns:
+            if pattern in name:
+                op_name = op
+                break
+        
+        # Extract dtype
+        if 'DF16b' in name:
+            extra['dtype'] = 'bf16'
+        elif 'DF16' in name:
+            extra['dtype'] = 'fp16'
+        elif 'DF32' in name:
+            extra['dtype'] = 'fp32'
+        
+        # Extract block shape
+        shape_match = re.search(r'sequenceIJLi(\d+)ELi(\d+)E', name)
+        if shape_match:
+            extra['block_shape'] = f"{shape_match.group(1)}x{shape_match.group(2)}"
+        
+        # Check for fused operations
+        if 'FusedAdd' in name:
+            extra['fused_add'] = True
+        if 'FusedQuant' in name:
+            extra['fused_quant'] = True
+        
+        return ParsedKernelName(
+            original_name=name,
+            kind=KernelKind.CK_TILE,
+            function_name=op_name,
+            extra=extra,
+        )
+    
+    def _parse_aten(self, name: str) -> ParsedKernelName:
+        """Parse ATen native kernel name."""
+        # Example: void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<int>...
+        
+        extra = {}
+        
+        # Extract kernel type
+        if 'vectorized_elementwise_kernel' in name:
+            extra['kernel_type'] = 'elementwise'
+        elif 'reduce_kernel' in name:
+            extra['kernel_type'] = 'reduce'
+        elif 'index_elementwise_kernel' in name:
+            extra['kernel_type'] = 'indexing'
+        
+        # Extract functor
+        functor_match = re.search(r'at::native::(\w+Functor)', name)
+        if functor_match:
+            extra['functor'] = functor_match.group(1)
+        
+        # Extract operation from lambda/functor
+        op_patterns = [
+            (r'FillFunctor', 'fill'),
+            (r'CompareEqFunctor', 'eq'),
+            (r'div_trunc_kernel_cuda', 'div_trunc'),
+            (r'direct_copy_kernel_cuda', 'copy'),
+            (r'ArgMaxOps', 'argmax'),
+        ]
+        
+        op_name = "ATen Op"
+        for pattern, op in op_patterns:
+            if pattern in name:
+                op_name = op
+                break
+        
+        return ParsedKernelName(
+            original_name=name,
+            kind=KernelKind.ATEN_NATIVE,
+            function_name=op_name,
+            extra=extra,
+        )
+    
+    def _parse_hip(self, name: str) -> ParsedKernelName:
+        """Parse HIP/CUDA C++ kernel name."""
+        # Example: void vllm::reshape_and_cache_flash_kernel<__hip_bfloat16...
+        # Example: void wvSplitK_hf_sml_<__hip_bfloat16, 64, 2...
+        
+        extra = {}
+        
+        # Extract namespace and kernel name
+        match = re.search(r'void (\w+)::(\w+)', name)
+        if match:
+            extra['namespace'] = match.group(1)
+            function_name = match.group(2)
+        else:
+            # Try without namespace
+            match = re.search(r'void (\w+)<', name)
+            if match:
+                function_name = match.group(1)
+            else:
+                function_name = "HIP kernel"
+        
+        # Extract dtype
+        if '__hip_bfloat16' in name:
+            extra['dtype'] = 'bf16'
+        elif 'float' in name:
+            extra['dtype'] = 'fp32'
+        elif '__half' in name:
+            extra['dtype'] = 'fp16'
+        
+        return ParsedKernelName(
+            original_name=name,
+            kind=KernelKind.HIP_CPP,
+            function_name=function_name,
+            namespace=extra.get('namespace', ''),
+            extra=extra,
+        )
+    
+    def _parse_inductor(self, name: str) -> ParsedKernelName:
+        """Parse torch.inductor generated kernel name."""
+        # Example: triton_poi_fused_0.kd
+        
+        base = name[:-3] if name.endswith('.kd') else name
+        
+        return ParsedKernelName(
+            original_name=name,
+            kind=KernelKind.INDUCTOR,
+            function_name=base,
+            extra={'generated': True},
+        )

--- a/Magpie/tools/amd_kernel_finder/repo_config.py
+++ b/Magpie/tools/amd_kernel_finder/repo_config.py
@@ -1,0 +1,340 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""
+Repository configuration for kernel source finder.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+from pathlib import Path
+
+
+@dataclass
+class RepoConfig:
+    """Configuration for a single repository."""
+    
+    name: str
+    var_name: str  # Environment variable name, e.g., $ROCM_LIBRARIES_DIR
+    path: str = ""
+    github_base: str = ""
+    
+    # Source search paths by kernel kind
+    source_paths: Dict[str, List[str]] = field(default_factory=dict)
+    
+    # Test search paths by kernel kind
+    test_paths: Dict[str, List[str]] = field(default_factory=dict)
+    
+    # File patterns to search
+    source_patterns: List[str] = field(default_factory=lambda: ["*.py", "*.cpp", "*.cu", "*.hip", "*.hpp"])
+    test_patterns: List[str] = field(default_factory=lambda: ["test_*.py", "*_test.py", "*_gtest.cpp"])
+
+
+# Default repository configurations
+REPO_CONFIGS = {
+    "rocm-libraries": RepoConfig(
+        name="rocm-libraries",
+        var_name="$ROCM_LIBRARIES_DIR",
+        github_base="https://github.com/ROCm/rocm-libraries",
+        source_paths={
+            "ck_tile": [
+                "projects/composablekernel/include/ck_tile/ops/",
+                "projects/composablekernel/library/",
+            ],
+            "tensile": [
+                "shared/tensile/Tensile/",
+                "projects/rocblas/library/src/blas3/Tensile/",
+            ],
+            "rocblas": [
+                "projects/rocblas/library/src/",
+            ],
+            "miopen": [
+                "projects/miopen/src/solver/",
+                "projects/miopen/src/kernels/",
+            ],
+            "hipblaslt": [
+                "projects/hipblaslt/library/src/",
+            ],
+        },
+        test_paths={
+            "ck_tile": [
+                "projects/composablekernel/test/ck_tile/",
+                "projects/composablekernel/example/ck_tile/",
+            ],
+            "tensile": [
+                "shared/tensile/Tensile/Tests/",
+            ],
+            "rocblas": [
+                "projects/rocblas/clients/gtest/",
+            ],
+            "miopen": [
+                "projects/miopen/test/",
+            ],
+        },
+    ),
+    "triton": RepoConfig(
+        name="triton",
+        var_name="$TRITON_DIR",
+        github_base="https://github.com/triton-lang/triton",
+        source_paths={
+            "triton_jit": [
+                "python/triton/",
+                "python/tutorials/",
+                "third_party/amd/",
+            ],
+        },
+        test_paths={
+            "triton_jit": [
+                "python/test/unit/language/",
+                "python/test/unit/",
+            ],
+        },
+    ),
+    "rocm-systems": RepoConfig(
+        name="rocm-systems",
+        var_name="$ROCM_SYSTEMS_DIR",
+        github_base="https://github.com/ROCm/rocm-systems",
+        source_paths={
+            "hip": [
+                "projects/hip/",
+                "projects/clr/",
+            ],
+            "rccl": [
+                "projects/rccl/src/device/",
+            ],
+        },
+        test_paths={
+            "hip": [
+                "projects/hip-tests/catch/",
+            ],
+            "rccl": [
+                "projects/rccl-tests/",
+            ],
+        },
+    ),
+}
+
+
+# Subproject mappings (for repos within repos)
+SUBPROJECT_MAPPINGS = {
+    "$CK_DIR": ("$ROCM_LIBRARIES_DIR", "projects/composablekernel"),
+    "$ROCBLAS_DIR": ("$ROCM_LIBRARIES_DIR", "projects/rocblas"),
+    "$MIOPEN_DIR": ("$ROCM_LIBRARIES_DIR", "projects/miopen"),
+    "$TENSILE_DIR": ("$ROCM_LIBRARIES_DIR", "shared/tensile"),
+    "$HIPBLASLT_DIR": ("$ROCM_LIBRARIES_DIR", "projects/hipblaslt"),
+    "$TRITON_KERNELS_DIR": ("$TRITON_DIR", "python/triton_kernels"),
+    "$VLLM_DIR": ("$VLLM_DIR", ""),  # vllm is its own repo
+    "$PYTORCH_DIR": ("$PYTORCH_DIR", ""),  # pytorch is its own repo
+}
+
+
+# GitHub URL templates
+GITHUB_URL_TEMPLATES = {
+    "rocm-libraries": "https://github.com/ROCm/rocm-libraries/blob/main/{path}",
+    "triton": "https://github.com/triton-lang/triton/blob/main/{path}",
+    "rocm-systems": "https://github.com/ROCm/rocm-systems/blob/main/{path}",
+    "vllm": "https://github.com/vllm-project/vllm/blob/main/{path}",
+    "pytorch": "https://github.com/pytorch/pytorch/blob/main/{path}",
+}
+
+
+def detect_repo_type(repo_path: str) -> Optional[str]:
+    """Detect the type of repository based on directory structure."""
+    path = Path(repo_path)
+    
+    if not path.exists():
+        return None
+    
+    # Check for rocm-libraries
+    if (path / "projects" / "composablekernel").exists():
+        return "rocm-libraries"
+    
+    # Check for triton
+    if (path / "python" / "triton").exists():
+        return "triton"
+    
+    # Check for rocm-systems
+    if (path / "projects" / "hip").exists() or (path / "projects" / "rccl").exists():
+        return "rocm-systems"
+    
+    # Check for vllm
+    if (path / "vllm").exists() and (path / "csrc").exists():
+        return "vllm"
+    
+    # Check for pytorch
+    if (path / "aten").exists() and (path / "torch").exists():
+        return "pytorch"
+    
+    return None
+
+
+def get_repo_config(repo_path: str) -> Optional[RepoConfig]:
+    """Get repository configuration for a given path."""
+    repo_type = detect_repo_type(repo_path)
+    
+    if repo_type and repo_type in REPO_CONFIGS:
+        config = REPO_CONFIGS[repo_type]
+        config.path = repo_path
+        return config
+    
+    return None
+
+
+# Test command templates
+TEST_CMD_TEMPLATES = {
+    "triton_jit": "cd {repo_path} && pytest {test_file} -q -k {function}",
+    "tensile_gemm": "cd {repo_path}/build/release && ./clients/staging/rocblas-bench -f gemm_ex --a_type bf16_r --b_type bf16_r --compute_type f32_r",
+    "ck_tile": "cd {repo_path}/build && cmake --build . -j --target tile_example_{op}_fwd && ./bin/tile_example_{op}_fwd",
+    "aten_native": "pytest {repo_path}/test/test_{module}.py -q",
+    "hip_cpp": "cd {repo_path} && pytest tests/kernels/ -q",
+}
+
+
+class RepoDiscovery:
+    """
+    Auto-discover repository structure.
+    
+    Scans a repository to find key directories and files,
+    adapting to different repo layouts.
+    """
+    
+    MARKER_FILES = {
+        "triton_kernels": [
+            "triton_kernels/__init__.py",
+            "triton_kernels/matmul.py",
+        ],
+        "ck_tile": [
+            "include/ck_tile/ops",
+            "example/ck_tile",
+        ],
+        "hipblaslt": [
+            "library/src/amd_detail",
+            "clients/tests",
+        ],
+        "vllm": [
+            "vllm/__init__.py",
+            "csrc/attention",
+        ],
+        "pytorch_aten": [
+            "aten/src/ATen/native/cuda",
+        ],
+    }
+    
+    @classmethod
+    def discover(cls, repo_path: str) -> Dict[str, str]:
+        """
+        Discover structure and return path mappings.
+        
+        Args:
+            repo_path: Path to repository
+            
+        Returns:
+            Dictionary mapping component names to their paths
+        """
+        structure = {}
+        path = Path(repo_path)
+        
+        if not path.exists():
+            return structure
+        
+        # Find triton_kernels location
+        for candidate in path.rglob("triton_kernels/__init__.py"):
+            parent = candidate.parent.parent
+            structure["triton_kernels"] = str(parent)
+            structure["triton_kernels_tests"] = str(parent / "tests")
+            break
+        
+        # Find CK ops location
+        for candidate in path.rglob("ck_tile/ops"):
+            if "include" in str(candidate):
+                structure["ck_ops"] = str(candidate)
+                ck_root = candidate.parent.parent.parent
+                structure["ck_examples"] = str(ck_root / "example" / "ck_tile")
+                break
+        
+        # Find hipBLASLt
+        for candidate in path.rglob("hipblaslt"):
+            if (candidate / "library").exists():
+                structure["hipblaslt"] = str(candidate)
+                structure["hipblaslt_tests"] = str(candidate / "clients" / "tests")
+                break
+        
+        # Find vLLM csrc
+        for candidate in path.rglob("csrc"):
+            if (candidate / "attention").exists() or (candidate / "cache_kernels.cu").exists():
+                structure["vllm_csrc"] = str(candidate)
+                vllm_root = candidate.parent
+                structure["vllm_tests"] = str(vllm_root / "tests" / "kernels")
+                break
+        
+        # Find PyTorch ATen
+        for candidate in path.rglob("ATen/native/cuda"):
+            structure["aten_cuda"] = str(candidate)
+            pytorch_root = candidate.parent.parent.parent.parent.parent
+            structure["pytorch_tests"] = str(pytorch_root / "test")
+            break
+        
+        return structure
+    
+    @classmethod
+    def find_tests_dir(cls, repo_path: str, component: str = None) -> Optional[str]:
+        """
+        Find test directory in a repository.
+        
+        Args:
+            repo_path: Path to repository
+            component: Optional component name to find tests for
+            
+        Returns:
+            Path to test directory if found
+        """
+        path = Path(repo_path)
+        
+        # Common test directory patterns
+        test_patterns = [
+            "tests",
+            "test",
+            "python/*/tests",
+            "clients/tests",
+            "example",
+        ]
+        
+        for pattern in test_patterns:
+            for candidate in path.glob(pattern):
+                if candidate.is_dir():
+                    return str(candidate)
+        
+        return None
+    
+    @classmethod
+    def find_source_dir(cls, repo_path: str, kernel_kind: str) -> Optional[str]:
+        """
+        Find source directory for a kernel kind.
+        
+        Args:
+            repo_path: Path to repository
+            kernel_kind: Kind of kernel (triton_jit, ck_tile, etc.)
+            
+        Returns:
+            Path to source directory if found
+        """
+        structure = cls.discover(repo_path)
+        
+        kind_to_component = {
+            "triton_jit": "triton_kernels",
+            "ck_tile": "ck_ops",
+            "hip_cpp": ["hipblaslt", "vllm_csrc"],
+            "aten_native": "aten_cuda",
+        }
+        
+        components = kind_to_component.get(kernel_kind, [])
+        if isinstance(components, str):
+            components = [components]
+        
+        for comp in components:
+            if comp in structure:
+                return structure[comp]
+        
+        return None

--- a/Magpie/tools/amd_kernel_finder/repo_manager.py
+++ b/Magpie/tools/amd_kernel_finder/repo_manager.py
@@ -1,0 +1,248 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""
+Repository manager for auto-cloning kernel source repositories.
+
+Automatically clones missing repositories needed for kernel source searching.
+Supports shallow cloning for faster downloads.
+"""
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+REPO_URLS = {
+    "rocm-libraries": "https://github.com/ROCm/rocm-libraries.git",
+    "triton": "https://github.com/triton-lang/triton.git",
+    "vllm": "https://github.com/vllm-project/vllm.git",
+    "pytorch": "https://github.com/pytorch/pytorch.git",
+    "rocm-systems": "https://github.com/ROCm/rocm-systems.git",
+}
+
+KERNEL_REPO_MAP = {
+    "triton_jit": ["triton"],
+    "ck_tile": ["rocm-libraries"],
+    "tensile_gemm": ["rocm-libraries"],
+    "hip_cpp": ["rocm-libraries"],
+    "aten_native": ["pytorch"],
+    "inductor": ["pytorch"],
+}
+
+
+class RepoManager:
+    """
+    Manage repository cloning and updates.
+    
+    Automatically clones missing repositories to a cache directory,
+    using shallow clones by default for faster downloads.
+    """
+    
+    def __init__(self, base_dir: str = None):
+        """
+        Initialize the repository manager.
+        
+        Args:
+            base_dir: Directory to store cloned repos. 
+                     Defaults to ~/.cache/magpie/repos/
+        """
+        if base_dir:
+            self.base_dir = Path(base_dir)
+        else:
+            self.base_dir = Path.home() / ".cache" / "magpie" / "repos"
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        
+        self._cloned_repos: Dict[str, str] = {}
+    
+    def ensure_repo(self, repo_name: str, shallow: bool = True) -> str:
+        """
+        Ensure a repository is cloned and return its path.
+        
+        Args:
+            repo_name: Name of the repository (e.g., "rocm-libraries")
+            shallow: If True, use shallow clone (--depth 1) for speed
+            
+        Returns:
+            Path to the cloned repository
+            
+        Raises:
+            ValueError: If repo_name is unknown
+            RuntimeError: If clone fails
+        """
+        if repo_name in self._cloned_repos:
+            return self._cloned_repos[repo_name]
+        
+        repo_path = self.base_dir / repo_name
+        
+        if repo_path.exists() and (repo_path / ".git").exists():
+            logger.info(f"Repo {repo_name} already exists at {repo_path}")
+            self._cloned_repos[repo_name] = str(repo_path)
+            return str(repo_path)
+        
+        if repo_name not in REPO_URLS:
+            raise ValueError(f"Unknown repository: {repo_name}. "
+                           f"Known repos: {list(REPO_URLS.keys())}")
+        
+        url = REPO_URLS[repo_name]
+        logger.info(f"Cloning {repo_name} from {url}...")
+        
+        cmd = ["git", "clone"]
+        if shallow:
+            cmd.extend(["--depth", "1"])
+        cmd.extend([url, str(repo_path)])
+        
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+            
+            if result.returncode != 0:
+                raise RuntimeError(f"Clone failed: {result.stderr}")
+            
+            logger.info(f"Successfully cloned {repo_name} to {repo_path}")
+            self._cloned_repos[repo_name] = str(repo_path)
+            return str(repo_path)
+            
+        except subprocess.TimeoutExpired:
+            raise RuntimeError(f"Clone timed out for {repo_name}")
+        except Exception as e:
+            raise RuntimeError(f"Clone failed for {repo_name}: {e}")
+    
+    def get_required_repos(self, kernel_kinds: List[str]) -> List[str]:
+        """
+        Determine which repos are needed for given kernel kinds.
+        
+        Args:
+            kernel_kinds: List of kernel kinds (e.g., ["triton_jit", "ck_tile"])
+            
+        Returns:
+            List of repo names needed
+        """
+        repos = set()
+        for kind in kernel_kinds:
+            if kind in KERNEL_REPO_MAP:
+                repos.update(KERNEL_REPO_MAP[kind])
+        return list(repos)
+    
+    def get_repos_for_kernels(self, kernel_names: List[str]) -> List[str]:
+        """
+        Analyze kernel names and determine which repos to clone.
+        
+        Args:
+            kernel_names: List of kernel names from profiler
+            
+        Returns:
+            List of repo names needed
+        """
+        from .parser import KernelNameParser
+        
+        parser = KernelNameParser()
+        kinds = set()
+        has_vllm = False
+        
+        for name in kernel_names:
+            parsed = parser.parse(name)
+            kinds.add(parsed.kind.value)
+            
+            if "vllm::" in name or "vllm" in name.lower():
+                has_vllm = True
+        
+        repos = set()
+        for kind in kinds:
+            if kind in KERNEL_REPO_MAP:
+                repos.update(KERNEL_REPO_MAP[kind])
+        
+        if has_vllm:
+            repos.add("vllm")
+        
+        return list(repos)
+    
+    def ensure_repos_for_kernels(self, kernel_names: List[str], 
+                                  shallow: bool = True) -> List[str]:
+        """
+        Ensure all repos needed for the given kernels are available.
+        
+        Args:
+            kernel_names: List of kernel names from profiler
+            shallow: If True, use shallow clone
+            
+        Returns:
+            List of repo paths
+        """
+        needed_repos = self.get_repos_for_kernels(kernel_names)
+        logger.info(f"Kernel analysis requires repos: {needed_repos}")
+        
+        paths = []
+        for repo_name in needed_repos:
+            try:
+                path = self.ensure_repo(repo_name, shallow=shallow)
+                paths.append(path)
+            except Exception as e:
+                logger.warning(f"Failed to ensure repo {repo_name}: {e}")
+        
+        return paths
+    
+    def get_repo_path(self, repo_name: str) -> Optional[str]:
+        """Get path to a repo if it exists."""
+        if repo_name in self._cloned_repos:
+            return self._cloned_repos[repo_name]
+        
+        repo_path = self.base_dir / repo_name
+        if repo_path.exists():
+            self._cloned_repos[repo_name] = str(repo_path)
+            return str(repo_path)
+        
+        return None
+    
+    def list_available_repos(self) -> List[str]:
+        """List all available (cloned) repositories."""
+        available = []
+        for repo_name in REPO_URLS:
+            repo_path = self.base_dir / repo_name
+            if repo_path.exists():
+                available.append(repo_name)
+        return available
+    
+    def update_repo(self, repo_name: str) -> bool:
+        """
+        Update (git pull) a repository.
+        
+        Args:
+            repo_name: Name of the repository
+            
+        Returns:
+            True if update succeeded
+        """
+        repo_path = self.get_repo_path(repo_name)
+        if not repo_path:
+            logger.warning(f"Repo {repo_name} not found, cannot update")
+            return False
+        
+        try:
+            result = subprocess.run(
+                ["git", "pull", "--ff-only"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            
+            if result.returncode == 0:
+                logger.info(f"Updated {repo_name}")
+                return True
+            else:
+                logger.warning(f"Update failed for {repo_name}: {result.stderr}")
+                return False
+                
+        except Exception as e:
+            logger.warning(f"Update failed for {repo_name}: {e}")
+            return False

--- a/Magpie/tools/amd_kernel_finder/searcher.py
+++ b/Magpie/tools/amd_kernel_finder/searcher.py
@@ -1,0 +1,674 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""
+Source file searcher with ripgrep and Python fallback.
+"""
+
+import glob
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Dict
+
+from .models import KernelKind, ParsedKernelName, SourceMatch, TestMatch
+from .repo_config import RepoConfig, SUBPROJECT_MAPPINGS, GITHUB_URL_TEMPLATES
+
+logger = logging.getLogger(__name__)
+
+
+class KernelSourceSearcher:
+    """Search for kernel source files in repositories."""
+    
+    def __init__(self, repos: List[str], repo_configs: Dict[str, RepoConfig] = None,
+                 auto_install_ripgrep: bool = True):
+        """
+        Initialize searcher with repository paths.
+        
+        Args:
+            repos: List of repository root paths
+            repo_configs: Optional custom repo configurations
+            auto_install_ripgrep: If True, attempt to install ripgrep if missing
+        """
+        self.repos = repos
+        self.repo_configs = repo_configs or {}
+        self._repo_var_map: Dict[str, str] = {}
+        
+        # Check/install ripgrep
+        self._has_ripgrep = self._check_ripgrep()
+        if not self._has_ripgrep and auto_install_ripgrep:
+            self._has_ripgrep = self._ensure_ripgrep()
+        
+        if not self._has_ripgrep:
+            logger.info("ripgrep not available, using Python fallback for searches")
+        
+        # Build repo variable map
+        self._build_repo_var_map()
+    
+    def _check_ripgrep(self) -> bool:
+        """Check if ripgrep is available."""
+        try:
+            result = subprocess.run(
+                ["rg", "--version"],
+                capture_output=True,
+                timeout=5,
+            )
+            return result.returncode == 0
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+    
+    def _ensure_ripgrep(self) -> bool:
+        """Attempt to install ripgrep if missing."""
+        logger.info("ripgrep not found, attempting to install...")
+        
+        install_cmds = [
+            (["apt-get", "update"], ["apt-get", "install", "-y", "ripgrep"]),
+            (None, ["yum", "install", "-y", "ripgrep"]),
+            (None, ["dnf", "install", "-y", "ripgrep"]),
+            (None, ["brew", "install", "ripgrep"]),
+            (None, ["cargo", "install", "ripgrep"]),
+        ]
+        
+        for pre_cmd, install_cmd in install_cmds:
+            try:
+                if pre_cmd:
+                    subprocess.run(pre_cmd, capture_output=True, timeout=60)
+                
+                result = subprocess.run(
+                    install_cmd,
+                    capture_output=True,
+                    timeout=300,
+                )
+                
+                if result.returncode == 0 and self._check_ripgrep():
+                    logger.info(f"ripgrep installed successfully via {install_cmd[0]}")
+                    return True
+            except (FileNotFoundError, subprocess.TimeoutExpired, PermissionError):
+                continue
+        
+        logger.warning("Could not install ripgrep automatically")
+        return False
+    
+    def _run_python_search(self, pattern: str, search_path: str,
+                           file_extensions: List[str] = None,
+                           max_results: int = 5) -> List[str]:
+        """
+        Python-native search fallback using glob + re.
+        
+        Args:
+            pattern: Regex pattern to search for
+            search_path: Directory to search in
+            file_extensions: List of extensions (e.g., ["py", "cpp"])
+            max_results: Maximum results to return
+            
+        Returns:
+            List of matching file paths
+        """
+        if not Path(search_path).exists():
+            return []
+        
+        results = []
+        extensions = file_extensions or ["py", "cpp", "cu", "hip", "hpp"]
+        
+        try:
+            compiled_pattern = re.compile(pattern, re.MULTILINE)
+        except re.error:
+            pattern = re.escape(pattern)
+            compiled_pattern = re.compile(pattern, re.MULTILINE)
+        
+        for ext in extensions:
+            glob_pattern = f"{search_path}/**/*.{ext}"
+            for filepath in glob.iglob(glob_pattern, recursive=True):
+                if ".git" in filepath or "__pycache__" in filepath:
+                    continue
+                
+                try:
+                    with open(filepath, 'r', errors='ignore') as f:
+                        content = f.read()
+                        if compiled_pattern.search(content):
+                            results.append(filepath)
+                            if len(results) >= max_results:
+                                return results
+                except (IOError, OSError):
+                    continue
+        
+        return results
+    
+    def _search_files(self, pattern: str, search_path: str,
+                      file_types: List[str] = None,
+                      max_results: int = 5) -> List[str]:
+        """
+        Search files using ripgrep with Python fallback.
+        
+        Args:
+            pattern: Search pattern
+            search_path: Directory to search
+            file_types: List of file type filters for ripgrep
+            max_results: Maximum results
+            
+        Returns:
+            List of matching file paths
+        """
+        if self._has_ripgrep:
+            results = self._run_ripgrep(pattern, search_path, file_types, max_results)
+            if results:
+                return results
+        
+        ext_map = {
+            "py": "py",
+            "cpp": "cpp",
+            "cu": "cu",
+            "hip": "hip",
+            "hpp": "hpp",
+        }
+        extensions = [ext_map.get(ft, ft) for ft in (file_types or [])]
+        return self._run_python_search(pattern, search_path, extensions, max_results)
+    
+    def _build_repo_var_map(self):
+        """Build mapping from repo variable names to actual paths."""
+        for repo_path in self.repos:
+            from .repo_config import detect_repo_type, REPO_CONFIGS
+            repo_type = detect_repo_type(repo_path)
+            if repo_type and repo_type in REPO_CONFIGS:
+                config = REPO_CONFIGS[repo_type]
+                self._repo_var_map[config.var_name] = repo_path
+                
+                # Add subproject mappings
+                for subvar, (parent_var, subpath) in SUBPROJECT_MAPPINGS.items():
+                    if config.var_name == parent_var:
+                        self._repo_var_map[subvar] = str(Path(repo_path) / subpath)
+    
+    def get_repo_paths(self) -> Dict[str, str]:
+        """Get mapping of repo variable names to actual paths."""
+        return self._repo_var_map.copy()
+    
+    def search_source(self, parsed: ParsedKernelName) -> Optional[SourceMatch]:
+        """
+        Search for kernel source file.
+        
+        Args:
+            parsed: Parsed kernel name information
+            
+        Returns:
+            SourceMatch if found, None otherwise
+        """
+        if parsed.kind == KernelKind.ANNOTATION:
+            return None
+        
+        if parsed.kind == KernelKind.TRITON_JIT:
+            return self._search_triton_source(parsed)
+        elif parsed.kind == KernelKind.TENSILE_GEMM:
+            return self._search_tensile_source(parsed)
+        elif parsed.kind == KernelKind.CK_TILE:
+            return self._search_ck_source(parsed)
+        elif parsed.kind == KernelKind.ATEN_NATIVE:
+            return self._search_aten_source(parsed)
+        elif parsed.kind == KernelKind.HIP_CPP:
+            return self._search_hip_source(parsed)
+        elif parsed.kind == KernelKind.INDUCTOR:
+            return self._search_inductor_source(parsed)
+        
+        return None
+    
+    def search_test(self, parsed: ParsedKernelName, source: Optional[SourceMatch] = None) -> Optional[TestMatch]:
+        """
+        Search for test files and generate test command.
+        
+        Args:
+            parsed: Parsed kernel name information
+            source: Optional source match for context
+            
+        Returns:
+            TestMatch if found, None otherwise
+        """
+        if parsed.kind == KernelKind.ANNOTATION:
+            return None
+        
+        if parsed.kind == KernelKind.TRITON_JIT:
+            return self._search_triton_test(parsed, source)
+        elif parsed.kind == KernelKind.TENSILE_GEMM:
+            return self._search_tensile_test(parsed)
+        elif parsed.kind == KernelKind.CK_TILE:
+            return self._search_ck_test(parsed)
+        elif parsed.kind == KernelKind.ATEN_NATIVE:
+            return self._search_aten_test(parsed)
+        elif parsed.kind == KernelKind.HIP_CPP:
+            return self._search_hip_test(parsed, source)
+        
+        return None
+    
+    def _run_ripgrep(self, pattern: str, search_path: str, 
+                     file_types: List[str] = None, max_results: int = 5) -> List[str]:
+        """Run ripgrep and return matching files."""
+        if not Path(search_path).exists():
+            return []
+        
+        cmd = ["rg", "-l", "--max-count", "1"]
+        
+        if file_types:
+            for ft in file_types:
+                cmd.extend(["--type", ft])
+        
+        cmd.extend([pattern, search_path])
+        
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode == 0:
+                files = result.stdout.strip().split('\n')
+                return [f for f in files if f][:max_results]
+        except (subprocess.TimeoutExpired, Exception) as e:
+            logger.warning(f"ripgrep failed: {e}")
+        
+        return []
+    
+    def _search_triton_source(self, parsed: ParsedKernelName) -> Optional[SourceMatch]:
+        """Search for Triton JIT kernel source."""
+        function_name = parsed.function_name
+        
+        # Known kernel mappings for common kernels
+        # $TRITON_KERNELS_DIR = triton/python/triton_kernels/
+        known_mappings = {
+            "_matmul_ogs": ("triton_kernels/matmul_details/_matmul.py", "$TRITON_KERNELS_DIR"),
+            "_matmul": ("triton_kernels/matmul_details/_matmul.py", "$TRITON_KERNELS_DIR"),
+            "_reduce": ("triton_kernels/reduce.py", "$TRITON_KERNELS_DIR"),
+            "kernel_unified_attention": ("vllm/v1/attention/ops/triton_unified_attention.py", "$VLLM_DIR"),
+            "_topk_forward": ("triton_kernels/topk_details/_topk_forward.py", "$TRITON_KERNELS_DIR"),
+            "_topk_backward": ("triton_kernels/topk_details/_topk_backward.py", "$TRITON_KERNELS_DIR"),
+            "_bitmatrix_metadata": ("triton_kernels/tensor_details/", "$TRITON_KERNELS_DIR"),
+            "_ragged_tensor_metadata": ("triton_kernels/tensor_details/", "$TRITON_KERNELS_DIR"),
+            "_sum_bitmatrix_rows": ("triton_kernels/tensor_details/", "$TRITON_KERNELS_DIR"),
+            "_fused_add_rmsnorm": ("triton_kernels/swiglu_details/", "$TRITON_KERNELS_DIR"),
+            "_swiglu": ("triton_kernels/swiglu_details/", "$TRITON_KERNELS_DIR"),
+            "_compaction": ("triton_kernels/compaction_details/", "$TRITON_KERNELS_DIR"),
+        }
+        
+        # Check known mappings first
+        for key, (path, repo_var) in known_mappings.items():
+            if key in function_name:
+                return SourceMatch(
+                    file_path=path,
+                    symbol=function_name,
+                    repo_name="triton_kernels",
+                    repo_var=repo_var,
+                )
+        
+        # Search patterns
+        patterns = [
+            f"def {function_name}",
+            f"@triton.jit.*\\n.*def {function_name}",
+            f'def {function_name}\\(',
+        ]
+        
+        # Search in triton repos
+        triton_path = self._repo_var_map.get("$TRITON_DIR")
+        if triton_path:
+            for pattern in patterns:
+                files = self._run_ripgrep(pattern, triton_path, ["py"])
+                if files:
+                    rel_path = os.path.relpath(files[0], triton_path)
+                    return SourceMatch(
+                        file_path=rel_path,
+                        symbol=function_name,
+                        repo_name="triton",
+                        repo_var="$TRITON_DIR",
+                    )
+        
+        # Search in rocm-libraries (triton_kernels might be there)
+        rocm_libs = self._repo_var_map.get("$ROCM_LIBRARIES_DIR")
+        if rocm_libs:
+            for pattern in patterns:
+                files = self._run_ripgrep(pattern, rocm_libs, ["py"])
+                if files:
+                    rel_path = os.path.relpath(files[0], rocm_libs)
+                    return SourceMatch(
+                        file_path=rel_path,
+                        symbol=function_name,
+                        repo_name="rocm-libraries",
+                        repo_var="$ROCM_LIBRARIES_DIR",
+                    )
+        
+        # Default fallback for triton kernels
+        return SourceMatch(
+            file_path="(search in triton_kernels or vllm)",
+            symbol=function_name,
+            repo_name="triton",
+            repo_var="$TRITON_DIR",
+        )
+    
+    def _search_tensile_source(self, parsed: ParsedKernelName) -> Optional[SourceMatch]:
+        """Search for Tensile GEMM source (logic YAML files)."""
+        rocm_libs = self._repo_var_map.get("$ROCM_LIBRARIES_DIR")
+        if not rocm_libs:
+            return None
+        
+        # Tensile kernels are generated, point to logic files
+        tensile_logic_path = Path(rocm_libs) / "projects/rocblas/library/src/blas3/Tensile/Logic"
+        if tensile_logic_path.exists():
+            return SourceMatch(
+                file_path="projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/",
+                symbol="Tensile-generated kernel (asm)",
+                repo_name="rocm-libraries",
+                repo_var="$ROCM_LIBRARIES_DIR",
+            )
+        
+        return None
+    
+    def _search_ck_source(self, parsed: ParsedKernelName) -> Optional[SourceMatch]:
+        """Search for Composable Kernel source."""
+        rocm_libs = self._repo_var_map.get("$ROCM_LIBRARIES_DIR")
+        if not rocm_libs:
+            return None
+        
+        ck_path = Path(rocm_libs) / "projects/composablekernel"
+        if not ck_path.exists():
+            return None
+        
+        # Map operation name to directory
+        op_name = parsed.function_name.lower()
+        op_dirs = {
+            "rmsnorm2dfwd": "rmsnorm2d",
+            "fmha": "fmha",
+            "softmax": "softmax",
+            "gemm": "gemm",
+        }
+        
+        for op_key, op_dir in op_dirs.items():
+            if op_key in op_name:
+                op_path = f"projects/composablekernel/include/ck_tile/ops/{op_dir}/"
+                if (Path(rocm_libs) / op_path).exists():
+                    return SourceMatch(
+                        file_path=op_path,
+                        symbol=parsed.function_name,
+                        repo_name="rocm-libraries",
+                        repo_var="$ROCM_LIBRARIES_DIR",
+                    )
+        
+        # Generic CK search
+        return SourceMatch(
+            file_path="projects/composablekernel/include/ck_tile/ops/",
+            symbol=parsed.function_name,
+            repo_name="rocm-libraries",
+            repo_var="$ROCM_LIBRARIES_DIR",
+        )
+    
+    def _search_aten_source(self, parsed: ParsedKernelName) -> Optional[SourceMatch]:
+        """Search for ATen native kernel source."""
+        # ATen kernels are in PyTorch, provide standard path
+        kernel_type = parsed.extra.get('kernel_type', '')
+        functor = parsed.extra.get('functor', '')
+        
+        # Map to known files
+        file_mapping = {
+            'FillFunctor': 'Fill.cu',
+            'CompareEqFunctor': 'CompareEQKernel.cu',
+            'div_trunc': 'BinaryDivTruncKernel.cu',
+            'copy': 'Copy.cu',
+            'argmax': 'ReduceArgMaxKernel.cu',
+        }
+        
+        for key, filename in file_mapping.items():
+            if key in parsed.original_name:
+                return SourceMatch(
+                    file_path=f"aten/src/ATen/native/cuda/{filename}",
+                    symbol=parsed.function_name,
+                    repo_name="pytorch",
+                    repo_var="$PYTORCH_DIR",
+                )
+        
+        return SourceMatch(
+            file_path="aten/src/ATen/native/cuda/",
+            symbol=parsed.function_name,
+            repo_name="pytorch",
+            repo_var="$PYTORCH_DIR",
+        )
+    
+    def _search_hip_source(self, parsed: ParsedKernelName) -> Optional[SourceMatch]:
+        """Search for HIP/CUDA C++ kernel source."""
+        namespace = parsed.namespace
+        function_name = parsed.function_name
+        original_name = parsed.original_name
+        
+        # Known HIP kernel mappings
+        known_hip_mappings = {
+            # WMMA / Matrix core kernels (hipBLASLt / rocWMMA)
+            "wvSplitK": ("projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/", "hipBLASLt WMMA kernel", "$ROCM_LIBRARIES_DIR"),
+            "wvSpltK": ("projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/", "hipBLASLt WMMA kernel", "$ROCM_LIBRARIES_DIR"),
+            "DeviceGemmWmma": ("projects/composablekernel/include/ck/tensor_operation/gpu/device/impl/", "CK WMMA GEMM", "$ROCM_LIBRARIES_DIR"),
+            # vLLM kernels
+            "reshape_and_cache": ("csrc/cache_kernels.cu", "reshape_and_cache_flash_kernel", "$VLLM_DIR"),
+            "paged_attention": ("csrc/attention/paged_attention_v1.cu", "paged_attention_kernel", "$VLLM_DIR"),
+            "rotary_embedding": ("csrc/pos_encoding_kernels.cu", "rotary_embedding_kernel", "$VLLM_DIR"),
+            "rms_norm": ("csrc/layernorm_kernels.cu", "rms_norm_kernel", "$VLLM_DIR"),
+            "silu_and_mul": ("csrc/activation_kernels.cu", "silu_and_mul_kernel", "$VLLM_DIR"),
+            "gelu": ("csrc/activation_kernels.cu", "gelu_kernel", "$VLLM_DIR"),
+            # rocBLAS / BLAS
+            "rocblas": ("projects/rocblas/library/src/", "rocBLAS kernel", "$ROCM_LIBRARIES_DIR"),
+            # ROCm system kernels
+            "rocclr_copy": ("projects/clr/rocclr/device/blitcl.cpp", "ROCclr blit", "$ROCM_SYSTEMS_DIR"),
+            "__amd_rocclr": ("projects/clr/rocclr/device/blitcl.cpp", "ROCclr blit", "$ROCM_SYSTEMS_DIR"),
+        }
+        
+        # Check known mappings
+        for key, (path, symbol, repo_var) in known_hip_mappings.items():
+            if key in original_name or key in function_name:
+                repo_name = "vllm" if repo_var == "$VLLM_DIR" else "rocm-libraries" if "ROCM_LIBRARIES" in repo_var else "rocm-systems"
+                return SourceMatch(
+                    file_path=path,
+                    symbol=symbol,
+                    repo_name=repo_name,
+                    repo_var=repo_var,
+                )
+        
+        # Check vLLM kernels by namespace
+        if namespace == "vllm" or "vllm" in original_name.lower():
+            return SourceMatch(
+                file_path="csrc/",
+                symbol=function_name,
+                repo_name="vllm",
+                repo_var="$VLLM_DIR",
+            )
+        
+        # Search in rocm-libraries
+        rocm_libs = self._repo_var_map.get("$ROCM_LIBRARIES_DIR")
+        if rocm_libs:
+            pattern = f"void.*{function_name}"
+            files = self._run_ripgrep(pattern, rocm_libs, ["cpp"])
+            if files:
+                rel_path = os.path.relpath(files[0], rocm_libs)
+                return SourceMatch(
+                    file_path=rel_path,
+                    symbol=function_name,
+                    repo_name="rocm-libraries",
+                    repo_var="$ROCM_LIBRARIES_DIR",
+                )
+        
+        return None
+    
+    def _search_inductor_source(self, parsed: ParsedKernelName) -> Optional[SourceMatch]:
+        """Search for torch.inductor generated kernel."""
+        return SourceMatch(
+            file_path="torch/_inductor/codegen/triton.py",
+            symbol=parsed.function_name,
+            repo_name="pytorch",
+            repo_var="$PYTORCH_DIR",
+        )
+    
+    def _search_triton_test(self, parsed: ParsedKernelName, 
+                           source: Optional[SourceMatch]) -> Optional[TestMatch]:
+        """Search for Triton kernel tests."""
+        function_name = parsed.function_name
+        
+        # Known test mappings for common kernels
+        # Note: $TRITON_KERNELS_DIR = triton/python/triton_kernels/
+        known_test_mappings = {
+            "_matmul_ogs": ("tests/test_matmul.py", "cd $TRITON_KERNELS_DIR && pytest tests/test_matmul.py -v", "$TRITON_KERNELS_DIR"),
+            "_matmul": ("tests/test_matmul.py", "cd $TRITON_KERNELS_DIR && pytest tests/test_matmul.py -v", "$TRITON_KERNELS_DIR"),
+            "_reduce": ("tests/test_reduce.py", "cd $TRITON_KERNELS_DIR && pytest tests/test_reduce.py -v", "$TRITON_KERNELS_DIR"),
+            "kernel_unified_attention": ("tests/v1/attention/", "cd $VLLM_DIR && pytest tests/v1/ -v -k attention", "$VLLM_DIR"),
+            "_topk_forward": ("tests/test_topk.py", "cd $TRITON_KERNELS_DIR && pytest tests/test_topk.py -v", "$TRITON_KERNELS_DIR"),
+            "_topk_backward": ("tests/test_topk.py", "cd $TRITON_KERNELS_DIR && pytest tests/test_topk.py -v", "$TRITON_KERNELS_DIR"),
+            "_bitmatrix": ("tests/test_tensor.py", "cd $TRITON_KERNELS_DIR && pytest tests/test_tensor.py -v", "$TRITON_KERNELS_DIR"),
+            "_ragged_tensor": ("tests/test_tensor.py", "cd $TRITON_KERNELS_DIR && pytest tests/test_tensor.py -v", "$TRITON_KERNELS_DIR"),
+            "_sum_bitmatrix_rows": ("tests/test_tensor.py", "cd $TRITON_KERNELS_DIR && pytest tests/test_tensor.py -v", "$TRITON_KERNELS_DIR"),
+            "_fused_add_rmsnorm": ("tests/test_swiglu.py", "cd $TRITON_KERNELS_DIR && pytest tests/test_swiglu.py -v", "$TRITON_KERNELS_DIR"),
+            "_swiglu": ("tests/test_swiglu.py", "cd $TRITON_KERNELS_DIR && pytest tests/test_swiglu.py -v", "$TRITON_KERNELS_DIR"),
+            "_compaction": ("tests/test_compaction.py", "cd $TRITON_KERNELS_DIR && pytest tests/test_compaction.py -v", "$TRITON_KERNELS_DIR"),
+        }
+        
+        # Check known mappings first
+        for key, (test_file, test_cmd, repo_var) in known_test_mappings.items():
+            if key in function_name:
+                return TestMatch(
+                    test_file=test_file,
+                    test_cmd=test_cmd,
+                    repo_var=repo_var,
+                )
+        
+        triton_path = self._repo_var_map.get("$TRITON_DIR")
+        if triton_path:
+            test_path = Path(triton_path) / "python/test/unit/language"
+            if test_path.exists():
+                # Search for test files mentioning the function
+                pattern = f"def test.*{function_name}|{function_name}"
+                files = self._run_ripgrep(pattern, str(test_path), ["py"])
+                if files:
+                    rel_path = os.path.relpath(files[0], triton_path)
+                    return TestMatch(
+                        test_file=rel_path,
+                        test_cmd=f"cd $TRITON_DIR && pytest {rel_path} -q",
+                        repo_var="$TRITON_DIR",
+                    )
+        
+        return None
+    
+    def _search_tensile_test(self, parsed: ParsedKernelName) -> Optional[TestMatch]:
+        """Search for Tensile GEMM tests."""
+        rocm_libs = self._repo_var_map.get("$ROCM_LIBRARIES_DIR")
+        if rocm_libs:
+            return TestMatch(
+                test_file="projects/rocblas/clients/gtest/blas3/gemm_gtest.cpp",
+                test_cmd="cd $ROCM_LIBRARIES_DIR/projects/rocblas/build/release && ./clients/staging/rocblas-bench -f gemm_ex --a_type bf16_r --b_type bf16_r --compute_type f32_r",
+                repo_var="$ROCM_LIBRARIES_DIR",
+            )
+        return None
+    
+    def _search_ck_test(self, parsed: ParsedKernelName) -> Optional[TestMatch]:
+        """Search for CK tile tests."""
+        op_name = parsed.function_name.lower()
+        original_name = parsed.original_name.lower()
+        
+        # Map operation to example/test directory
+        # CK examples are at: projects/composablekernel/example/ck_tile/
+        if "rmsnorm" in op_name or "rmsnorm" in original_name:
+            return TestMatch(
+                test_file="projects/composablekernel/example/ck_tile/10_rmsnorm2d/",
+                test_cmd="cd $ROCM_LIBRARIES_DIR/projects/composablekernel/build && cmake --build . -j --target tile_example_rmsnorm2d_fwd && ./bin/tile_example_rmsnorm2d_fwd -m 1024 -n 2048",
+                repo_var="$ROCM_LIBRARIES_DIR",
+            )
+        elif "fmha" in op_name or "fmha" in original_name:
+            return TestMatch(
+                test_file="projects/composablekernel/example/ck_tile/01_fmha/",
+                test_cmd="cd $ROCM_LIBRARIES_DIR/projects/composablekernel/build && cmake --build . -j --target tile_example_fmha_fwd && ./bin/tile_example_fmha_fwd",
+                repo_var="$ROCM_LIBRARIES_DIR",
+            )
+        elif "layernorm" in op_name or "layernorm" in original_name:
+            return TestMatch(
+                test_file="projects/composablekernel/example/ck_tile/02_layernorm2d/",
+                test_cmd="cd $ROCM_LIBRARIES_DIR/projects/composablekernel/build && cmake --build . -j --target tile_example_layernorm2d_fwd && ./bin/tile_example_layernorm2d_fwd",
+                repo_var="$ROCM_LIBRARIES_DIR",
+            )
+        elif "gemm" in op_name or "gemm" in original_name:
+            return TestMatch(
+                test_file="projects/composablekernel/example/ck_tile/03_gemm/",
+                test_cmd="cd $ROCM_LIBRARIES_DIR/projects/composablekernel/build && cmake --build . -j --target tile_example_gemm && ./bin/tile_example_gemm",
+                repo_var="$ROCM_LIBRARIES_DIR",
+            )
+        elif "topk" in op_name or "softmax" in op_name:
+            return TestMatch(
+                test_file="projects/composablekernel/example/ck_tile/09_topk_softmax/",
+                test_cmd="cd $ROCM_LIBRARIES_DIR/projects/composablekernel/build && cmake --build . -j --target tile_example_topk_softmax && ./bin/tile_example_topk_softmax",
+                repo_var="$ROCM_LIBRARIES_DIR",
+            )
+        
+        return None
+    
+    def _search_aten_test(self, parsed: ParsedKernelName) -> Optional[TestMatch]:
+        """Search for ATen native tests."""
+        # Map operation to test file
+        test_mapping = {
+            'fill': 'test_torch.py',
+            'eq': 'test_binary_ufuncs.py',
+            'div': 'test_binary_ufuncs.py',
+            'copy': 'test_torch.py',
+            'argmax': 'test_reductions.py',
+        }
+        
+        for op, test_file in test_mapping.items():
+            if op in parsed.function_name.lower():
+                return TestMatch(
+                    test_file=f"test/{test_file}",
+                    test_cmd=f"pytest $PYTORCH_DIR/test/{test_file} -q -k {op}",
+                    repo_var="$PYTORCH_DIR",
+                )
+        
+        return TestMatch(
+            test_file="test/test_torch.py",
+            test_cmd="pytest $PYTORCH_DIR/test/test_torch.py -q",
+            repo_var="$PYTORCH_DIR",
+        )
+    
+    def _search_hip_test(self, parsed: ParsedKernelName,
+                        source: Optional[SourceMatch]) -> Optional[TestMatch]:
+        """Search for HIP/CUDA kernel tests."""
+        namespace = parsed.namespace
+        function_name = parsed.function_name
+        original_name = parsed.original_name
+        
+        # Known HIP kernel test mappings
+        known_hip_test_mappings = {
+            # WMMA / Matrix core kernels (hipBLASLt)
+            "wvSplitK": ("projects/hipblaslt/clients/tests/", "cd $ROCM_LIBRARIES_DIR/projects/hipblaslt/build/release && ./clients/staging/hipblaslt-bench -f gemm_ex --a_type bf16_r --b_type bf16_r --compute_type f32_r -m 1024 -n 1024 -k 1024", "$ROCM_LIBRARIES_DIR"),
+            "wvSpltK": ("projects/hipblaslt/clients/tests/", "cd $ROCM_LIBRARIES_DIR/projects/hipblaslt/build/release && ./clients/staging/hipblaslt-bench -f gemm_ex --a_type bf16_r --b_type bf16_r --compute_type f32_r -m 1024 -n 1024 -k 1024", "$ROCM_LIBRARIES_DIR"),
+            # vLLM kernels
+            "reshape_and_cache": ("tests/kernels/test_cache.py", "cd $VLLM_DIR && pytest tests/kernels/test_cache.py -v", "$VLLM_DIR"),
+            "paged_attention": ("tests/kernels/test_attention.py", "cd $VLLM_DIR && pytest tests/kernels/test_attention.py -v", "$VLLM_DIR"),
+            "rotary_embedding": ("tests/kernels/test_pos_encoding.py", "cd $VLLM_DIR && pytest tests/kernels/test_pos_encoding.py -v", "$VLLM_DIR"),
+            "rms_norm": ("tests/kernels/test_layernorm.py", "cd $VLLM_DIR && pytest tests/kernels/test_layernorm.py -v", "$VLLM_DIR"),
+            "silu_and_mul": ("tests/kernels/test_activation.py", "cd $VLLM_DIR && pytest tests/kernels/test_activation.py -v", "$VLLM_DIR"),
+            # ROCm system
+            "rocclr_copy": ("tests/catch/unit/memory/", "cd $ROCM_SYSTEMS_DIR && ctest -R hipMemcpy", "$ROCM_SYSTEMS_DIR"),
+        }
+        
+        # Check known mappings
+        for key, (test_file, test_cmd, repo_var) in known_hip_test_mappings.items():
+            if key in original_name or key in function_name:
+                return TestMatch(
+                    test_file=test_file,
+                    test_cmd=test_cmd,
+                    repo_var=repo_var,
+                )
+        
+        if namespace == "vllm" or "vllm" in original_name.lower():
+            # Map to vLLM test directories
+            if "cache" in function_name.lower():
+                return TestMatch(
+                    test_file="tests/kernels/attention/test_cache.py",
+                    test_cmd="cd $VLLM_DIR && pytest tests/kernels/attention/test_cache.py -q",
+                    repo_var="$VLLM_DIR",
+                )
+            return TestMatch(
+                test_file="tests/kernels/",
+                test_cmd="cd $VLLM_DIR && pytest tests/kernels/ -q",
+                repo_var="$VLLM_DIR",
+            )
+        
+        return None

--- a/examples/benchmarks/benchmark_vllm_dsv32_fp8.yaml
+++ b/examples/benchmarks/benchmark_vllm_dsv32_fp8.yaml
@@ -1,9 +1,9 @@
 # vLLM Benchmark Configuration Example
 # =====================================
-# This example shows how to benchmark vLLM with Qwen3-Next-80B-A3B-Instruct model.
+# This example shows how to benchmark vLLM with DeepSeek-V3.2 model.
 #
 # Usage:
-#   python -m Magpie benchmark --benchmark-config examples/benchmarks/benchmark_vllm_qwen3_next_80b.yaml
+#   python -m Magpie benchmark --benchmark-config examples/benchmarks/benchmark_vllm_dsv32.yaml
 #
 # Prerequisites:
 #   - Docker with GPU support
@@ -11,29 +11,29 @@
 
 benchmark:
   framework: vllm
-  model: Qwen/Qwen3-Next-80B-A3B-Instruct-FP8
+  model: deepseek-ai/DeepSeek-V3.2
   precision: fp8
   run_mode: docker
-
+  
   # Environment variables
   envs:
-    TP: 1
-    CONC: 16
+    TP: 8
+    CONC: 32
     ISL: 1024
     OSL: 1024
     RANDOM_RANGE_RATIO: 1
-    MAX_MODEL_LEN: 2248 # ISL + OSL + 200
-    EXTRA_VLLM_ARGS: "--no-enable-prefix-caching"
-        
-    # AMD performance flags
-    VLLM_ROCM_USE_AITER: 1
+    MAX_MODEL_LEN: 2248  # ISL + OSL + 200
+    EXTRA_VLLM_ARGS: "--no-enable-prefix-caching --block-size 1"
+    VLLM_LOGGING_LEVEL: "WARNING" 
+
     
+  # Profiler configuration
   profiler:
     torch_profiler:
       enabled: true
     system_profiler:
       enabled: false
-
+      
   gap_analysis:
     enabled: true
     top_k: 100

--- a/examples/benchmarks/benchmark_vllm_dsv32_mxfp4.yaml
+++ b/examples/benchmarks/benchmark_vllm_dsv32_mxfp4.yaml
@@ -11,8 +11,8 @@
 
 benchmark:
   framework: vllm
-  model: deepseek-ai/DeepSeek-V3.2
-  precision: fp8
+  model: amd/DeepSeek-V3.2-mxfp4
+  precision: mxfp4
   run_mode: docker
   
   # Environment variables

--- a/examples/benchmarks/benchmark_vllm_glm5_fp8.yaml
+++ b/examples/benchmarks/benchmark_vllm_glm5_fp8.yaml
@@ -1,0 +1,45 @@
+# vLLM Benchmark Configuration Example
+# =====================================
+# This example shows how to benchmark vLLM with Qwen3-Next-80B-A3B-Instruct model.
+#
+# Usage:
+#   python -m Magpie benchmark --benchmark-config examples/benchmarks/benchmark_vllm_qwen3_next_80b.yaml
+#
+# Prerequisites:
+#   - Docker with GPU support
+#   - HuggingFace token (HF_TOKEN) for gated models
+
+benchmark:
+  framework: vllm
+  model: zai-org/GLM-5-FP8
+  precision: fp8
+  run_mode: docker
+
+  # Environment variables
+  envs:
+    TP: 1
+    CONC: 16
+    ISL: 1024
+    OSL: 1024
+    RANDOM_RANGE_RATIO: 1
+    MAX_MODEL_LEN: 2248 # ISL + OSL + 200
+    EXTRA_VLLM_ARGS: "--no-enable-prefix-caching"
+        
+    # AMD performance flags
+    VLLM_ROCM_USE_AITER: 1
+    
+  profiler:
+    torch_profiler:
+      enabled: true
+    system_profiler:
+      enabled: false
+
+  gap_analysis:
+    enabled: true
+    top_k: 100
+    find_kernel_sources: true
+
+  docker_image: "vllm/vllm-openai-rocm:v0.19.1"
+  benchmark_script: "vllm_mi355x.sh"
+
+  timeout_seconds: 3600

--- a/examples/benchmarks/benchmark_vllm_gptoss_120b.yaml
+++ b/examples/benchmarks/benchmark_vllm_gptoss_120b.yaml
@@ -37,10 +37,12 @@ benchmark:
     tracelens:
       enabled: false
 
-  # docker_image: "vllm/vllm-openai-rocm:v0.15.1"
-  # benchmark_script: "vllm_mi355x.sh"
+  docker_image: "vllm/vllm-openai-rocm:v0.19.1"
+  benchmark_script: "vllm_mi355x.sh"
 
   gap_analysis:
-    enabled: false
+    enabled: true
+    top_k: 100
+    find_kernel_sources: true
 
   timeout_seconds: 5400

--- a/examples/benchmarks/benchmark_vllm_gptoss_20b.yaml
+++ b/examples/benchmarks/benchmark_vllm_gptoss_20b.yaml
@@ -44,5 +44,6 @@ benchmark:
   gap_analysis:
     enabled: true
     top_k: 100
+    find_kernel_sources: true
 
   timeout_seconds: 2700

--- a/examples/benchmarks/benchmark_vllm_qwen3_next_80b.yaml
+++ b/examples/benchmarks/benchmark_vllm_qwen3_next_80b.yaml
@@ -1,0 +1,44 @@
+# vLLM Benchmark Configuration Example
+# =====================================
+# This example shows how to benchmark vLLM with Qwen3-Next-80B-A3B-Instruct model.
+#
+# Usage:
+#   python -m Magpie benchmark --benchmark-config examples/benchmarks/benchmark_vllm_qwen3_next_80b.yaml
+#
+# Prerequisites:
+#   - Docker with GPU support
+#   - HuggingFace token (HF_TOKEN) for gated models
+
+benchmark:
+  framework: vllm
+  model: Qwen/Qwen3-Next-80B-A3B-Instruct
+  precision: fp8
+  run_mode: docker
+
+  envs:
+    TP: 1
+    CONC: 16
+    ISL: 1024
+    OSL: 1024
+    RANDOM_RANGE_RATIO: 1
+    MAX_MODEL_LEN: 2248 # ISL + OSL + 200
+    EXTRA_VLLM_ARGS: "--quantization fp8 --no-enable-prefix-caching"
+        
+    # AMD performance flags
+    VLLM_ROCM_USE_AITER: 1
+    
+  profiler:
+    torch_profiler:
+      enabled: true
+    system_profiler:
+      enabled: false
+
+  gap_analysis:
+    enabled: true
+    top_k: 100
+    find_kernel_sources: true
+
+  docker_image: "vllm/vllm-openai-rocm:v0.19.1"
+  benchmark_script: "vllm_mi355x.sh"
+
+  timeout_seconds: 3600

--- a/examples/benchmarks/benchmark_vllm_qwen3_next_80b_fp8.yaml
+++ b/examples/benchmarks/benchmark_vllm_qwen3_next_80b_fp8.yaml
@@ -11,7 +11,7 @@
 
 benchmark:
   framework: vllm
-  model: Qwen/Qwen3-Next-80B-A3B-Instruct
+  model: Qwen/Qwen3-Next-80B-A3B-Instruct-FP8
   precision: fp8
   run_mode: docker
 
@@ -22,7 +22,7 @@ benchmark:
     OSL: 1024
     RANDOM_RANGE_RATIO: 1
     MAX_MODEL_LEN: 2248 # ISL + OSL + 200
-    EXTRA_VLLM_ARGS: "--quantization fp8 --no-enable-prefix-caching"
+    EXTRA_VLLM_ARGS: "--no-enable-prefix-caching"
         
     # AMD performance flags
     VLLM_ROCM_USE_AITER: 1

--- a/skills/amd-kernel-source-finder/SKILL.md
+++ b/skills/amd-kernel-source-finder/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: amd-kernel-source-finder
+description: Find kernel source code, test files, and test commands for AMD GPU kernels identified in profiler traces. Use when the user wants to locate kernel implementations, find tests for specific kernels, or enrich gap_analysis results with source information. Supports Triton JIT (ROCm), Tensile GEMM (rocBLAS), CK Tile, hipBLASLt, and HIP kernels.
+---
+
+# AMD Kernel Source Finder
+
+Find source code locations and test cases for **AMD GPU kernels** (ROCm/HIP) identified in profiler traces.
+
+> **Note:** This skill is specifically designed for AMD GPUs. It supports kernels from ROCm libraries including Composable Kernel (CK), hipBLASLt, rocBLAS, and Triton on ROCm.
+
+## Workflow
+
+This skill works with Magpie's gap_analysis output. The workflow is:
+
+### Step 1: Run Profiling and Gap Analysis
+
+First, generate a `gap_analysis.csv` with kernel statistics:
+
+```bash
+# Use Magpie CLI
+magpie benchmark --config benchmark.yaml
+```
+
+### Step 2: Find Kernel Sources
+
+**Option A: Automatic Enrichment (Recommended)**
+
+Enable `find_kernel_sources` in your benchmark config:
+
+```yaml
+gap_analysis:
+  enabled: true
+  find_kernel_sources: true
+  kernel_source_repos:
+    - <path-to-rocm-libraries>
+    - <path-to-triton>
+```
+
+**Option B: Manual Search by Agent**
+
+If you already have a `gap_analysis.csv`, ask the agent to find sources for specific kernels.
+
+## When to Use This Skill
+
+- User has a `gap_analysis.csv` and wants source/test info for specific kernels
+- User asks "where is this kernel defined?" with a kernel name
+- User wants to run tests for kernels identified as performance bottlenecks
+
+## Prerequisites
+
+Clone the relevant repositories for source searching:
+
+| Repository | URL | Contains |
+|------------|-----|----------|
+| rocm-libraries | `https://github.com/ROCm/rocm-libraries` | CK, hipBLASLt, rocBLAS |
+| triton | `https://github.com/triton-lang/triton` | Triton JIT kernels |
+| vllm | `https://github.com/vllm-project/vllm` | vLLM kernels |
+| pytorch | `https://github.com/pytorch/pytorch` | ATen native kernels |
+
+## Kernel Classification
+
+### 1. Triton JIT Kernels (`triton_jit`)
+
+**Pattern:** `<function_name>.kd` or `<function_name>_<config>.kd`
+
+**Examples:**
+- `_matmul_ogs_NNT_bf16xbf16xmxfp4_32x256x128x1_swiglu.kd` → function: `_matmul_ogs`
+- `kernel_unified_attention_3d.kd` → function: `kernel_unified_attention`
+- `triton_poi_fused_0.kd` → torch.compile/inductor generated
+
+**Source locations:**
+- `triton/python/triton_kernels/triton_kernels/` - triton_kernels package
+- `vllm/vllm/` - vLLM Triton kernels
+
+**Test locations:**
+- `triton/python/triton_kernels/tests/test_*.py`
+- `vllm/tests/kernels/`
+
+### 2. Tensile GEMM Kernels (`tensile_gemm`)
+
+**Pattern:** `Cijk_<layout>_<options>_MT<M>x<N>x<K>_..._WG<x>_<y>_<z>.kd`
+
+**Example:**
+- `Cijk_Alik_Bljk_BBS_BH_MT32x64x256_MI16x16x1_WG16_8_2.kd`
+
+**Key tokens:**
+- `Alik` = A transposed, `Bljk` = B not transposed
+- `MT<M>x<N>x<K>` = tile sizes
+- `MI<m>x<n>x<k>` = MFMA instruction
+- `WG<x>_<y>_<z>` = workgroup size
+
+**Source:** `rocm-libraries/projects/rocblas/` or Tensile generated
+
+**Test:** `rocblas-bench -f gemm_ex --a_type bf16_r --b_type bf16_r`
+
+### 3. Composable Kernel Tiles (`ck_tile`)
+
+**Pattern:** `_ZN7ck_tile<len>kentryILi<N>ENS_<OpName>...`
+
+**Examples:**
+- `_ZN7ck_tile6kentryILi1ENS_12Rmsnorm2dFwd...` → Op: `Rmsnorm2dFwd`
+- Contains `Fmha` → Flash attention
+- Contains `DF16b` → bf16 dtype
+
+**Source:** `rocm-libraries/projects/composablekernel/include/ck_tile/ops/`
+
+**Test:** `rocm-libraries/projects/composablekernel/example/ck_tile/`
+
+### 4. ATen Native Kernels (`aten_native`)
+
+**Pattern:** `void at::native::<kernel_template><...>(...) [clone .kd]`
+
+**Examples:**
+- `vectorized_elementwise_kernel<4, FillFunctor...` → Fill kernel
+- `reduce_kernel<512, 1, ...` → Reduce kernel
+
+**Key tokens:**
+- `FillFunctor` → `torch.fill_`, `torch.zeros`
+- `CompareEqFunctor` → `torch.eq`
+- `direct_copy_kernel_cuda` → `torch.Tensor.to`
+
+**Source:** `pytorch/aten/src/ATen/native/cuda/`
+
+**Test:** `pytest pytorch/test/test_torch.py -k <op_name>`
+
+### 5. HIP/CUDA C++ Kernels (`hip_cpp`)
+
+**Pattern:** `void <namespace>::<kernel_name><templates>(...) [clone .kd]`
+
+**Examples:**
+- `void vllm::reshape_and_cache_flash_kernel<...` → vLLM cache kernel
+- `void wvSplitK_hf_sml_<__hip_bfloat16, 64...` → hipBLASLt WMMA kernel
+
+**Source locations:**
+- `vllm/csrc/*.cu` - vLLM HIP kernels
+- `rocm-libraries/projects/hipblaslt/` - hipBLASLt kernels
+
+## Agent Instructions
+
+### If user has NO gap_analysis.csv:
+1. Guide them to run profiling first:
+   ```bash
+   magpie benchmark --config <config.yaml>
+   ```
+2. Suggest enabling `find_kernel_sources: true` for automatic source finding
+
+### If user HAS a gap_analysis.csv:
+1. Read the CSV to identify top kernels by `% Total` or `Self CUDA total (us)`
+2. Classify each kernel using the patterns above
+3. Ask user for repo paths if not provided
+4. Search and provide source file + test command
+
+### If user asks about a specific kernel name:
+1. Classify by name pattern
+2. Identify the likely source repository
+3. Provide: source file path, test command
+
+## Category Classification
+
+| Category | Keywords in kernel name |
+|----------|------------------------|
+| `attention` | `attention`, `fmha`, `Fmha` |
+| `gemm` | `gemm`, `matmul`, `Cijk_`, `wvSplitK` |
+| `moe_gemm` | `matmul_ogs`, `_ogs_` |
+| `layernorm` | `rmsnorm`, `layernorm`, `Rmsnorm` |
+| `softmax` | `softmax`, `Softmax` |
+| `elementwise` | `elementwise`, `Fill`, `copy` |
+| `reduce` | `reduce`, `sum`, `argmax` |
+| `router` | `topk`, `bitmatrix`, `routing` |
+| `kv_cache` | `reshape_and_cache`, `cache` |
+
+## Programmatic Usage
+
+```python
+from Magpie.tools.amd_kernel_finder import KernelSourceFinder
+
+# Initialize with user's repo paths
+finder = KernelSourceFinder(repos=[
+    "<path-to-rocm-libraries>",
+    "<path-to-triton>",
+])
+
+# Search for a kernel
+result = finder.search("_matmul_ogs_NNT_bf16xbf16xmxfp4.kd")
+print(f"Kind: {result.kind}")
+print(f"Category: {result.category}")
+print(f"Source: {result.source_file}")
+print(f"Test: {result.test_cmd}")
+```
+
+## YAML Config
+
+```yaml
+gap_analysis:
+  enabled: true
+  find_kernel_sources: true
+  kernel_source_repos:
+    - <path-to-rocm-libraries>
+    - <path-to-triton>
+    # Add other repos as needed
+```


### PR DESCRIPTION
- Add amd_kernel_finder module to find kernel source files and tests
- Support Triton JIT, Tensile GEMM, CK tile, hipBLASLt, ATen kernels
- Auto-clone repos on-demand, Python search fallback if no ripgrep
- Add --find-kernel-sources CLI flag for standalone gap_analysis
- Add amd-kernel-source-finder skill for agent guidance
- add more benchamrk examples