### PR TITLE
feat(benchmark): local server lifecycle reuse

### DIFF
--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -9,6 +9,7 @@ Core benchmarker for benchmark mode.
 Orchestrates benchmark execution using InferenceX as backend.
 """
 
+import json
 import logging
 import os
 import signal
@@ -16,6 +17,8 @@ import shutil
 import subprocess
 import time
 import uuid
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
@@ -34,6 +37,16 @@ from ...utils.gpu import detect_gpu, find_idle_gpus, GPUVendor
 from ...utils.gpu_monitor import GPUMonitor
 
 logger = logging.getLogger(__name__)
+
+# Scripts shipping with Magpie that honor MAGPIE_RUN_PHASE (server/client split).
+MAGPIE_BUILTIN_SCRIPTS = frozenset(
+    {
+        "vllm_mi300x.sh",
+        "vllm_mi355x.sh",
+        "sglang_mi300x.sh",
+        "sglang_mi355x.sh",
+    }
+)
 
 
 class BenchmarkMode:
@@ -102,9 +115,24 @@ class BenchmarkMode:
             )
             return result
         
-        # 0b. Optionally pick idle GPU(s) and pin VISIBLE_DEVICES
+        # 0b. Optionally pick idle GPU(s) and pin VISIBLE_DEVICES.
+        # When server_lifecycle will reuse an existing HTTP server, skip
+        # find_idle_gpus so ROCR/HIP/CUDA_VISIBLE_* are not reshuffled versus
+        # the already-running server's physical devices.
+        skip_idle_gpu_for_reuse = (
+            self.config.is_local
+            and self.config.is_server_lifecycle
+            and self._reuse_will_attach_to_existing_server()
+        )
         try:
-            self._apply_gpu_selection()
+            if skip_idle_gpu_for_reuse:
+                logger.info(
+                    "server_lifecycle: reusing eligible server on PORT=%s — "
+                    "skipping gpu_selection.auto (find_idle_gpus)",
+                    self._reuse_benchmark_port(),
+                )
+            else:
+                self._apply_gpu_selection()
         except RuntimeError as e:
             result = BenchmarkResult()
             result.success = False
@@ -156,21 +184,30 @@ class BenchmarkMode:
         
         # 5-7. Build and execute (Docker or local)
         if self.config.is_local:
-            local_cmd, local_env = self._build_local_command(
-                workspace=workspace,
-                runner_type=runner_type,
-            )
-            logger.info("Running benchmark locally (no Docker)")
-            logger.debug(f"Local command: {' '.join(local_cmd)}")
-
             symlink = self._create_workspace_symlink(workspace)
             try:
-                result, stdout, stderr = self._execute_local_benchmark(
-                    local_cmd, local_env, workspace,
-                )
+                if self.config.is_server_lifecycle:
+                    logger.info(
+                        "Running local benchmark with server lifecycle (reuse-aware)"
+                    )
+                    result, stdout, stderr = self._execute_local_benchmark_with_reuse(
+                        workspace=workspace,
+                        runner_type=runner_type,
+                    )
+                else:
+                    local_cmd, local_env = self._build_local_command(
+                        workspace=workspace,
+                        runner_type=runner_type,
+                    )
+                    logger.info("Running benchmark locally (no Docker)")
+                    logger.debug(f"Local command: {' '.join(local_cmd)}")
+                    result, stdout, stderr = self._execute_local_benchmark(
+                        local_cmd, local_env, workspace,
+                    )
             finally:
                 self._remove_workspace_symlink(symlink)
-                self._cleanup_server_processes(self.config.framework)
+                if not self.config.is_server_lifecycle:
+                    self._cleanup_server_processes(self.config.framework)
         else:
             docker_image = self._select_image()
             docker_cmd = self._build_docker_command(
@@ -560,18 +597,18 @@ class BenchmarkMode:
         self,
         workspace: Path,
         runner_type: str,
+        phase: str = "all",
+        server_pid_file: Optional[Path] = None,
     ) -> tuple:
         """
         Build command and environment for local (non-Docker) execution.
-        
-        Runs the benchmark script directly on the host via bash.
-        Useful when already inside a container/pod with the required
-        runtime (vLLM/SGLang) installed.
-        
+
         Args:
             workspace: Workspace directory path
             runner_type: InferenceX runner type
