### PR TITLE
add CODEOWNERS, CONTRIBUTING.md, SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Team slugs: https://github.com/orgs/AMD-AGI/teams
+# Syntax:     https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Last matching rule wins. Prefer GitHub Teams over individuals.
+
+# Default — every file requires project-team approval
+# (any of: team OR any listed contributor satisfies the rule)
+*                            @AMD-AGI/brain-tio @haofrank @sinarafati-amd @mawad-amd @irvineoy 
+
+# Stricter paths — leads must approve
+.github/CODEOWNERS           @AMD-AGI/brain-tio-leads
+/.github/workflows/          @AMD-AGI/brain-tio-leads
+/src/core/                   @AMD-AGI/brain-tio-leads

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Do not open a public GitHub issue.** Report privately via one of:
 
-- **GitHub Private Vulnerability Reporting:** [Report a vulnerability](../../security/advisories/new)
+- **GitHub Private Vulnerability Reporting:** [Report a vulnerability](https://github.com/AMD-AGI/Magpie/security/advisories/new)
 - **AMD Product Security portal:** https://www.amd.com/en/resources/product-security.html
 
 Please include: description and impact, steps to reproduce, and affected versions or commits.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue.** Report privately via one of:
+
+- **GitHub Private Vulnerability Reporting:** [Report a vulnerability](../../security/advisories/new)
+- **AMD Product Security portal:** https://www.amd.com/en/resources/product-security.html
+
+Please include: description and impact, steps to reproduce, and affected versions or commits.
+
+We aim to acknowledge reports within 1 business day.
+
+## Scope
+
+This policy covers code and configuration in this repository — the Magpie kernel evaluation framework, including the compilation, correctness, and performance grading pipeline.
+
+Because Magpie compiles and executes user-supplied kernels, please flag any sandbox-escape, arbitrary-execution, or resource-exhaustion issues privately.
+
+For issues in third-party dependencies (ROCm, PyTorch, Triton, HIP/CUDA toolchains) report upstream. For AMD product issues unrelated to this repo, use the [AMD Product Security portal](https://www.amd.com/en/resources/product-security.html).


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` with team + individual contributor handles.
- Adds `CONTRIBUTING.md` at the repo root — project-tailored contribution guide mirroring the team's standard structure (Before You Start / Setup / Workflow / Code Style / Testing / Filing Issues / Security / Suggested Contributions / License).
- Adds `SECURITY.md` at the repo root — vulnerability-disclosure policy pointing to GitHub Private Vulnerability Reporting and the AMD Product Security portal, with a project-specific Scope section.