### PR TITLE
Fix broken references in magpie skills

### DIFF
--- a/skills/magpie/SKILL.md
+++ b/skills/magpie/SKILL.md
@@ -68,7 +68,7 @@ Run framework-level LLM inference benchmarks with optional profiling and gap ana
 **With config (recommended):**
 
 ```bash
-magpie benchmark --benchmark-config examples/benchmark_vllm.yaml
+magpie benchmark --benchmark-config examples/benchmarks/benchmark_vllm_dsr1.yaml
 ```
 
 **CLI overrides:** `magpie benchmark [vllm|sglang] -m <model> --benchmark-config <yaml>` with optional:
@@ -81,7 +81,7 @@ magpie benchmark --benchmark-config examples/benchmark_vllm.yaml
 - `--run-mode`: `docker` (default) or `local`.
 - `--docker-image`, `--timeout`, `-o`: Override image, timeout (seconds), output dir.
 
-Example configs: [examples/benchmark_vllm.yaml](examples/benchmark_vllm.yaml), [docs/benchmark.md](docs/benchmark.md).
+Example configs: [examples/benchmarks/benchmark_vllm_dsr1.yaml](examples/benchmarks/benchmark_vllm_dsr1.yaml), [docs/benchmark.md](docs/benchmark.md).
 
 ## Gap analysis (standalone)
 

--- a/skills/magpie/examples.md
+++ b/skills/magpie/examples.md
@@ -40,15 +40,15 @@ magpie compare k1.hip k2.hip k3.hip -t "./test.sh" --baseline 0
 ## Benchmark (config file)
 
 ```bash
-magpie benchmark --benchmark-config examples/benchmark_vllm.yaml
-magpie benchmark --benchmark-config examples/benchmark_sglang.yaml -o ./results
+magpie benchmark --benchmark-config examples/benchmarks/benchmark_vllm_dsr1.yaml
+magpie benchmark --benchmark-config examples/benchmarks/benchmark_sglang_dsr1.yaml -o ./results
 ```
 
 ## Benchmark (CLI overrides)
 
 ```bash
 magpie benchmark vllm -m deepseek-ai/DeepSeek-R1-0528 -p fp8 --tp 8
-magpie benchmark --benchmark-config examples/benchmark_vllm.yaml --run-mode local --timeout 1800
+magpie benchmark --benchmark-config examples/benchmarks/benchmark_vllm_dsr1.yaml --run-mode local --timeout 1800
 ```
 
 ## Gap analysis (standalone)
@@ -62,5 +62,5 @@ magpie benchmark gap-analysis --trace-dir ./results/run_xyz/torch_trace --top-k 
 
 ```bash
 magpie -v analyze --kernel-config my.yaml
-magpie --config path/to/config.yaml benchmark --benchmark-config examples/benchmark_vllm.yaml
+magpie --config path/to/config.yaml benchmark --benchmark-config examples/benchmarks/benchmark_vllm_dsr1.yaml
 ```

--- a/skills/magpie/reference.md
+++ b/skills/magpie/reference.md
@@ -100,4 +100,4 @@ kernels:
 
 ## Benchmark config YAML
 
-Top-level key `benchmark:` with `framework`, `model`, `precision`, `envs`, `profiler`, `gap_analysis`, `timeout_seconds`, etc. See `examples/benchmark_vllm.yaml` and `docs/benchmark.md`.
+Top-level key `benchmark:` with `framework`, `model`, `precision`, `envs`, `profiler`, `gap_analysis`, `timeout_seconds`, etc. See `examples/benchmarks/benchmark_vllm_dsr1.yaml` and `docs/benchmark.md`.


### PR DESCRIPTION
# Description

SKILL.md and reference.md point to `examples/benchmark_vllm.yaml`, which doesn't exist. Repointed to `examples/benchmarks/benchmark_vllm_dsr1.yaml`