-        
+            phase: InferenceX MAGPIE_RUN_PHASE: ``all``, ``server``, or ``client``.
+            server_pid_file: Writes server PID during ``MAGPIE_RUN_PHASE=server``.
+
         Returns:
             Tuple of (command list, environment dict)
         """
@@ -589,6 +626,9 @@ class BenchmarkMode:
         env_vars["RESULT_FILENAME"] = "inferencex_result"
         env_vars["RESULT_DIR"] = str(workspace)
         env_vars["RUNNER_TYPE"] = runner_type
+        env_vars["MAGPIE_RUN_PHASE"] = phase
+        if phase == "server" and server_pid_file is not None:
+            env_vars["MAGPIE_SERVER_PID_FILE"] = str(server_pid_file)
 
         if self.config.profiler.torch_profiler.enabled:
             torch_trace_dir = workspace / "torch_trace"
@@ -608,11 +648,481 @@ class BenchmarkMode:
 
         return cmd, env
 
+    def _execute_local_benchmark_with_reuse(
+        self,
+        workspace: Path,
+        runner_type: str,
+    ) -> Tuple[BenchmarkResult, str, str]:
+        """
+        Launch or reuse one shared server, run only the benchmark client locally.
+
+        See ``BenchmarkConfig.server_lifecycle`` — requires a Magpie built-in shell
+        that implements ``MAGPIE_RUN_PHASE=server`` / ``client``.
+        """
+        lc = self.config.server_lifecycle
+        assert lc is not None
+
+        result = BenchmarkResult()
+        stdout_parts: List[str] = []
+        stderr_parts: List[str] = []
+
+        try:
+            rel_script = self._get_benchmark_script(runner_type)
+        except FileNotFoundError as exc:
+            result.success = False
+            result.errors.append(str(exc))
+            return result, "", ""
+
+        script_name = Path(rel_script).name
+        if script_name not in MAGPIE_BUILTIN_SCRIPTS:
+            result.success = False
+            result.errors.append(
+                "server_lifecycle requires a Magpie built-in InferenceX benchmark "
+                "script (vllm_mi300x.sh, vllm_mi355x.sh, sglang_mi300x.sh, "
+                f"sglang_mi355x.sh). Current resolved script={script_name}. "
+                "Set benchmark_script accordingly or omit server_lifecycle."
+            )
+            return result, "", ""
+
+        port = self._reuse_benchmark_port()
+
+        pid_dir, pid_file, meta_file = self._reuse_server_paths(port)
+        desired = self._desired_reuse_server_meta(port)
+
+        if self._reuse_http_healthy(port):
+            stored_meta = self._reuse_read_meta(meta_file)
+            if not lc.force_reuse:
+                mismatch = self._reuse_meta_mismatch(stored_meta, desired)
+                if mismatch:
+                    result.success = False
+                    result.errors.append(
+                        f"Reuse metadata mismatch ({mismatch}); running server on "
+                        f"PORT={port} is incompatible with this benchmark config "
+                        "or leftover state is stale. Set server_lifecycle."
+                        "force_reuse=true to skip checks, recycle with cleanup:true, "
+                        "or terminate the unrelated process manually."
+                    )
+                    return result, "", ""
+
+            rec_pid = None
+            if isinstance(stored_meta, dict):
+                rec_pid = stored_meta.get("server_pid")
+            logger.info(
+                "server_lifecycle: reusing HTTP server on port %s "
+                "(meta server_pid=%s, cleanup_after_run=%s)",
+                port,
+                rec_pid if rec_pid is not None else "n/a",
+                lc.cleanup,
+            )
+            stdout_parts.append(
+                f"[reuse] Using existing HTTP server on 127.0.0.1:{port}\n"
+            )
+        else:
+            self._reuse_clear_stale_artifacts(pid_file, meta_file, port)
+
+            spawn_pid_path = workspace / "reuse_server_spawn.pid"
+            server_timeout = float(lc.server_ready_timeout_s) + 180.0
+            server_cmd, server_env = self._build_local_command(
+                workspace=workspace,
+                runner_type=runner_type,
+                phase="server",
+                server_pid_file=spawn_pid_path,
+            )
+
+            logger.info(
+                "server_lifecycle: starting shared server phase (timeout %.0fs)",
+                server_timeout,
+            )
+            try:
+                proc = subprocess.run(
+                    server_cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=server_timeout,
+                    env=server_env,
+                )
+            except subprocess.TimeoutExpired as exc:
+                result.success = False
+                msg = (
+                    f"Shared server launcher timed out after {server_timeout:.0f}s "
+                    "(see workspace server.log)."
+                )
+                result.errors.append(msg)
+                sout = getattr(exc, "stdout", "") or ""
+                serr = getattr(exc, "stderr", "") or ""
+                return result, sout, serr
+
+            if proc.stdout:
+                stdout_parts.append(proc.stdout)
+            if proc.stderr:
+                stderr_parts.append(proc.stderr)
+
+            if proc.returncode != 0:
+                result.success = False
+                joined_err = "".join(stderr_parts[-1:]) if stderr_parts else (proc.stderr or "")
+                tail = joined_err[-500:] if joined_err else ""
+                result.errors.append(
+                    f"server_lifecycle server phase exited with "
+                    f"{proc.returncode}. stderr tail: {tail}"
+                )
+                return result, "\n".join(stdout_parts), "\n".join(stderr_parts)
+
+            if not spawn_pid_path.exists():
+                result.success = False
+                result.errors.append(
+                    "server_lifecycle: expected MAGPIE_SERVER_PID_FILE missing after "
+                    f"server phase ({spawn_pid_path})."
+                )
+                return result, "\n".join(stdout_parts), "\n".join(stderr_parts)
+
+            try:
+                server_pid_txt = spawn_pid_path.read_text().strip()
+                _ = int(server_pid_txt)
+            except (ValueError, OSError) as exc:
+                result.success = False
+                result.errors.append(
+                    f"server_lifecycle: could not read server PID ({exc})."
+                )
+                return result, "\n".join(stdout_parts), "\n".join(stderr_parts)
+
+            try:
+                pid_file.write_text(server_pid_txt + "\n")
+            except OSError as exc:
+                result.success = False
+                result.errors.append(f"failed to persist pid file ({exc}).")
+                return result, "\n".join(stdout_parts), "\n".join(stderr_parts)
+
+            deadline = time.time() + float(lc.server_ready_timeout_s)
+            if not self._reuse_wait_health(port, deadline):
+                tail = ""
+                srv_log = workspace / "server.log"
+                try:
+                    if srv_log.exists():
+                        tail = srv_log.read_text(errors="replace")[-2000:]
+                except OSError:
+                    tail = ""
+                result.success = False
+                result.errors.append(
+                    "Shared server did not become healthy in time "
+                    f"({lc.server_ready_timeout_s}s).\nTail server.log:\n{tail}"
+                )
+                try:
+                    self._reuse_terminate_persistent_server(int(server_pid_txt))
+                finally:
+                    self._cleanup_server_processes(self.config.framework)
+                    for p in (pid_file, meta_file):
+                        try:
+                            p.unlink()
+                        except FileNotFoundError:
+                            pass
+                        except OSError as exc_u:
+                            logger.warning("reuse failure cleanup unlink %s: %s", p, exc_u)
+                return result, "\n".join(stdout_parts), "\n".join(stderr_parts)
+
+            merged_meta = {"server_pid": int(server_pid_txt), **desired}
+            merged_meta.setdefault("started_at", time.time())
+            merged_meta["last_used_at"] = time.time()
+            self._reuse_write_meta(meta_file, merged_meta)
+
+            logger.info(
+                "server_lifecycle: persistent server is healthy (pid=%s, port=%s)",
+                server_pid_txt,
+                port,
+            )
+            stdout_parts.append(f"[reuse] Spawned persistent server PID {server_pid_txt}\n")
+
+        client_cmd, client_env = self._build_local_command(
+            workspace=workspace,
+            runner_type=runner_type,
+            phase="client",
+        )
+        client_res, cli_out, cli_err = self._execute_local_benchmark(
+            client_cmd,
+            client_env,
+            workspace,
+            timeout_seconds=self.config.timeout_seconds,
+        )
+        if cli_out:
+            stdout_parts.append(cli_out)
+        if cli_err:
+            stderr_parts.append(cli_err)
+
+        result = client_res
+
+        canonical_pid_text: Optional[str] = None
+        try:
+            if pid_file.exists():
+                canonical_pid_text = pid_file.read_text().strip()
+        except OSError:
+            canonical_pid_text = None
+
+        if lc.cleanup:
+            if canonical_pid_text:
+                try:
+                    self._reuse_terminate_persistent_server(int(canonical_pid_text))
+                except (ProcessLookupError, ValueError):
+                    logger.warning(
+                        "cleanup: persisted PID %s not running", canonical_pid_text
+                    )
+            self._cleanup_server_processes(self.config.framework)
+            try:
+                pid_file.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                logger.warning("Could not delete pid_file %s: %s", pid_file, exc)
+            try:
+                meta_file.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                logger.warning("Could not delete meta_file %s: %s", meta_file, exc)
+            logger.info(
+                "server_lifecycle: cleanup finished "
+                "(terminated pid=%s; removed reuse state files under %s)",
+                canonical_pid_text or "none",
+                pid_file.parent,
+            )
+        elif canonical_pid_text:
+            merged = self._reuse_read_meta(meta_file) or {}
+            merged.update(desired)
+            try:
+                merged["server_pid"] = int(canonical_pid_text.split()[0])
+            except ValueError:
+                merged["server_pid"] = canonical_pid_text
+            merged["last_used_at"] = time.time()
+            merged.setdefault(
+                "started_at",
+                merged.get("started_at", time.time()),
+            )
+            self._reuse_write_meta(meta_file, merged)
+            logger.info(
+                "server_lifecycle: server left running (pid=%s, port=%s, state=%s)",
+                canonical_pid_text,
+                port,
+                pid_file.parent,
+            )
+
+        full_out = "\n".join(stdout_parts)
+        full_err = "\n".join(stderr_parts)
+        self._save_logs(workspace, full_out, full_err)
+
+        return (result, full_out, full_err)
+
+    def _reuse_benchmark_port(self) -> int:
+        try:
+            return int(str(self.config.envs.get("PORT", 8888)))
+        except (TypeError, ValueError):
+            return 8888
+
+    def _reuse_will_attach_to_existing_server(self) -> bool:
+        """True when local server_lifecycle will only run the client (HTTP to existing server)."""
+        if not self.config.is_local or not self.config.is_server_lifecycle:
+            return False
+        lc = self.config.server_lifecycle
+        assert lc is not None
+        port = self._reuse_benchmark_port()
+        if not self._reuse_http_healthy(port):
+            return False
+        _, _, meta_file = self._reuse_server_paths(port)
+        stored = self._reuse_read_meta(meta_file)
+        desired = self._desired_reuse_server_meta(port)
+        if lc.force_reuse:
+            return True
+        return self._reuse_meta_mismatch(stored, desired) is None
+
+    @staticmethod
+    def _reuse_http_healthy(port: int) -> bool:
+        try:
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{int(port)}/health",
+                headers={"Accept": "*/*"},
+            )
+            with urllib.request.urlopen(req, timeout=3) as resp:
+                status = getattr(resp, "status", None) or resp.getcode()
+                return isinstance(status, int) and 200 <= status < 400
+        except (urllib.error.URLError, TimeoutError, ValueError, OSError):
+            return False
+
+    def _reuse_wait_health(self, port: int, deadline: float) -> bool:
+        while time.time() < deadline:
+            if self._reuse_http_healthy(port):
+                return True
+            time.sleep(5.0)
+        return False
+
+    def _desired_reuse_server_meta(self, port: int) -> Dict[str, Any]:
+        upper = {
+            str(k).upper(): str(v) for k, v in (self.config.envs or {}).items()
+        }
+        ix_path = str(Path(self.config.inferencex_path).resolve())
+
+        fw = self.config.framework.lower()
+
+        extras_vllm = str(upper.get("EXTRA_VLLM_ARGS", ""))
+        extras_sglang = str(upper.get("EXTRA_SGLANG_ARGS", ""))
+        tp = upper.get("TP", "1")
+        max_ml = upper.get(
+            "MAX_MODEL_LEN",
+            upper.get(
+                "MAX_MODEL_LENGTH",
+                upper.get(
+                    "SGL_MEM_FRACTION_STATIC",
+                    "",
+                ),
+            ),
+        )
+
+        return {
+            "framework": fw,
+            "model": str(self.config.model),
+            "tp": str(tp),
+            "port": int(port),
+            "extra_vllm_args": extras_vllm,
+            "extra_sglang_args": extras_sglang,
+            "max_model_len": str(max_ml),
+            "inferencex_path": ix_path,
+        }
+
+    def _reuse_meta_mismatch(
+        self,
+        stored: Optional[Dict[str, Any]],
+        desired: Dict[str, Any],
+    ) -> Optional[str]:
+        if not stored:
+            return (
+                "missing reuse metadata JSON (possible zombie server on PORT or "
+                "first warm-up before metadata was persisted)"
+            )
+
+        check_keys = (
+            ("framework", "framework"),
+            ("model", "model"),
+            ("tp", "tp"),
+            ("port", "port"),
+            ("extra_vllm_args", "extra_vllm_args"),
+            ("extra_sglang_args", "extra_sglang_args"),
+            ("max_model_len", "max_model_len"),
+            ("inferencex_path", "inferencex_path"),
+        )
+
+        diffs = []
+        for sk, dk in check_keys:
+            have = stored.get(sk)
+            want = desired.get(dk)
+            sh = "" if have is None else str(have)
+            sw = "" if want is None else str(want)
+            if sh != sw:
+                diffs.append(f"{sk}: stored={have!r} vs wanted={want!r}")
+
+        if diffs:
+            head = "; ".join(diffs[:8])
+            if len(diffs) > 8:
+                head += f" ...(+{len(diffs) - 8} more)"
+            return head
+
+        return None
+
+    def _reuse_server_paths(self, port: int) -> Tuple[Path, Path, Path]:
+        lc = self.config.server_lifecycle
+        assert lc is not None
+        base = Path(
+            lc.pid_dir
+            if lc.pid_dir
+            else os.path.join(Path.home(), ".cache", "magpie", "server")
+        ).expanduser()
+        base.mkdir(parents=True, exist_ok=True)
+        tag = f"{self.config.framework}_{port}"
+        pid_path = base / f"{tag}.pid"
+        meta_path = base / f"{tag}.json"
+        return base, pid_path, meta_path
+
+    @staticmethod
+    def _reuse_read_meta(meta_file: Path) -> Optional[Dict[str, Any]]:
+        try:
+            data = meta_file.read_text(encoding="utf-8", errors="replace")
+            parsed = json.loads(data)
+            if isinstance(parsed, dict):
+                return parsed
+            return None
+        except FileNotFoundError:
+            return None
+        except (json.JSONDecodeError, OSError, TypeError):
+            return None
+
+    @staticmethod
+    def _reuse_write_meta(meta_file: Path, payload: Dict[str, Any]) -> None:
+        try:
+            meta_file.write_text(json.dumps(payload, indent=2, sort_keys=True))
+        except OSError as exc:
+            logger.warning("Could not persist reuse metadata (%s)", exc)
+
+    def _reuse_clear_stale_artifacts(
+        self,
+        pid_file: Path,
+        meta_file: Path,
+        port: int,
+    ) -> None:
+        stale_txt: Optional[str] = None
+        try:
+            if pid_file.exists():
+                stale_txt = pid_file.read_text().strip()
+        except OSError:
+            stale_txt = None
+
+        if stale_txt:
+            try:
+                stale_pid = int(stale_txt.split()[0])
+                self._reuse_terminate_persistent_server(stale_pid)
+            except (ProcessLookupError, ValueError):
+                logger.debug(
+                    "Reuse cleanup: persisted PID unreadable/outdated (%s)",
+                    stale_txt,
+                )
+
+        self._cleanup_server_processes(self.config.framework)
+
+        for path in (pid_file, meta_file):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                logger.warning("reuse cleanup unlink %s failed: %s", path, exc)
+
+    @staticmethod
+    def _reuse_terminate_persistent_server(root_pid: int) -> None:
+        try:
+            os.killpg(root_pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        except (PermissionError, OSError):
+            try:
+                os.kill(root_pid, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError, OSError):
+                return
+
+        for _ in range(120):
+            try:
+                os.kill(root_pid, 0)
+                time.sleep(0.25)
+            except ProcessLookupError:
+                return
+
+        try:
+            os.killpg(root_pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                os.kill(root_pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+
     def _execute_local_benchmark(
         self,
         cmd: List[str],
         env: Dict[str, str],
         workspace: Path,
+        timeout_seconds: Optional[float] = None,
     ) -> tuple:
         """
         Execute benchmark locally (no Docker).
