### PR TITLE
feat(benchmark): add sweep_matrix for single-server multi-case sweeps

### DIFF
--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -770,12 +770,18 @@ class BenchmarkMode:
     @staticmethod
     def _sweep_case_tag(index: int, case_envs: Dict[str, Any]) -> str:
         """Create a deterministic filesystem-safe sweep case tag."""
+        import re
+        def _safe(v: Any) -> str:
+            return re.sub(r"[^a-zA-Z0-9._-]", "", str(v))
+
         parts = [f"{index:02d}"]
         for key in ("CONC", "ISL", "OSL"):
             if key in case_envs:
-                parts.append(f"{key.lower()}{case_envs[key]}")
+                parts.append(f"{key.lower()}{_safe(case_envs[key])}")
         if len(parts) == 1:
-            parts.extend(f"{str(k).lower()}{v}" for k, v in sorted(case_envs.items()))
+            parts.extend(
+                f"{str(k).lower()}{_safe(v)}" for k, v in sorted(case_envs.items())
+            )
         return "_".join(parts)
 
     @staticmethod

--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -9,12 +9,15 @@ Core benchmarker for benchmark mode.
 Orchestrates benchmark execution using InferenceX as backend.
 """
 
+import json
 import logging
 import os
 import signal
 import shutil
 import subprocess
 import time
+import urllib.error
+import urllib.request
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
@@ -156,21 +159,28 @@ class BenchmarkMode:
         
         # 5-7. Build and execute (Docker or local)
         if self.config.is_local:
-            local_cmd, local_env = self._build_local_command(
-                workspace=workspace,
-                runner_type=runner_type,
-            )
-            logger.info("Running benchmark locally (no Docker)")
-            logger.debug(f"Local command: {' '.join(local_cmd)}")
-
-            symlink = self._create_workspace_symlink(workspace)
-            try:
-                result, stdout, stderr = self._execute_local_benchmark(
-                    local_cmd, local_env, workspace,
+            if self.config.is_sweep:
+                logger.info("Running local benchmark sweep (single shared server)")
+                result, stdout, stderr = self._execute_local_sweep(
+                    workspace=workspace,
+                    runner_type=runner_type,
                 )
-            finally:
-                self._remove_workspace_symlink(symlink)
-                self._cleanup_server_processes(self.config.framework)
+            else:
+                local_cmd, local_env = self._build_local_command(
+                    workspace=workspace,
+                    runner_type=runner_type,
+                )
+                logger.info("Running benchmark locally (no Docker)")
+                logger.debug(f"Local command: {' '.join(local_cmd)}")
+
+                symlink = self._create_workspace_symlink(workspace)
+                try:
+                    result, stdout, stderr = self._execute_local_benchmark(
+                        local_cmd, local_env, workspace,
+                    )
+                finally:
+                    self._remove_workspace_symlink(symlink)
+                    self._cleanup_server_processes(self.config.framework)
         else:
             docker_image = self._select_image()
             docker_cmd = self._build_docker_command(
@@ -556,6 +566,8 @@ class BenchmarkMode:
         self,
         workspace: Path,
         runner_type: str,
+        phase: str = "all",
+        case_envs: Optional[Dict[str, Any]] = None,
     ) -> tuple:
         """
         Build command and environment for local (non-Docker) execution.
@@ -567,6 +579,8 @@ class BenchmarkMode:
         Args:
             workspace: Workspace directory path
             runner_type: InferenceX runner type
+            phase: Runner phase: "all", "server", or "client".
+            case_envs: Per-case environment overrides for client phase.
         
         Returns:
             Tuple of (command list, environment dict)
@@ -585,6 +599,7 @@ class BenchmarkMode:
         env_vars["RESULT_FILENAME"] = "inferencex_result"
         env_vars["RESULT_DIR"] = str(workspace)
         env_vars["RUNNER_TYPE"] = runner_type
+        env_vars["MAGPIE_RUN_PHASE"] = phase
 
         if self.config.profiler.torch_profiler.enabled:
             torch_trace_dir = workspace / "torch_trace"
@@ -599,16 +614,338 @@ class BenchmarkMode:
 
         env_vars["SERVER_LOG"] = str(workspace / "server.log")
 
+        if phase == "client" and case_envs:
+            for key, value in case_envs.items():
+                env_vars[str(key).upper()] = str(value)
+
         for key, value in env_vars.items():
             env[key] = str(value)
 
         return cmd, env