@@ -621,7 +1131,8 @@ class BenchmarkMode:
             cmd: Shell command list
             env: Environment variables
             workspace: Workspace directory for saving logs
-        
+            timeout_seconds: Override :attr:`BenchmarkConfig.timeout_seconds`.
+
         Returns:
             Tuple of (BenchmarkResult, stdout, stderr)
         """
@@ -629,12 +1140,18 @@ class BenchmarkMode:
         stdout = ""
         stderr = ""
 
+        deadline = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else self.config.timeout_seconds
+        )
+
         try:
             process = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=self.config.timeout_seconds,
+                timeout=deadline,
                 env=env,
             )
 
@@ -661,7 +1178,7 @@ class BenchmarkMode:
 
         except subprocess.TimeoutExpired as e:
             result.errors.append(
-                f"Benchmark timed out after {self.config.timeout_seconds}s"
+                f"Benchmark timed out after {deadline}s"
             )
             logger.error("Benchmark timed out")
 

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -489,6 +489,47 @@ class GpuSelectionConfig:
 
 
 @dataclass
+class ServerLifecycleConfig:
+    """
+    Persist a benchmark inference server across multiple local runs.
+
+    When enabled, ``timeout_seconds`` applies to the client (benchmark serving)
+    phase only; server startup is gated by ``server_ready_timeout_s``.
+    Server processes are only recycled when ``cleanup`` is True for a run.
+
+    Intended for ``run_mode: local`` with Magpie built-in benchmarks scripts
+    (``vllm_*.sh`` / ``sglang_*.sh``) that honour ``MAGPIE_RUN_PHASE``.
+    """
+
+    enabled: bool = False
+    cleanup: bool = False
+    force_reuse: bool = False
+    pid_dir: Optional[str] = None
+    server_ready_timeout_s: int = 2700
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "cleanup": self.cleanup,
+            "force_reuse": self.force_reuse,
+            "pid_dir": self.pid_dir,
+            "server_ready_timeout_s": self.server_ready_timeout_s,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "ServerLifecycleConfig":
+        if not data:
+            return cls(enabled=False)
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            cleanup=bool(data.get("cleanup", False)),
+            force_reuse=bool(data.get("force_reuse", False)),
+            pid_dir=data.get("pid_dir"),
+            server_ready_timeout_s=int(data.get("server_ready_timeout_s", 2700)),
+        )
+
+
+@dataclass
 class BenchmarkConfig:
     """
     Configuration for benchmark mode.
@@ -506,6 +547,7 @@ class BenchmarkConfig:
         inferencex_path: Path to InferenceX installation
         hf_cache_path: HuggingFace cache directory
         runner_type: Hardware runner type for InferenceX (e.g., "mi300x", "h100")
+        server_lifecycle: Optional persisted-server settings (local-only)
     """
 
     framework: str
@@ -545,6 +587,9 @@ class BenchmarkConfig:
 
     # Ray remote execution configuration (used when run_mode="ray")
     ray_config: Optional[RayConfig] = None
+
+    # Persist inference server across local benchmark runs (opt-in).
+    server_lifecycle: Optional[ServerLifecycleConfig] = None
 
     def __post_init__(self):
         """Validate and set defaults."""
@@ -591,6 +636,28 @@ class BenchmarkConfig:
         # Ensure ray_config exists when run_mode is "ray"
         if self.run_mode == "ray" and self.ray_config is None:
             self.ray_config = RayConfig()
+
+        if isinstance(self.server_lifecycle, dict):
+            self.server_lifecycle = ServerLifecycleConfig.from_dict(
+                self.server_lifecycle
+            )
+
+        if self.is_server_lifecycle:
+            if self.run_mode != "local":
+                raise ValueError(
+                    "server_lifecycle.enabled requires run_mode='local'. "
+                    "Docker/Ray executions cannot reuse a server process "
+                    "across Magpie invocations."
+                )
+            lc = self.server_lifecycle
+            assert lc is not None
+            if self.profiler.torch_profiler.enabled and not lc.cleanup:
+                raise ValueError(
+                    "server_lifecycle is incompatible with "
+                    "profiler.torch_profiler.enabled=true when cleanup=false. "
+                    "Disable torch_profiler for reuse runs or set cleanup=true "
+                    "so the profiled server terminates with the benchmark."
+                )
 
     def get_env_vars(self) -> Dict[str, str]:
         """
@@ -640,6 +707,11 @@ class BenchmarkConfig:
         """Check if running in Ray remote execution mode."""
         return self.run_mode == "ray"
 
+    @property
+    def is_server_lifecycle(self) -> bool:
+        """Reuse a shared inference server across local benchmark tasks."""
+        return self.server_lifecycle is not None and bool(self.server_lifecycle.enabled)
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
         d: Dict[str, Any] = {
@@ -661,6 +733,8 @@ class BenchmarkConfig:
         }
         if self.ray_config is not None:
             d["ray_config"] = self.ray_config.to_dict()
+        if self.server_lifecycle is not None:
+            d["server_lifecycle"] = self.server_lifecycle.to_dict()
         return d
 
     @classmethod
@@ -680,6 +754,22 @@ class BenchmarkConfig:
 
         ray_data = data.get("ray_config")
         ray_config = RayConfig.from_dict(ray_data) if ray_data else None
+
+        sl_raw = data.get("server_lifecycle")
+        server_lifecycle = (
+            ServerLifecycleConfig.from_dict(sl_raw)
+            if isinstance(sl_raw, dict)
+            else (sl_raw if isinstance(sl_raw, ServerLifecycleConfig) else None)
+        )
+        sweep_matrix = data.get("sweep_matrix")
+        cases_forbidden = isinstance(sweep_matrix, dict) and bool(
+            sweep_matrix.get("cases")
+        )
+        if server_lifecycle and server_lifecycle.enabled and cases_forbidden:
+            raise ValueError(
+                "server_lifecycle cannot be combined with sweep_matrix "
+                "(non-empty sweep_matrix.cases)."
+            )
 
         return cls(
             framework=data.get("framework", "sglang"),
@@ -702,4 +792,5 @@ class BenchmarkConfig:
             benchmark_script=data.get("benchmark_script"),
             gpu_selection=GpuSelectionConfig.from_dict(data.get("gpu_selection") or {}),
             ray_config=ray_config,
+            server_lifecycle=server_lifecycle,
         )

--- a/Magpie/scripts/benchmark/sglang_mi300x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi300x.sh
@@ -2,24 +2,32 @@
 ###############################################################################
 # Magpie Generic SGLang Benchmark Script for MI300X
 ###############################################################################
+#
+# Phases (via MAGPIE_RUN_PHASE): all | server | client (default all).
 
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
-check_env_vars \
-    MODEL \
-    TP \
-    CONC \
-    ISL \
-    OSL \
-    RANDOM_RANGE_RATIO \
-    RESULT_FILENAME
+PHASE="${MAGPIE_RUN_PHASE:-all}"
+case "$PHASE" in
+  all|server|client) ;;
+  *) echo "ERROR: Invalid MAGPIE_RUN_PHASE='$PHASE'. Must be all|server|client." >&2; exit 2 ;;
+esac
+
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL TP
+fi
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL CONC ISL OSL RANDOM_RANGE_RATIO RESULT_FILENAME
+fi
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 fi
 
-hf download "$MODEL" 2>/dev/null || true
+if [[ "$PHASE" != "client" ]]; then
+  hf download "$MODEL" 2>/dev/null || true
+fi
 
 # MI300X specific: Check MEC firmware version for RCCL memory reclaim
 version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
@@ -51,40 +59,58 @@ for flag_val in "--mem-fraction-static=0.8" "--disable-radix-cache"; do
 done
 
 set -x
-setsid python3 -m sglang.launch_server \
-  --model-path=$MODEL \
-  --host=0.0.0.0 \
-  --port=$PORT \
-  --trust-remote-code \
-  --tensor-parallel-size=$TP \
-  $DEFAULT_ARGS \
-  $EXTRA_SGLANG_ARGS > $SERVER_LOG 2>&1 &
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  setsid python3 -m sglang.launch_server \
+    --model-path=$MODEL \
+    --host=0.0.0.0 \
+    --port=$PORT \
+    --trust-remote-code \
+    --tensor-parallel-size=$TP \
+    $DEFAULT_ARGS \
+    $EXTRA_SGLANG_ARGS > $SERVER_LOG 2>&1 &
 