+
+    def _execute_local_sweep(
+        self,
+        workspace: Path,
+        runner_type: str,
+    ) -> Tuple[BenchmarkResult, str, str]:
+        """
+        Execute a sweep matrix with one shared local server.
+
+        The runner shell is invoked once in server phase, then once per case in
+        client phase. Per-case raw outputs remain in case subdirectories, while
+        the best case is copied to the sweep root for legacy result parsing.
+        """
+        result = BenchmarkResult(
+            framework=self.config.framework,
+            model=self.config.model,
+        )
+        stdout_parts: List[str] = []
+        stderr_parts: List[str] = []
+        cases: List[Dict[str, Any]] = []
+        best_case: Optional[Dict[str, Any]] = None
+        best_result_file: Optional[Path] = None
+        server_proc: Optional[subprocess.Popen] = None
+        server_pid: Optional[int] = None
+        server_log = workspace / "server.log"
+        server_pid_file = workspace / "server.pid"
+        sweep_cfg = self.config.sweep_matrix
+        assert sweep_cfg is not None
+
+        port = int(self.config.envs.get("PORT", 8888))
+        self._cleanup_server_processes(self.config.framework)
+
+        try:
+            server_cmd, server_env = self._build_local_command(
+                workspace=workspace,
+                runner_type=runner_type,
+                phase="server",
+            )
+            server_env["MAGPIE_SERVER_PID_FILE"] = str(server_pid_file)
+            server_env["SERVER_LOG"] = str(server_log)
+
+            logger.info("Sweep: launching shared server")
+            server_stdout = open(workspace / "server_phase_stdout.log", "w")
+            server_stderr = open(workspace / "server_phase_stderr.log", "w")
+            try:
+                server_proc = subprocess.Popen(
+                    server_cmd,
+                    env=server_env,
+                    stdout=server_stdout,
+                    stderr=server_stderr,
+                    start_new_session=True,
+                    text=True,
+                )
+            finally:
+                server_stdout.close()
+                server_stderr.close()
+
+            if not self._wait_sweep_server_ready(
+                port=port,
+                process=server_proc,
+                timeout_seconds=sweep_cfg.server_ready_timeout_s,
+            ):
+                result.success = False
+                result.errors.append(
+                    "Sweep server failed to become ready. "
+                    f"See {server_log} and server_phase_stderr.log."
+                )
+                return result, "", self._read_tail(server_log)
+
+            server_pid = self._read_server_pid(server_pid_file)
+            logger.info("Sweep: server ready; running %d cases", len(sweep_cfg.cases))
+
+            for index, raw_case in enumerate(sweep_cfg.cases):
+                if not self._is_sweep_server_alive(port, server_proc):
+                    msg = "Sweep server stopped before case execution completed"
+                    logger.error(msg)
+                    result.errors.append(msg)
+                    break
+
+                case_envs = {str(k).upper(): v for k, v in raw_case.items()}
+                case_tag = self._sweep_case_tag(index, case_envs)
+                case_workspace = workspace / f"case_{case_tag}"
+                case_workspace.mkdir(parents=True, exist_ok=True)
+
+                case_cmd, case_env = self._build_local_command(
+                    workspace=case_workspace,
+                    runner_type=runner_type,
+                    phase="client",
+                    case_envs=case_envs,
+                )
+                logger.info("Sweep case %s: %s", case_tag, case_envs)
+                case_result, case_stdout, case_stderr = self._execute_local_benchmark(
+                    case_cmd,
+                    case_env,
+                    case_workspace,
+                    timeout_seconds=sweep_cfg.per_client_timeout_s,
+                )
+                stdout_parts.append(case_stdout)
+                stderr_parts.append(case_stderr)
+
+                case_summary = self._summarize_sweep_case(
+                    case_workspace,
+                    case_envs,
+                    case_result,
+                )
+                cases.append(case_summary)
+
+                if case_summary["success"]:
+                    current_tput = case_summary["throughput"]["output_throughput"]
+                    best_tput = (
+                        best_case["throughput"]["output_throughput"]
+                        if best_case is not None
+                        else -1
+                    )
+                    if current_tput > best_tput:
+                        best_case = case_summary
+                        best_result_file = case_workspace / "inferencex_result.json"
+                elif sweep_cfg.on_failure == "abort":
+                    result.errors.append(f"Sweep aborted at failed case {case_tag}")
+                    break
+
+                if index < len(sweep_cfg.cases) - 1:
+                    time.sleep(sweep_cfg.inter_client_sleep_s)
+
+            if best_result_file and best_result_file.exists():
+                shutil.copy2(best_result_file, workspace / "inferencex_result.json")
+                parsed = ResultParser.parse_inferencex_result(
+                    best_result_file,
+                    framework=self.config.framework,
+                    model=self.config.model,
+                )
+                result.throughput = parsed.throughput
+                result.latency = parsed.latency
+                result.raw_result = parsed.raw_result
+
+            result.success = best_case is not None
+            if not result.success and not result.errors:
+                result.errors.append("Sweep completed without a successful case")
+
+            self._save_sweep_artifacts(workspace, cases, best_case)
+            return result, "\n".join(stdout_parts), "\n".join(stderr_parts)
+        finally:
+            self._stop_sweep_server(server_proc, server_pid)
+            self._cleanup_server_processes(self.config.framework)
+
+    @staticmethod
+    def _sweep_case_tag(index: int, case_envs: Dict[str, Any]) -> str:
+        """Create a deterministic filesystem-safe sweep case tag."""
+        parts = [f"{index:02d}"]
+        for key in ("CONC", "ISL", "OSL"):
+            if key in case_envs:
+                parts.append(f"{key.lower()}{case_envs[key]}")
+        if len(parts) == 1:
+            parts.extend(f"{str(k).lower()}{v}" for k, v in sorted(case_envs.items()))
+        return "_".join(parts)
+
+    @staticmethod
+    def _read_tail(path: Path, max_chars: int = 4000) -> str:
+        """Read the end of a text file for diagnostics."""
+        try:
+            return path.read_text(errors="replace")[-max_chars:]
+        except OSError:
+            return ""
+
+    @staticmethod
+    def _read_server_pid(path: Path) -> Optional[int]:
+        """Read the persisted server PID written by the runner shell."""
+        try:
+            return int(path.read_text().strip())
+        except (OSError, ValueError):
+            return None
+
+    @staticmethod
+    def _is_http_healthy(port: int) -> bool:
+        """Return True when the local OpenAI-compatible server is healthy."""
+        try:
+            with urllib.request.urlopen(f"http://0.0.0.0:{port}/health", timeout=3) as resp:
+                return 200 <= resp.status < 400
+        except (urllib.error.URLError, TimeoutError, OSError):
+            return False
+
+    def _wait_sweep_server_ready(
+        self,
+        port: int,
+        process: subprocess.Popen,
+        timeout_seconds: int,
+    ) -> bool:
+        """Wait until the sweep server passes /health or exits."""
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            if process.poll() is not None:
+                logger.error(
+                    "Sweep server runner exited before readiness (code=%s)",
+                    process.returncode,
+                )
+                return False
+            if self._is_http_healthy(port):
+                return True
+            time.sleep(5)
+        return False
+
+    def _is_sweep_server_alive(
+        self,
+        port: int,
+        process: Optional[subprocess.Popen],
+    ) -> bool:
+        """Check both runner process state and /health for the sweep server."""
+        if process is not None and process.poll() is not None:
+            return False
+        return self._is_http_healthy(port)
+
+    @staticmethod
+    def _stop_sweep_server(
+        process: Optional[subprocess.Popen],
+        server_pid: Optional[int],
+    ) -> None:
+        """Stop the sweep server and its process group."""
+        if server_pid:
+            try:
+                os.killpg(server_pid, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError, OSError):
+                try:
+                    os.kill(server_pid, signal.SIGTERM)
+                except (ProcessLookupError, PermissionError, OSError):
+                    pass
+
+        if process is not None and process.poll() is None:
+            try:
+                process.terminate()
+                process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+            except OSError:
+                pass
+
+        if server_pid:
+            try:
+                os.killpg(server_pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+
+    def _summarize_sweep_case(
+        self,
+        workspace: Path,
+        case_envs: Dict[str, Any],
+        case_result: BenchmarkResult,
+    ) -> Dict[str, Any]:
+        """Parse and summarize a single sweep case result."""
+        summary: Dict[str, Any] = {
+            "envs": dict(case_envs),
+            "workspace": str(workspace),
+            "success": False,
+            "throughput": None,
+            "latency": None,
+            "errors": list(case_result.errors),
+        }
+        result_file = workspace / "inferencex_result.json"
+        parsed = ResultParser.parse_inferencex_result(
+            result_file,
+            framework=self.config.framework,
+            model=self.config.model,
+        )
+        if parsed.errors:
+            summary["errors"].extend(parsed.errors)
+        if parsed.throughput:
+            summary["throughput"] = parsed.throughput.to_dict()
+        if parsed.latency:
+            summary["latency"] = parsed.latency.to_dict()
+        summary["success"] = bool(case_result.success and self._validate_results(parsed))
+        return summary
+
+    def _save_sweep_artifacts(
+        self,
+        workspace: Path,
+        cases: List[Dict[str, Any]],
+        best_case: Optional[Dict[str, Any]],
+    ) -> None:
+        """Write machine-readable and TSV sweep summaries."""
+        report = {
+            "framework": self.config.framework,
+            "model": self.config.model,
+            "success": best_case is not None,
+            "best_case": best_case,
+            "cases": cases,
+        }
+        try:
+            with open(workspace / "sweep_report.json", "w") as f:
+                json.dump(report, f, indent=2)
+        except OSError as e:
+            logger.warning("Failed to write sweep_report.json: %s", e)
+
+        try:
+            tp = int(self.config.envs.get("TP", 1))
+        except (TypeError, ValueError):
+            tp = 1
+
+        try:
+            with open(workspace / "results.tsv", "w") as f:
+                f.write(
+                    "CONC\tISL\tOSL\toutput_tput\ttput_per_gpu\t"
+                    "TPOT_mean\tTTFT_mean\tsuccess\n"
+                )
+                for case in cases:
+                    envs = case["envs"]
+                    throughput = case.get("throughput") or {}
+                    latency = case.get("latency") or {}
+                    tpot = (latency.get("tpot") or {}).get("mean_ms", 0.0)
+                    ttft = (latency.get("ttft") or {}).get("mean_ms", 0.0)
+                    output_tput = throughput.get("output_throughput", 0.0) or 0.0
+                    f.write(
+                        f"{envs.get('CONC', '')}\t{envs.get('ISL', '')}\t"
+                        f"{envs.get('OSL', '')}\t{output_tput:.2f}\t"
+                        f"{output_tput / tp:.2f}\t{tpot:.2f}\t{ttft:.2f}\t"
+                        f"{int(case.get('success', False))}\n"
+                    )
+        except OSError as e:
+            logger.warning("Failed to write results.tsv: %s", e)
 
     def _execute_local_benchmark(
         self,
         cmd: List[str],
         env: Dict[str, str],
         workspace: Path,
+        timeout_seconds: Optional[float] = None,
     ) -> tuple:
         """
         Execute benchmark locally (no Docker).
@@ -617,6 +954,7 @@ class BenchmarkMode:
             cmd: Shell command list
             env: Environment variables
             workspace: Workspace directory for saving logs
+            timeout_seconds: Optional override for subprocess timeout
         
         Returns:
             Tuple of (BenchmarkResult, stdout, stderr)
@@ -630,7 +968,7 @@ class BenchmarkMode:
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=self.config.timeout_seconds,
+                timeout=timeout_seconds or self.config.timeout_seconds,
                 env=env,
             )
 
@@ -657,7 +995,7 @@ class BenchmarkMode:
 
         except subprocess.TimeoutExpired as e:
             result.errors.append(
-                f"Benchmark timed out after {self.config.timeout_seconds}s"
+                f"Benchmark timed out after {timeout_seconds or self.config.timeout_seconds}s"
             )
             logger.error("Benchmark timed out")
 

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -489,6 +489,76 @@ class GpuSelectionConfig:
 
 
 @dataclass
+class SweepMatrix:
+    """
+    Client-side sweep cases that reuse a single server.
+
+    Server-side settings (TP, framework, EXTRA_*_ARGS, memory fraction, and
+    backend flags) must remain fixed in BenchmarkConfig.envs. Each case may
+    only override request/client parameters used by benchmark_serving.py.
+    """
+
+    cases: List[Dict[str, Any]] = field(default_factory=list)
+    on_failure: str = "continue"
+    inter_client_sleep_s: int = 5
+    per_client_timeout_s: int = 1800
+    server_ready_timeout_s: int = 2700
+
+    _ALLOWED_CASE_KEYS = {
+        "CONC",
+        "ISL",
+        "OSL",
+        "NUM_PROMPTS",
+        "RANDOM_RANGE_RATIO",
+    }
+
+    def __post_init__(self):
+        """Validate sweep behavior and case override keys."""
+        if self.on_failure not in ("continue", "abort"):
+            raise ValueError(
+                "sweep_matrix.on_failure must be 'continue' or 'abort', "
+                f"got {self.on_failure!r}"
+            )
+        if not isinstance(self.cases, list):
+            raise ValueError("sweep_matrix.cases must be a list of dictionaries")
+        for i, case in enumerate(self.cases):
+            if not isinstance(case, dict):
+                raise ValueError(
+                    f"sweep_matrix.cases[{i}] must be a dictionary, "
+                    f"got {type(case).__name__}"
+                )
+            unknown = {str(k).upper() for k in case} - self._ALLOWED_CASE_KEYS
+            if unknown:
+                allowed = ", ".join(sorted(self._ALLOWED_CASE_KEYS))
+                bad = ", ".join(sorted(unknown))
+                raise ValueError(
+                    f"sweep_matrix.cases[{i}] has unsupported key(s): {bad}. "
+                    f"Allowed keys: {allowed}"
+                )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "cases": self.cases,
+            "on_failure": self.on_failure,
+            "inter_client_sleep_s": self.inter_client_sleep_s,
+            "per_client_timeout_s": self.per_client_timeout_s,
+            "server_ready_timeout_s": self.server_ready_timeout_s,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SweepMatrix":
+        """Create from dictionary."""
+        return cls(
+            cases=data.get("cases", []),
+            on_failure=data.get("on_failure", "continue"),
+            inter_client_sleep_s=int(data.get("inter_client_sleep_s", 5)),
+            per_client_timeout_s=int(data.get("per_client_timeout_s", 1800)),
+            server_ready_timeout_s=int(data.get("server_ready_timeout_s", 2700)),
+        )
+
+
+@dataclass
 class BenchmarkConfig:
     """
     Configuration for benchmark mode.
@@ -546,6 +616,9 @@ class BenchmarkConfig:
     # Ray remote execution configuration (used when run_mode="ray")
     ray_config: Optional[RayConfig] = None
 
+    # Client-side sweep matrix (local mode only)
+    sweep_matrix: Optional[SweepMatrix] = None
+
     def __post_init__(self):
         """Validate and set defaults."""
         # Normalize framework name
@@ -588,9 +661,25 @@ class BenchmarkConfig:
         if isinstance(self.ray_config, dict):
             self.ray_config = RayConfig.from_dict(self.ray_config)
 
+        # Convert sweep_matrix dict to SweepMatrix if needed
+        if isinstance(self.sweep_matrix, dict):
+            self.sweep_matrix = SweepMatrix.from_dict(self.sweep_matrix)
+
         # Ensure ray_config exists when run_mode is "ray"
         if self.run_mode == "ray" and self.ray_config is None:
             self.ray_config = RayConfig()
+
+        if self.is_sweep:
+            if self.run_mode != "local":
+                raise ValueError(
+                    "sweep_matrix is only supported with run_mode='local'. "
+                    "For Ray/Claw, run Magpie inside the Ray worker via exec_on_gpu."
+                )
+            if self.profiler.torch_profiler.enabled:
+                raise ValueError(
+                    "sweep_matrix is incompatible with torch_profiler.enabled=True. "
+                    "Use a single benchmark config for profiling."
+                )
 
     def get_env_vars(self) -> Dict[str, str]:
         """
@@ -640,6 +729,11 @@ class BenchmarkConfig:
         """Check if running in Ray remote execution mode."""
         return self.run_mode == "ray"
 
+    @property
+    def is_sweep(self) -> bool:
+        """Check if benchmark should run a client-side sweep."""
+        return self.sweep_matrix is not None and bool(self.sweep_matrix.cases)
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
         d: Dict[str, Any] = {
@@ -661,6 +755,8 @@ class BenchmarkConfig:
         }
         if self.ray_config is not None:
             d["ray_config"] = self.ray_config.to_dict()
+        if self.sweep_matrix is not None:
+            d["sweep_matrix"] = self.sweep_matrix.to_dict()
         return d
 
     @classmethod
@@ -680,6 +776,9 @@ class BenchmarkConfig:
 
         ray_data = data.get("ray_config")
         ray_config = RayConfig.from_dict(ray_data) if ray_data else None
+
+        sweep_data = data.get("sweep_matrix")
+        sweep_matrix = SweepMatrix.from_dict(sweep_data) if sweep_data else None
 
         return cls(
             framework=data.get("framework", "sglang"),
@@ -702,4 +801,5 @@ class BenchmarkConfig:
             benchmark_script=data.get("benchmark_script"),
             gpu_selection=GpuSelectionConfig.from_dict(data.get("gpu_selection") or {}),
             ray_config=ray_config,
+            sweep_matrix=sweep_matrix,
         )

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -676,10 +676,12 @@ class BenchmarkConfig:
                     "For Ray/Claw, run Magpie inside the Ray worker via exec_on_gpu."
                 )
             if self.profiler.torch_profiler.enabled:
-                raise ValueError(
-                    "sweep_matrix is incompatible with torch_profiler.enabled=True. "
-                    "Use a single benchmark config for profiling."
+                import logging as _logging
+                _logging.getLogger(__name__).warning(
+                    "sweep_matrix: auto-disabling torch_profiler (profiling is "
+                    "incompatible with sweep mode; use a single benchmark for profiling)"
                 )
+                self.profiler.torch_profiler.enabled = False
 
     def get_env_vars(self) -> Dict[str, str]:
         """

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -675,13 +675,16 @@ class BenchmarkConfig:
                     "sweep_matrix is only supported with run_mode='local'. "
                     "For Ray/Claw, run Magpie inside the Ray worker via exec_on_gpu."
                 )