-SERVER_PID=$!
-trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  SERVER_PID=$!
+  if [[ "$PHASE" == "all" ]]; then
+    trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  fi
 
-# Wait for server to be ready
-wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+  wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-run_benchmark_serving \
-    --model "$MODEL" \
-    --port "$PORT" \
-    --backend vllm \
-    --input-len "$ISL" \
-    --output-len "$OSL" \
-    --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
-    --max-concurrency "$CONC" \
-    --result-filename "$RESULT_FILENAME" \
-    --result-dir ${RESULT_DIR:-/workspace/}
+  if [[ "$PHASE" == "server" ]]; then
+    if [[ -z "${MAGPIE_SERVER_PID_FILE:-}" ]]; then
+      echo "ERROR: MAGPIE_SERVER_PID_FILE must be set for MAGPIE_RUN_PHASE=server" >&2
+      kill -TERM "-$SERVER_PID" 2>/dev/null || true
+      exit 3
+    fi
+    printf '%s\n' "$SERVER_PID" > "$MAGPIE_SERVER_PID_FILE"
+    disown "$SERVER_PID" 2>/dev/null || true
+    exit 0
+  fi
+fi
 
-# After throughput, run evaluation only if RUN_EVAL is true
-if [ "${RUN_EVAL}" = "true" ]; then
-    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+SERVER_MONITOR_ARGS=()
+if [[ -n "${SERVER_PID:-}" ]]; then
+  SERVER_MONITOR_ARGS+=(--server-pid "$SERVER_PID")
+fi
+
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  run_benchmark_serving \
+      --model "$MODEL" \
+      --port "$PORT" \
+      --backend vllm \
+      --input-len "$ISL" \
+      --output-len "$OSL" \
+      --random-range-ratio "$RANDOM_RANGE_RATIO" \
+      --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
+      --max-concurrency "$CONC" \
+      --result-filename "$RESULT_FILENAME" \
+      "${SERVER_MONITOR_ARGS[@]}" \
+      --result-dir ${RESULT_DIR:-/workspace/} || exit $?
+fi
+
+if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?
     append_lm_eval_summary
 fi
 set +x
-
-
-
 

--- a/Magpie/scripts/benchmark/sglang_mi355x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi355x.sh
@@ -4,26 +4,34 @@
 #
 # See LICENSE for license information.
 ###############################################################################
-
+#
 # Magpie Generic SGLang Benchmark Script for MI355X
+#
+# Phases (via MAGPIE_RUN_PHASE): all | server | client (default all).
 
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
-check_env_vars \
-    MODEL \
-    TP \
-    CONC \
-    ISL \
-    OSL \
-    RANDOM_RANGE_RATIO \
-    RESULT_FILENAME
+PHASE="${MAGPIE_RUN_PHASE:-all}"
+case "$PHASE" in
+  all|server|client) ;;
+  *) echo "ERROR: Invalid MAGPIE_RUN_PHASE='$PHASE'. Must be all|server|client." >&2; exit 2 ;;
+esac
+
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL TP
+fi
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL CONC ISL OSL RANDOM_RANGE_RATIO RESULT_FILENAME
+fi
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 fi
 
-hf download "$MODEL" 2>/dev/null || true
+if [[ "$PHASE" != "client" ]]; then
+  hf download "$MODEL" 2>/dev/null || true
+fi
 
 # MI355X specific: Check MEC firmware version for RCCL memory reclaim
 version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
@@ -45,7 +53,6 @@ if [[ "${PROFILE:-}" == "1" ]]; then
   export SGLANG_TORCH_PROFILER_DIR="$TRACE_DIR"
 fi
 
-# Build default args, skipping any that EXTRA_SGLANG_ARGS already overrides
 DEFAULT_ARGS=""
 for flag_val in "--mem-fraction-static=0.8" "--disable-radix-cache"; do
   flag="${flag_val%%=*}"
@@ -55,40 +62,57 @@ for flag_val in "--mem-fraction-static=0.8" "--disable-radix-cache"; do
 done
 
 set -x
-setsid python3 -m sglang.launch_server \
-  --model-path=$MODEL \
-  --host=0.0.0.0 \
-  --port=$PORT \
-  --trust-remote-code \
-  --tensor-parallel-size=$TP \
-  $DEFAULT_ARGS \
-  $EXTRA_SGLANG_ARGS > $SERVER_LOG 2>&1 &
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  setsid python3 -m sglang.launch_server \
+    --model-path=$MODEL \
+    --host=0.0.0.0 \
+    --port=$PORT \
+    --trust-remote-code \
+    --tensor-parallel-size=$TP \
+    $DEFAULT_ARGS \
+    $EXTRA_SGLANG_ARGS > $SERVER_LOG 2>&1 &
 
-SERVER_PID=$!
-trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  SERVER_PID=$!
+  if [[ "$PHASE" == "all" ]]; then
+    trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  fi
 
-# Wait for server to be ready
-wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+  wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-run_benchmark_serving \
-    --model "$MODEL" \
-    --port "$PORT" \
-    --backend vllm \
-    --input-len "$ISL" \
-    --output-len "$OSL" \
-    --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
-    --max-concurrency "$CONC" \
-    --result-filename "$RESULT_FILENAME" \
-    --result-dir ${RESULT_DIR:-/workspace/}
+  if [[ "$PHASE" == "server" ]]; then
+    if [[ -z "${MAGPIE_SERVER_PID_FILE:-}" ]]; then
+      echo "ERROR: MAGPIE_SERVER_PID_FILE must be set for MAGPIE_RUN_PHASE=server" >&2
+      kill -TERM "-$SERVER_PID" 2>/dev/null || true
+      exit 3
+    fi
+    printf '%s\n' "$SERVER_PID" > "$MAGPIE_SERVER_PID_FILE"
+    disown "$SERVER_PID" 2>/dev/null || true
+    exit 0
+  fi
+fi
 
-# After throughput, run evaluation only if RUN_EVAL is true
-if [ "${RUN_EVAL}" = "true" ]; then
-    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+SERVER_MONITOR_ARGS=()
+if [[ -n "${SERVER_PID:-}" ]]; then
+  SERVER_MONITOR_ARGS+=(--server-pid "$SERVER_PID")
+fi
+
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  run_benchmark_serving \
+      --model "$MODEL" \
+      --port "$PORT" \
+      --backend vllm \
+      --input-len "$ISL" \
+      --output-len "$OSL" \
+      --random-range-ratio "$RANDOM_RANGE_RATIO" \
+      --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
+      --max-concurrency "$CONC" \
+      --result-filename "$RESULT_FILENAME" \
+      "${SERVER_MONITOR_ARGS[@]}" \
+      --result-dir ${RESULT_DIR:-/workspace/} || exit $?
+fi
+
+if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?
     append_lm_eval_summary
 fi
 set +x
-
-
-
-

--- a/Magpie/scripts/benchmark/vllm_mi300x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi300x.sh
@@ -6,18 +6,25 @@
 ###############################################################################
 
 # Magpie Generic vLLM Benchmark Script for MI300X
+#
+# Phases (via MAGPIE_RUN_PHASE): all | server | client (default all).
+# Server-only writes PID to MAGPIE_SERVER_PID_FILE then disowns and exits.
 
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
-check_env_vars \
-    MODEL \
-    TP \
-    CONC \
-    ISL \
-    OSL \
-    RANDOM_RANGE_RATIO \
-    RESULT_FILENAME
+PHASE="${MAGPIE_RUN_PHASE:-all}"
+case "$PHASE" in
+  all|server|client) ;;
+  *) echo "ERROR: Invalid MAGPIE_RUN_PHASE='$PHASE'. Must be all|server|client." >&2; exit 2 ;;
+esac
+
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL TP
+fi
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL CONC ISL OSL RANDOM_RANGE_RATIO RESULT_FILENAME
+fi
 
 MAX_MODEL_LEN=${MAX_MODEL_LEN:-4096}
 
@@ -25,7 +32,9 @@ if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 fi
 
-hf download "$MODEL" 2>/dev/null || true
+if [[ "$PHASE" != "client" ]]; then
+  hf download "$MODEL" 2>/dev/null || true
+fi
 
 # MI300X specific: Check MEC firmware version for RCCL memory reclaim
 version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
@@ -61,37 +70,58 @@ if [[ "${PROFILE:-}" == "1" ]]; then
 fi
 
 set -x
-setsid vllm serve $MODEL --port $PORT \
-  --tensor-parallel-size=$TP \
-  --gpu-memory-utilization 0.95 \
-  --max-model-len $MAX_MODEL_LEN \
-  --trust-remote-code \
-  "${PROFILER_ARGS[@]}" \
-  $EXTRA_VLLM_ARGS > $SERVER_LOG 2>&1 &
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  setsid vllm serve $MODEL --port $PORT \
+    --tensor-parallel-size=$TP \
+    --gpu-memory-utilization 0.95 \
+    --max-model-len $MAX_MODEL_LEN \
+    --trust-remote-code \
+    "${PROFILER_ARGS[@]}" \
+    $EXTRA_VLLM_ARGS > $SERVER_LOG 2>&1 &
 
-SERVER_PID=$!
-trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  SERVER_PID=$!
+  if [[ "$PHASE" == "all" ]]; then
+    trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  fi
 
-# Wait for server to be ready
-wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+  wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-run_benchmark_serving \
-    --model "$MODEL" \
-    --port "$PORT" \
-    --backend vllm \
-    --input-len "$ISL" \
-    --output-len "$OSL" \
-    --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
-    --max-concurrency "$CONC" \
-    --result-filename "$RESULT_FILENAME" \
-    --result-dir "$WORKSPACE_DIR/" \
-    --server-pid "$SERVER_PID" \
-    --trust-remote-code
+  if [[ "$PHASE" == "server" ]]; then
+    if [[ -z "${MAGPIE_SERVER_PID_FILE:-}" ]]; then
+      echo "ERROR: MAGPIE_SERVER_PID_FILE must be set for MAGPIE_RUN_PHASE=server" >&2
+      kill -TERM "-$SERVER_PID" 2>/dev/null || true
+      exit 3
+    fi
+    printf '%s\n' "$SERVER_PID" > "$MAGPIE_SERVER_PID_FILE"
+    disown "$SERVER_PID" 2>/dev/null || true
+    exit 0
+  fi
+fi
+
+SERVER_MONITOR_ARGS=()
+if [[ -n "${SERVER_PID:-}" ]]; then
+  SERVER_MONITOR_ARGS+=(--server-pid "$SERVER_PID")
+fi
+
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  run_benchmark_serving \
+      --model "$MODEL" \
+      --port "$PORT" \
+      --backend vllm \
+      --input-len "$ISL" \
+      --output-len "$OSL" \
+      --random-range-ratio "$RANDOM_RANGE_RATIO" \
+      --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
+      --max-concurrency "$CONC" \
+      --result-filename "$RESULT_FILENAME" \
+      --result-dir "$WORKSPACE_DIR/" \
+      "${SERVER_MONITOR_ARGS[@]}" \
+      --trust-remote-code || exit $?
+fi
 
 # After throughput, run evaluation only if RUN_EVAL is true
-if [ "${RUN_EVAL}" = "true" ]; then
-    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?
     append_lm_eval_summary
 fi
 set +x

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -6,18 +6,25 @@
 ###############################################################################
 
 # Magpie Generic vLLM Benchmark Script for MI355X
+#
+# Phases (via MAGPIE_RUN_PHASE): all | server | client (default all).
+# Server-only writes PID to MAGPIE_SERVER_PID_FILE then disowns and exits.
 
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 
-check_env_vars \
-    MODEL \
-    TP \
-    CONC \
-    ISL \
-    OSL \
-    RANDOM_RANGE_RATIO \
-    RESULT_FILENAME
+PHASE="${MAGPIE_RUN_PHASE:-all}"
+case "$PHASE" in
+  all|server|client) ;;
+  *) echo "ERROR: Invalid MAGPIE_RUN_PHASE='$PHASE'. Must be all|server|client." >&2; exit 2 ;;
+esac
+
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL TP
+fi
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  check_env_vars MODEL CONC ISL OSL RANDOM_RANGE_RATIO RESULT_FILENAME
+fi
 
 MAX_MODEL_LEN=${MAX_MODEL_LEN:-4096}
 
@@ -25,7 +32,9 @@ if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 fi
 
-hf download "$MODEL" 2>/dev/null || true
+if [[ "$PHASE" != "client" ]]; then
+  hf download "$MODEL" 2>/dev/null || true
+fi
 
 # MI355X specific: Check MEC firmware version for RCCL memory reclaim
 version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
@@ -61,38 +70,59 @@ if [[ "${PROFILE:-}" == "1" ]]; then
 fi
 
 set -x
-# setsid: PG leader so magpie_stop_benchmark_server_stack can kill the whole tree.
-setsid vllm serve $MODEL --port $PORT \
-  --tensor-parallel-size=$TP \
-  --gpu-memory-utilization 0.95 \
-  --max-model-len $MAX_MODEL_LEN \
-  --trust-remote-code \
-  "${PROFILER_ARGS[@]}" \
-  $EXTRA_VLLM_ARGS > $SERVER_LOG 2>&1 &
+if [[ "$PHASE" == "server" || "$PHASE" == "all" ]]; then
+  setsid vllm serve $MODEL --port $PORT \
+    --tensor-parallel-size=$TP \
+    --gpu-memory-utilization 0.95 \
+    --max-model-len $MAX_MODEL_LEN \
+    --trust-remote-code \
+    "${PROFILER_ARGS[@]}" \
+    $EXTRA_VLLM_ARGS > $SERVER_LOG 2>&1 &
 
-SERVER_PID=$!
-trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  SERVER_PID=$!
+  if [[ "$PHASE" == "all" ]]; then
+    trap 'magpie_stop_benchmark_server_stack "$SERVER_PID"' EXIT INT TERM
+  fi
 