+            # By the time __post_init__ runs, from_dict has already silently
+            # turned off the default torch_profiler when the caller did not
+            # explicitly set it. If torch_profiler is still enabled here, the
+            # caller did set it on purpose, so fail fast.
             if self.profiler.torch_profiler.enabled:
-                import logging as _logging
-                _logging.getLogger(__name__).warning(
-                    "sweep_matrix: auto-disabling torch_profiler (profiling is "
-                    "incompatible with sweep mode; use a single benchmark for profiling)"
+                raise ValueError(
+                    "sweep_matrix is incompatible with explicit "
+                    "profiler.torch_profiler.enabled=true. Use a single "
+                    "benchmark config for profiling, or remove the explicit flag."
                 )
-                self.profiler.torch_profiler.enabled = False
 
     def get_env_vars(self) -> Dict[str, str]:
         """
@@ -765,6 +768,33 @@ class BenchmarkConfig:
     def from_dict(cls, data: Dict[str, Any]) -> "BenchmarkConfig":
         """Create from dictionary."""
         profiler_data = data.get("profiler", {})
+
+        # Detect whether the caller explicitly set torch_profiler.enabled.
+        # When sweep_matrix is present and enabled was NOT explicitly set, we
+        # auto-disable torch_profiler so the user does not have to add a
+        # boilerplate `profiler.torch_profiler.enabled: false` to every sweep
+        # YAML. When the caller explicitly enables the profiler, we keep the
+        # existing behavior of failing fast (the two are incompatible).
+        sweep_data = data.get("sweep_matrix")
+        has_sweep = (
+            isinstance(sweep_data, dict)
+            and bool(sweep_data.get("cases"))
+        )
+        torch_data = (
+            profiler_data.get("torch_profiler", {})
+            if isinstance(profiler_data, dict)
+            else {}
+        )
+        torch_enabled_explicit = (
+            isinstance(torch_data, dict) and "enabled" in torch_data
+        )
+        if has_sweep and not torch_enabled_explicit:
+            new_profiler = dict(profiler_data) if isinstance(profiler_data, dict) else {}
+            new_torch = dict(torch_data) if isinstance(torch_data, dict) else {}
+            new_torch["enabled"] = False
+            new_profiler["torch_profiler"] = new_torch
+            profiler_data = new_profiler
+
         profiler = (
             ProfilerConfig.from_dict(profiler_data)
             if profiler_data

--- a/Magpie/scripts/benchmark/sglang_mi300x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi300x.sh
@@ -7,6 +7,10 @@ source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
 PHASE="${MAGPIE_RUN_PHASE:-all}"
+case "$PHASE" in
+  all|server|client) ;;
+  *) echo "ERROR: Invalid MAGPIE_RUN_PHASE='$PHASE'. Must be all|server|client." >&2; exit 2 ;;
+esac
 
 if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
   check_env_vars MODEL TP

--- a/Magpie/scripts/benchmark/sglang_mi300x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi300x.sh
@@ -6,20 +6,22 @@
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
-check_env_vars \
-    MODEL \
-    TP \
-    CONC \
-    ISL \
-    OSL \
-    RANDOM_RANGE_RATIO \
-    RESULT_FILENAME
+PHASE="${MAGPIE_RUN_PHASE:-all}"
+
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL TP
+fi
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL CONC ISL OSL RANDOM_RANGE_RATIO RESULT_FILENAME
+fi
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 fi
 
-hf download "$MODEL" 2>/dev/null || true
+if [[ "$PHASE" != "client" ]]; then
+  hf download "$MODEL" 2>/dev/null || true
+fi
 
 # MI300X specific: Check MEC firmware version for RCCL memory reclaim
 version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
@@ -51,22 +53,37 @@ for flag_val in "--mem-fraction-static=0.8" "--disable-radix-cache"; do
 done
 
 set -x
-setsid python3 -m sglang.launch_server \
-  --model-path=$MODEL \
-  --host=0.0.0.0 \
-  --port=$PORT \
-  --trust-remote-code \
-  --tensor-parallel-size=$TP \
-  $DEFAULT_ARGS \
-  $EXTRA_SGLANG_ARGS > $SERVER_LOG 2>&1 &
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  setsid python3 -m sglang.launch_server \
+    --model-path=$MODEL \
+    --host=0.0.0.0 \
+    --port=$PORT \
+    --trust-remote-code \
+    --tensor-parallel-size=$TP \
+    $DEFAULT_ARGS \
+    $EXTRA_SGLANG_ARGS > $SERVER_LOG 2>&1 &
 
-SERVER_PID=$!
-trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  SERVER_PID=$!
+  if [[ -n "${MAGPIE_SERVER_PID_FILE:-}" ]]; then
+    echo "$SERVER_PID" > "$MAGPIE_SERVER_PID_FILE"
+  fi
+  if [[ "$PHASE" == "all" ]]; then
+    trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  else
+    trap 'kill -TERM "-$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null; exit 0' INT TERM
+  fi
 
-# Wait for server to be ready
-wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+  # Wait for server to be ready
+  wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-run_benchmark_serving \
+  if [[ "$PHASE" == "server" ]]; then
+    wait "$SERVER_PID"
+    exit 0
+  fi
+fi
+
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  run_benchmark_serving \
     --model "$MODEL" \
     --port "$PORT" \
     --backend vllm \
@@ -77,9 +94,10 @@ run_benchmark_serving \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir ${RESULT_DIR:-/workspace/}
+fi
 
 # After throughput, run evaluation only if RUN_EVAL is true
-if [ "${RUN_EVAL}" = "true" ]; then
+if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
     run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
     append_lm_eval_summary
 fi

--- a/Magpie/scripts/benchmark/sglang_mi355x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi355x.sh
@@ -11,6 +11,10 @@ source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
 PHASE="${MAGPIE_RUN_PHASE:-all}"
+case "$PHASE" in
+  all|server|client) ;;
+  *) echo "ERROR: Invalid MAGPIE_RUN_PHASE='$PHASE'. Must be all|server|client." >&2; exit 2 ;;
+esac
 
 if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
   check_env_vars MODEL TP

--- a/Magpie/scripts/benchmark/sglang_mi355x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi355x.sh
@@ -10,20 +10,22 @@
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
-check_env_vars \
-    MODEL \
-    TP \
-    CONC \
-    ISL \
-    OSL \
-    RANDOM_RANGE_RATIO \
-    RESULT_FILENAME
+PHASE="${MAGPIE_RUN_PHASE:-all}"
+
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL TP
+fi
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL CONC ISL OSL RANDOM_RANGE_RATIO RESULT_FILENAME
+fi
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 fi
 
-hf download "$MODEL" 2>/dev/null || true
+if [[ "$PHASE" != "client" ]]; then
+  hf download "$MODEL" 2>/dev/null || true
+fi
 
 # MI355X specific: Check MEC firmware version for RCCL memory reclaim
 version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
@@ -55,22 +57,37 @@ for flag_val in "--mem-fraction-static=0.8" "--disable-radix-cache"; do
 done
 
 set -x
-setsid python3 -m sglang.launch_server \
-  --model-path=$MODEL \
-  --host=0.0.0.0 \
-  --port=$PORT \
-  --trust-remote-code \
-  --tensor-parallel-size=$TP \
-  $DEFAULT_ARGS \
-  $EXTRA_SGLANG_ARGS > $SERVER_LOG 2>&1 &
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  setsid python3 -m sglang.launch_server \
+    --model-path=$MODEL \
+    --host=0.0.0.0 \
+    --port=$PORT \
+    --trust-remote-code \
+    --tensor-parallel-size=$TP \
+    $DEFAULT_ARGS \
+    $EXTRA_SGLANG_ARGS > $SERVER_LOG 2>&1 &
 
-SERVER_PID=$!
-trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  SERVER_PID=$!
+  if [[ -n "${MAGPIE_SERVER_PID_FILE:-}" ]]; then
+    echo "$SERVER_PID" > "$MAGPIE_SERVER_PID_FILE"
+  fi
+  if [[ "$PHASE" == "all" ]]; then
+    trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  else
+    trap 'kill -TERM "-$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null; exit 0' INT TERM
+  fi
 
-# Wait for server to be ready
-wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+  # Wait for server to be ready
+  wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-run_benchmark_serving \
+  if [[ "$PHASE" == "server" ]]; then
+    wait "$SERVER_PID"
+    exit 0
+  fi
+fi
+
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  run_benchmark_serving \
     --model "$MODEL" \
     --port "$PORT" \
     --backend vllm \
@@ -81,9 +98,10 @@ run_benchmark_serving \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir ${RESULT_DIR:-/workspace/}
+fi
 
 # After throughput, run evaluation only if RUN_EVAL is true
-if [ "${RUN_EVAL}" = "true" ]; then
+if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
     run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
     append_lm_eval_summary
 fi

--- a/Magpie/scripts/benchmark/vllm_mi300x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi300x.sh
@@ -11,6 +11,10 @@ source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
 PHASE="${MAGPIE_RUN_PHASE:-all}"
+case "$PHASE" in
+  all|server|client) ;;
+  *) echo "ERROR: Invalid MAGPIE_RUN_PHASE='$PHASE'. Must be all|server|client." >&2; exit 2 ;;
+esac
 
 if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
   check_env_vars MODEL TP

--- a/Magpie/scripts/benchmark/vllm_mi300x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi300x.sh
@@ -10,14 +10,14 @@
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
-check_env_vars \
-    MODEL \
-    TP \
-    CONC \
-    ISL \
-    OSL \
-    RANDOM_RANGE_RATIO \
-    RESULT_FILENAME
+PHASE="${MAGPIE_RUN_PHASE:-all}"
+
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL TP
+fi
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL CONC ISL OSL RANDOM_RANGE_RATIO RESULT_FILENAME
+fi
 
 MAX_MODEL_LEN=${MAX_MODEL_LEN:-4096}
 
@@ -25,7 +25,9 @@ if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 fi
 
-hf download "$MODEL" 2>/dev/null || true
+if [[ "$PHASE" != "client" ]]; then
+  hf download "$MODEL" 2>/dev/null || true
+fi
 
 # MI300X specific: Check MEC firmware version for RCCL memory reclaim
 version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
@@ -61,21 +63,41 @@ if [[ "${PROFILE:-}" == "1" ]]; then
 fi
 
 set -x
-setsid vllm serve $MODEL --port $PORT \
-  --tensor-parallel-size=$TP \
-  --gpu-memory-utilization 0.95 \
-  --max-model-len $MAX_MODEL_LEN \
-  --trust-remote-code \
-  "${PROFILER_ARGS[@]}" \
-  $EXTRA_VLLM_ARGS > $SERVER_LOG 2>&1 &
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  setsid vllm serve $MODEL --port $PORT \
+    --tensor-parallel-size=$TP \
+    --gpu-memory-utilization 0.95 \
+    --max-model-len $MAX_MODEL_LEN \
+    --trust-remote-code \
+    "${PROFILER_ARGS[@]}" \
+    $EXTRA_VLLM_ARGS > $SERVER_LOG 2>&1 &
 
-SERVER_PID=$!
-trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  SERVER_PID=$!
+  if [[ -n "${MAGPIE_SERVER_PID_FILE:-}" ]]; then
+    echo "$SERVER_PID" > "$MAGPIE_SERVER_PID_FILE"
+  fi
+  if [[ "$PHASE" == "all" ]]; then
+    trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  else
+    trap 'kill -TERM "-$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null; exit 0' INT TERM
+  fi
 
-# Wait for server to be ready
-wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+  # Wait for server to be ready
+  wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-run_benchmark_serving \
+  if [[ "$PHASE" == "server" ]]; then
+    wait "$SERVER_PID"
+    exit 0
+  fi
+fi
+
+SERVER_MONITOR_ARGS=()
+if [[ -n "${SERVER_PID:-}" ]]; then
+  SERVER_MONITOR_ARGS+=(--server-pid "$SERVER_PID")
+fi
+
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  run_benchmark_serving \
     --model "$MODEL" \
     --port "$PORT" \
     --backend vllm \
@@ -86,11 +108,12 @@ run_benchmark_serving \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir "$WORKSPACE_DIR/" \
-    --server-pid "$SERVER_PID" \
+    "${SERVER_MONITOR_ARGS[@]}" \
     --trust-remote-code
+fi
 
 # After throughput, run evaluation only if RUN_EVAL is true
-if [ "${RUN_EVAL}" = "true" ]; then
+if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
     run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
     append_lm_eval_summary
 fi

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -11,6 +11,10 @@ source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
 PHASE="${MAGPIE_RUN_PHASE:-all}"
+case "$PHASE" in
+  all|server|client) ;;
+  *) echo "ERROR: Invalid MAGPIE_RUN_PHASE='$PHASE'. Must be all|server|client." >&2; exit 2 ;;
+esac
 
 if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
   check_env_vars MODEL TP

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -10,14 +10,14 @@
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
-check_env_vars \
-    MODEL \
-    TP \
-    CONC \
-    ISL \
-    OSL \
-    RANDOM_RANGE_RATIO \
-    RESULT_FILENAME
+PHASE="${MAGPIE_RUN_PHASE:-all}"
+
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL TP
+fi
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL CONC ISL OSL RANDOM_RANGE_RATIO RESULT_FILENAME
+fi
 
 MAX_MODEL_LEN=${MAX_MODEL_LEN:-4096}
 
@@ -25,7 +25,9 @@ if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 fi
 
-hf download "$MODEL" 2>/dev/null || true
+if [[ "$PHASE" != "client" ]]; then
+  hf download "$MODEL" 2>/dev/null || true
+fi
 
 # MI355X specific: Check MEC firmware version for RCCL memory reclaim
 version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
@@ -62,21 +64,41 @@ fi
 
 set -x
 # setsid: PG leader so magpie_stop_benchmark_server_stack can kill the whole tree.
-setsid vllm serve $MODEL --port $PORT \
-  --tensor-parallel-size=$TP \
-  --gpu-memory-utilization 0.95 \
-  --max-model-len $MAX_MODEL_LEN \
-  --trust-remote-code \
-  "${PROFILER_ARGS[@]}" \
-  $EXTRA_VLLM_ARGS > $SERVER_LOG 2>&1 &
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  setsid vllm serve $MODEL --port $PORT \
+    --tensor-parallel-size=$TP \
+    --gpu-memory-utilization 0.95 \
+    --max-model-len $MAX_MODEL_LEN \
+    --trust-remote-code \
+    "${PROFILER_ARGS[@]}" \
+    $EXTRA_VLLM_ARGS > $SERVER_LOG 2>&1 &
 
-SERVER_PID=$!
-trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  SERVER_PID=$!
+  if [[ -n "${MAGPIE_SERVER_PID_FILE:-}" ]]; then
+    echo "$SERVER_PID" > "$MAGPIE_SERVER_PID_FILE"
+  fi
+  if [[ "$PHASE" == "all" ]]; then
+    trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  else
+    trap 'kill -TERM "-$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null; exit 0' INT TERM
+  fi
 
-# Wait for server to be ready
-wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+  # Wait for server to be ready
+  wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-run_benchmark_serving \
+  if [[ "$PHASE" == "server" ]]; then
+    wait "$SERVER_PID"
+    exit 0
+  fi
+fi
+
+SERVER_MONITOR_ARGS=()
+if [[ -n "${SERVER_PID:-}" ]]; then
+  SERVER_MONITOR_ARGS+=(--server-pid "$SERVER_PID")
+fi
+
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  run_benchmark_serving \
     --model "$MODEL" \
     --port "$PORT" \
     --backend vllm \
@@ -87,11 +109,12 @@ run_benchmark_serving \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir "$WORKSPACE_DIR/" \
-    --server-pid "$SERVER_PID" \
+    "${SERVER_MONITOR_ARGS[@]}" \
     --trust-remote-code
+fi
 
 # After throughput, run evaluation only if RUN_EVAL is true
-if [ "${RUN_EVAL}" = "true" ]; then
+if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
     run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
     append_lm_eval_summary
 fi


### PR DESCRIPTION
Allow magpie benchmark to run an ISL/OSL/CONC sweep against one shared server instead of restarting the framework for every case, which amortizes the ~12 min CUDA graph capture across N cases.

- modes/benchmark/config.py: introduce SweepMatrix with strict validation. Only run_mode=local is supported, torch_profiler must be off, and case overrides are restricted to a whitelist of client-side env vars (CONC, ISL, OSL, NUM_PROMPTS, RANDOM_RANGE_RATIO).
- modes/benchmark/benchmarker.py: keep the single-point path untouched. When sweep_matrix is set, dispatch to _execute_local_sweep which launches the runner once in server phase, iterates clients, tears the server down in finally, and writes sweep_report.json plus results.tsv. The top-level inferencex_result.json is populated from the best case so legacy consumers keep working.
- scripts/benchmark/{sglang,vllm}_{mi300x,mi355x}.sh: honor MAGPIE_RUN_PHASE=all|server|client. all keeps the original behavior; server writes MAGPIE_SERVER_PID_FILE and parks until SIGTERM; client only runs benchmark_serving against the existing server. Skip hf download in client phase to avoid per-case overhead.

No new dependencies. Verified with python -m compileall and bash -n.