-# Wait for server to be ready
-wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+  wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-run_benchmark_serving \
-    --model "$MODEL" \
-    --port "$PORT" \
-    --backend vllm \
-    --input-len "$ISL" \
-    --output-len "$OSL" \
-    --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
-    --max-concurrency "$CONC" \
-    --result-filename "$RESULT_FILENAME" \
-    --result-dir "$WORKSPACE_DIR/" \
-    --server-pid "$SERVER_PID" \
-    --trust-remote-code
+  if [[ "$PHASE" == "server" ]]; then
+    if [[ -z "${MAGPIE_SERVER_PID_FILE:-}" ]]; then
+      echo "ERROR: MAGPIE_SERVER_PID_FILE must be set for MAGPIE_RUN_PHASE=server" >&2
+      kill -TERM "-$SERVER_PID" 2>/dev/null || true
+      exit 3
+    fi
+    printf '%s\n' "$SERVER_PID" > "$MAGPIE_SERVER_PID_FILE"
+    disown "$SERVER_PID" 2>/dev/null || true
+    exit 0
+  fi
+fi
 
-# After throughput, run evaluation only if RUN_EVAL is true
-if [ "${RUN_EVAL}" = "true" ]; then
-    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+SERVER_MONITOR_ARGS=()
+if [[ -n "${SERVER_PID:-}" ]]; then
+  SERVER_MONITOR_ARGS+=(--server-pid "$SERVER_PID")
+fi
+
+if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
+  run_benchmark_serving \
+      --model "$MODEL" \
+      --port "$PORT" \
+      --backend vllm \
+      --input-len "$ISL" \
+      --output-len "$OSL" \
+      --random-range-ratio "$RANDOM_RANGE_RATIO" \
+      --num-prompts ${NUM_PROMPTS:-$(( $CONC * 10 ))} \
+      --max-concurrency "$CONC" \
+      --result-filename "$RESULT_FILENAME" \
+      --result-dir "$WORKSPACE_DIR/" \
+      "${SERVER_MONITOR_ARGS[@]}" \
+      --trust-remote-code || exit $?
+
+fi
+
+if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?
     append_lm_eval_summary
 fi
 set +x
+

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -210,6 +210,45 @@ devices itself via `num_gpus`. To restrict the cluster to specific cards,
 export `ROCR_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` in the shell before
 starting `ray start`.
 
+**Local server lifecycle reuse** (`server_lifecycle.enabled: true`): When the run
+would attach to an existing healthy server matching reuse metadata (`force_reuse`
+skips mismatch checks), **`gpu_selection.auto` is skipped** entirely for that invocation
+so pinned devices do not churn between chain runs — see **Persistent server reuse** below.
+
+## Persistent server reuse (local)
+
+Use `server_lifecycle.enabled: true` with **`run_mode: local`** to keep one
+detached inference server alive across successive `python -m Magpie benchmark`
+runs on the **same PORT**.
+
+- **`timeout_seconds`**: applies to the **client** subprocess (`benchmark_serving.py`)
+  only — it does not stop the shared HTTP server afterward.
+- **`server_lifecycle.cleanup`**: Magpie terminates the persisted process group
+  (writes `SIGTERM`, then kills stragglers) **only when** `cleanup: true`; it also
+  removes the associated `*.pid` / `*.json` artifacts under ``~/.cache/magpie/server/``
+  (or `server_lifecycle.pid_dir`).
+- **Compatibility gate**: reuse checks JSON metadata versus `MODEL`, `TP`,
+  `EXTRA_VLLM_ARGS`, `EXTRA_SGLANG_ARGS`, `MAX_MODEL_LEN`, InferenceX resolved path,
+  framework, and `PORT`. Set `force_reuse: true` to bypass the mismatch errors.
+- **Scripts**: Requires **Magpie built-in InferenceX wrappers** that implement
+  `MAGPIE_RUN_PHASE=server|client` (e.g. `vllm_mi355x.sh`). Native InferenceX
+  `gptoss_*` / `dsr1_*` scripts reject this flag path by design until they are
+  updated upstream — point `benchmark_script` at one of the Magpie `*.sh` files.
+- **Profiling**: Torch profiler + `cleanup: false` is rejected (profiler state
+  is tied to surviving workers). Configure `profiler.torch_profiler.enabled: false`
+  for warmed servers, or set `cleanup: true`.
+- **GPU pins vs reuse**: Before each run Magpie probes `http://127.0.0.1:$PORT/health`
+  and compares reuse metadata against the chosen config (`force_reuse: true`
+  skips the comparison). If that probe says the **existing** server should be reused
+  (eligible client-only path), **`gpu_selection.auto` is skipped** (`find_idle_gpus`
+  is not run), so visible-device env vars are **not** re-randomised relative to
+  the server's physical GPUs on the reuse chain. When the probe fails (cold start /
+  stale server after crash), idle-GPU selection runs as usual and Magpie launches a
+  new server phase. For `profiler.gpu_monitor` while reusing without auto-selection,
+  pin GPUs in `envs` or set `gpu_monitor.device_id` if you care which card is sampled.
+
+Example YAML: **`examples/benchmarks/benchmark_vllm_reuse.yaml`**.
+
 ## Profiling Options
 
 ### Torch Profiler

--- a/examples/benchmarks/benchmark_vllm_reuse.yaml
+++ b/examples/benchmarks/benchmark_vllm_reuse.yaml
@@ -1,0 +1,59 @@
+# vLLM benchmark with persistent server reuse (local / Magpie built-in scripts)
+# ================================================================================
+#
+# server_lifecycle keeps the vLLM process alive across multiple Magpie invocations
+# on the SAME host + PORT. Typical workflow:
+#   Run 1: cleanup: false → server starts, stays up after benchmark.
+#   Run 2+: cleanup false → benchmarks attach to /health-reachable server only.
+#   Final run: cleanup: true → Magpie terminates the persisted server pid group.
+#
+# Requirements:
+#   - run_mode: local
+#   - benchmark_script: one of Magpie builtins (vllm_mi300x.sh / vllm_mi355x.sh)
+#     Native InferenceX scripts (gptoss_*.sh) do NOT honour MAGPIE_RUN_PHASE.
+#   - profiler.torch_profiler.enabled: false unless cleanup: true each time.
+#
+# Under reuse, timeout_seconds refers to the CLIENT (benchmark_serving.py) slice
+# only — it does NOT stop the detached server afterwards.
+#
+# Final run with cleanup:true (same envs/model as warm runs): see
+#   examples/benchmarks/benchmark_vllm_reuse_cleanup.yaml
+#
+# Usage:
+#   python -m Magpie benchmark --benchmark-config examples/benchmarks/benchmark_vllm_reuse.yaml
+
+benchmark:
+  framework: vllm
+  model: MiniMaxAI/MiniMax-M2.5
+  precision: fp8
+  run_mode: local
+
+  timeout_seconds: 3600
+
+  envs:
+    TP: 2
+    PORT: 8888
+    CONC: 4
+    ISL: 8192
+    OSL: 1024
+    RANDOM_RANGE_RATIO: 0.8
+    MAX_MODEL_LEN: 131072
+    EXTRA_VLLM_ARGS: "--no-enable-prefix-caching --block-size 32 --kv-cache-dtype fp8 --attention-backend ROCM_AITER_FA --enable-auto-tool-choice --tool-call-parser minimax_m2 --reasoning-parser minimax_m2_append_think"
+    VLLM_ROCM_USE_AITER: 1
+
+  profiler:
+    torch_profiler:
+      enabled: false
+
+  server_lifecycle:
+    # enabled: true to enable the server lifecycle
+    enabled: true
+    # cleanup: true to terminate the persisted server pid group after benchmark
+    cleanup: false
+    # force_reuse: true to bypass the mismatch errors (metadata mismatch includes tp, port, extra_vllm_args, extra_sglang_args, max_model_len, inferencex_path)
+    force_reuse: false 
+    # pid_dir defaults to ~/.cache/magpie/server/
+    server_ready_timeout_s: 2700
+
+  docker_image: "" # no docker image required for local run
+  benchmark_script: "vllm_mi355x.sh"

--- a/examples/benchmarks/benchmark_vllm_reuse_cleanup.yaml
+++ b/examples/benchmarks/benchmark_vllm_reuse_cleanup.yaml
@@ -1,0 +1,45 @@
+# Pair with benchmark_vllm_reuse.yaml: run this once as the final step to tear
+# down the persistent shared server.
+# =====================================================================
+#
+# MODEL, TP, PORT, EXTRA_VLLM_ARGS, etc. must match the warm-reuse runs; strict
+# metadata checks will error on mismatch (unless you temporarily set
+# force_reuse: true).
+#
+# Usage (after reuse has started the server and you have run several client-only
+# benchmarks):
+#   python -m Magpie benchmark --benchmark-config examples/benchmarks/benchmark_vllm_reuse_cleanup.yaml
+#
+# Only difference from reuse is server_lifecycle.cleanup: true.
+#
+benchmark:
+  framework: vllm
+  model: MiniMaxAI/MiniMax-M2.5
+  precision: fp8
+  run_mode: local
+
+  timeout_seconds: 3600
+
+  envs:
+    TP: 2
+    PORT: 8888
+    CONC: 4
+    ISL: 1024
+    OSL: 1024
+    RANDOM_RANGE_RATIO: 0.8
+    MAX_MODEL_LEN: 131072
+    EXTRA_VLLM_ARGS: "--no-enable-prefix-caching --block-size 32 --kv-cache-dtype fp8 --attention-backend ROCM_AITER_FA --enable-auto-tool-choice --tool-call-parser minimax_m2 --reasoning-parser minimax_m2_append_think"
+    VLLM_ROCM_USE_AITER: 1
+
+  profiler:
+    torch_profiler:
+      enabled: false
+
+  server_lifecycle:
+    enabled: true
+    cleanup: true
+    force_reuse: false
+    server_ready_timeout_s: 2700
+
+  docker_image: "vllm/vllm-openai-rocm:v0.19.1"
+  benchmark_script: "vllm_mi355x.sh"

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -7,12 +7,91 @@ import yaml
 from Magpie.modes.benchmark.config import (
     BenchmarkConfig,
     GapAnalysisConfig,
+    ProfilerConfig,
     RayConfig,
+    ServerLifecycleConfig,
+    TorchProfilerConfig,
     TraceLensConfig,
 )
 from Magpie.modes.benchmark.image_selector import ImageSelector
 from Magpie.modes.benchmark.result import BenchmarkResult, ResultParser
 from Magpie.utils.gpu import GPUVendor
+
+
+def test_benchmark_server_lifecycle_requires_local_runtime():
+    with pytest.raises(ValueError, match="server_lifecycle"):
+        BenchmarkConfig(
+            framework="vllm",
+            model="demo",
+            run_mode="docker",
+            envs={
+                "TP": 1,
+                "CONC": 32,
+                "ISL": 1024,
+                "OSL": 512,
+                "RANDOM_RANGE_RATIO": 0.5,
+            },
+            profiler=ProfilerConfig(
+                torch_profiler=TorchProfilerConfig(enabled=False),
+            ),
+            server_lifecycle=ServerLifecycleConfig(enabled=True),
+        )
+
+
+def test_benchmark_server_lifecycle_rejects_profiler_without_cleanup():
+    with pytest.raises(ValueError, match="torch_profiler"):
+        BenchmarkConfig(
+            framework="vllm",
+            model="demo",
+            run_mode="local",
+            envs={
+                "TP": 1,
+                "CONC": 32,
+                "ISL": 1024,
+                "OSL": 512,
+                "RANDOM_RANGE_RATIO": 0.5,
+            },
+            profiler=ProfilerConfig(
+                torch_profiler=TorchProfilerConfig(enabled=True),
+            ),
+            server_lifecycle=ServerLifecycleConfig(enabled=True, cleanup=False),
+        )
+
+
+def test_benchmark_server_lifecycle_sweep_conflict():
+    with pytest.raises(ValueError, match="sweep_matrix"):
+        BenchmarkConfig.from_dict(
+            {
+                "framework": "vllm",
+                "model": "demo",
+                "run_mode": "local",
+                "profiler": {"torch_profiler": {"enabled": False}},
+                "envs": {
+                    "TP": 1,
+                    "CONC": 32,
+                    "ISL": 1024,
+                    "OSL": 512,
+                    "RANDOM_RANGE_RATIO": 0.5,
+                },
+                "server_lifecycle": {"enabled": True},
+                "sweep_matrix": {"cases": [{"CONC": 2}]},
+            }
+        )
+
+
+def test_benchmark_server_lifecycle_from_dict_ok():
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "vllm",
+            "model": "demo",
+            "run_mode": "local",
+            "profiler": {"torch_profiler": {"enabled": False}},
+            "envs": {"PORT": 8899},
+            "server_lifecycle": {"enabled": True},
+        }
+    )
+
+    assert cfg.is_server_lifecycle is True
 
 
 def test_tracelens_config_supports_legacy_export_flags():


### PR DESCRIPTION
## Summary
- Add **`server_lifecycle`** for **`run_mode: local`**: optional shared HTTP inference server across successive `Magpie benchmark` runs on the same `PORT`.
- Built-in InferenceX wrappers (`vllm_*.sh`, `sglang_*.sh`) support **`MAGPIE_RUN_PHASE=all|server|client`** (detached server + client-only benchmarks).
- **Reuse gate**: `/health` on `127.0.0.1:$PORT` + JSON metadata compatibility (`MODEL`, `TP`, `EXTRA_*`, `MAX_MODEL_LEN`, framework, InferenceX path, `PORT`); optional **`force_reuse`** to bypass mismatch errors.
- **`cleanup: true`**: terminate persisted server and remove `*.pid` / `*.json` under `~/.cache/magpie/server` (or `pid_dir`).
- When reuse is **eligible** (same checks as client-only path), **`gpu_selection.auto` is skipped** so `find_idle_gpus` does not reshuffle visible devices vs the already-running server.
- Examples: `examples/benchmarks/benchmark_vllm_reuse.yaml`, `benchmark_vllm_reuse_cleanup.yaml`; docs in `docs/benchmark.md`; tests in `tests/test_benchmark_support.py`.
- Reject native InferenceX scripts for this path until they implement the phase split; torch profiler + `cleanup: false` remains disallowed (existing validation).

> 
``` yaml
benchmark:
...
  server_lifecycle:
    # enabled: true to enable the server lifecycle
    enabled: true
    # cleanup: true to terminate the persisted server pid group after benchmark
    cleanup: false
    # force_reuse: true to bypass the mismatch errors (metadata mismatch includes tp, port, extra_vllm_args, extra_sglang_args, max_model_len, inferencex_path)
    force_reuse: false 
    # pid_dir defaults to ~/.cache/magpie/server/
    server_ready_timeout_s: 2700
```

## How to test
- Chain multiple runs with `benchmark_vllm_reuse.yaml` (`cleanup: false`), then one run with `benchmark_vllm_reuse_cleanup.yaml`.
