### PR TITLE
docs: add ROCm documentation site source for Magpie

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration for Magpie documentation.
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: docs/sphinx/requirements.txt
+
+sphinx:
+  configuration: docs/conf.py
+
+# Only build HTML (+ htmlzip). PDF/epub are intentionally disabled: the docs
+# contain Mermaid diagrams, which require a headless browser to render in the
+# LaTeX/PDF pipeline and are not needed for the hosted HTML site.
+formats:
+  - htmlzip

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ python -m Magpie.mcp
 | **Compare** | Multi-kernel comparison and ranking | ✅ |
 | **Benchmark** | Framework-level benchmarking (vLLM/SGLang/Atom) with trace analysis | ✅ |
 
-> 📖 See [Benchmark mode](docs/benchmark.md) for vLLM/SGLang/Atom usage.  
-> 📖 See [Analyze vs Compare](docs/analysis_compare.md) for kernel evaluation modes.
+> 📖 See [Benchmark mode](docs/how-to/benchmark.md) for vLLM/SGLang/Atom usage.  
+> 📖 See [Analyze vs Compare](docs/how-to/analyze-compare.md) for kernel evaluation modes.
 
 ## Configuration
 
@@ -127,7 +127,7 @@ Available tools:
 - `get_benchmark_result` - Read detailed results from a specific benchmark run
 - `compare_benchmark_reports` - Compare TraceLens reports across benchmark runs
 
-For environments without MCP, install the Magpie skill; see [docs/skills-install.md](docs/skills-install.md).
+For environments without MCP, install the Magpie skill; see [docs/how-to/mcp-and-skills.md](docs/how-to/mcp-and-skills.md).
 
 ## Development
 
@@ -147,10 +147,13 @@ make format
 ├── requirements.txt
 ├── Makefile
 ├── examples/            # Example configurations
-├── docs/                # Documentation
-│   ├── benchmark.md          # Benchmark mode (vLLM / SGLang / Atom)
-│   ├── analysis_compare.md   # Analyze vs Compare kernel modes
-│   ├── skills-install.md     # Agent skill installation
+├── docs/                # Documentation (ROCm docs site source)
+│   ├── index.rst             # Overview / landing page
+│   ├── install/              # Installation instructions
+│   ├── reference/            # Release notes, compatibility, API reference
+│   ├── how-to/               # How-to guides (benchmark, analyze/compare, ray, MCP/skills)
+│   ├── examples/             # Step-by-step examples
+│   ├── about/                # License
 │   └── images/               # Architecture diagrams
 └── Magpie/
     ├── __init__.py          # Package initialization

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+_build/
+_doxygen/
+_toc.yml
+sphinx/_toc.yml

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,74 @@
+# Magpie documentation
+
+This directory contains the source for the Magpie documentation site, which is
+intended for publication on [rocm.docs.amd.com](https://rocm.docs.amd.com/) as a
+component of the Hyperloom toolkit. It follows the same structure as other ROCm
+toolkit component docs (for example,
+[ROCm-LLMExt](https://rocm.docs.amd.com/projects/rocm-llmext/en/latest/index.html)).
+
+The site is built with [Sphinx](https://www.sphinx-doc.org/) and
+[rocm-docs-core](https://github.com/ROCm/rocm-docs-core). Both Markdown (MyST,
+`.md`) and reStructuredText (`.rst`) sources are supported and can be mixed.
+
+## Building locally
+
+```bash
+# From the repository root
+python3 -m venv .docvenv
+source .docvenv/bin/activate
+pip install -r docs/sphinx/requirements.txt
+
+python -m sphinx -T -b html docs docs/_build/html
+# Open docs/_build/html/index.html
+```
+
+## Layout
+
+| Path | Required page | Notes |
+| --- | --- | --- |
+| `index.rst` | Overview | Landing page; feature summary, use cases, links to all subpages and the GitHub repo. |
+| `install/install.md` | Installation Instructions | pip-from-GitHub, source/editable, and `make` methods, plus verification. |
+| `reference/release-notes.md` | Release Notes | Per-release feature breakdown; initial release lists all features. |
+| `reference/compatibility-matrix.md` | Compatibility Matrix | Verified hardware/software versions. Contains `TODO (verify)` markers. |
+| `reference/api-reference.md` | API Reference | CLI commands and options, configuration schema, and MCP tools. |
+| `how-to/analyze-compare.md` | How-to | Analyze vs compare kernel modes. |
+| `how-to/benchmark.md` | How-to | vLLM/SGLang/Atom benchmarking, TraceLens, gap analysis. |
+| `how-to/ray.md` | How-to | Remote execution on a Ray cluster. |
+| `how-to/mcp-and-skills.md` | How-to | MCP server and agent skill installation. |
+| `how-to/kernel-source-finder.md` | How-to | Locating kernel sources from traces. |
+| `examples/examples.md` | Examples | Step-by-step walkthroughs with expected output. |
+| `about/license.md` | License | Full MIT license text (mirrors the repo `LICENSE`). |
+
+Navigation (the left sidebar) is defined in `sphinx/_toc.yml.in`.
+
+## Configuration files
+
+| File | Purpose |
+| --- | --- |
+| `../.readthedocs.yaml` | Read the Docs build configuration. |
+| `conf.py` | Sphinx configuration (rocm-docs-core, MyST, mermaid). |
+| `sphinx/_toc.yml.in` | Table of contents / sidebar navigation. |
+| `sphinx/requirements.in` | Top-level documentation dependencies. |
+| `sphinx/requirements.txt` | Pinned documentation dependencies used by the build. |
+
+## Open items for the Magpie team
+
+These must be resolved before publication:
+
+- **Compatibility matrix**: replace every `TODO (verify)` entry in
+  `reference/compatibility-matrix.md` with verified, tested versions (ROCm/CUDA,
+  GPU architectures, framework versions, Docker, Ray, profilers).
+- **About / Resources**: add the public Magpie blog URL once available (the
+  ROCm-LLMExt site links a per-component blog under "Resources").
+- **API reference depth**: decide whether to keep the hand-written CLI/MCP/config
+  reference or augment it with `autodoc`/`autosummary` generated from Python
+  docstrings.
+- **Project registration**: during ROCm onboarding, register `Magpie` in the
+  rocm-docs-core project registry. Until then, a local build prints a benign
+  `Current project 'Magpie' not found in projects` warning.
+
+## Notes on the local build
+
+A local build outside AMD infrastructure prints benign warnings for intersphinx
+inventory fetches (for example, `instinct.docs.amd.com/objects.inv`); these
+resolve on the ROCm build infrastructure. The build itself succeeds.

--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -1,0 +1,29 @@
+# License
+
+Magpie is released under the MIT License. The full license text below matches
+the [`LICENSE`](https://github.com/AMD-AGI/Magpie/blob/main/LICENSE) file in the
+Magpie GitHub repository.
+
+```text
+MIT License
+
+Copyright (c) 2026 AMD-AGI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,37 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# Magpie documentation is built with rocm-docs-core, which configures the
+# theme, navigation, MyST Markdown support, and shared ROCm options. Both
+# Markdown (.md, via MyST) and reStructuredText (.rst) source files build out
+# of the box.
+#
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+# https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/
+
+# -- Project information ------------------------------------------------------
+
+project = "Magpie"
+author = "Advanced Micro Devices, Inc."
+copyright = "2026, Advanced Micro Devices, Inc."
+
+# Single-sourced version. Update alongside pyproject.toml / package version.
+version = "0.1.0"
+release = version
+
+# -- General configuration ----------------------------------------------------
+
+extensions = ["rocm_docs", "sphinxcontrib.mermaid"]
+
+# Render fenced ```mermaid code blocks in Markdown as diagrams.
+myst_fence_as_directive = ["mermaid"]
+
+external_toc_path = "./sphinx/_toc.yml"
+
+# docs/README.md documents the build process for contributors and is not a
+# published page; keep it out of the source build so it is not treated as an
+# orphan document.
+exclude_patterns = ["README.md"]
+
+# rocm-docs-core options.
+html_theme = "rocm_docs_theme"
+html_theme_options = {"flavor": "rocm-docs-home"}

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -1,0 +1,170 @@
+# Examples
+
+This page provides end-to-end, step-by-step examples for common Magpie use
+cases. Each example lists the prerequisites, the exact commands to run, and the
+expected output. All example configuration files referenced here live in the
+[`examples/`](https://github.com/AMD-AGI/Magpie/tree/main/examples) directory of
+the Magpie repository.
+
+Run every command from the Magpie repository root unless noted otherwise.
+
+## Example 1: Analyze a simple HIP kernel
+
+This example analyzes a minimal HIP `vector_add` kernel for correctness using a
+testcase command.
+
+**Prerequisites**
+
+- A working AMD ROCm/HIP toolchain (`hipcc` on your `PATH`).
+- Magpie installed (see [Install Magpie](../install/install.md)).
+
+**Steps**
+
+1. Build the sample kernel binary:
+
+   ```bash
+   cd examples/simple_hip_test
+   hipcc -g -O2 -o vector_add vector_add.hip
+   cd ../..
+   ```
+
+2. Run the analysis, skipping performance profiling:
+
+   ```bash
+   python -m Magpie analyze \
+     --kernel-config examples/simple_hip_test/analyze_default.yaml \
+     --no-perf
+   ```
+
+   The config defines a single kernel and its testcase:
+
+   ```yaml
+   kernel:
+     id: "vector_add"
+     type: hip
+     source_files:
+       - "./vector_add.hip"
+     testcase_command: "./vector_add"
+     working_dir: "examples/simple_hip_test"
+   ```
+
+**Expected output**
+
+Magpie reports a passing correctness state and writes a JSON report to
+`./results`. The summary indicates the kernel compiled and the testcase passed,
+with an overall `score` of `1.0` when correctness succeeds and profiling is
+skipped.
+
+## Example 2: Compare two kernel implementations
+
+This example compares BF16 and FP16 grouped GEMM kernels from Composable Kernel
+and ranks them by performance.
+
+**Prerequisites**
+
+- AMD ROCm/HIP toolchain and a built
+  [Composable Kernel](https://github.com/ROCm/composable_kernel) checkout.
+- `rocprof-compute` installed if you want performance metrics.
+
+**Steps**
+
+1. Clone and point Magpie at Composable Kernel:
+
+   ```bash
+   git clone https://github.com/ROCm/composable_kernel.git
+   export CK_HOME=/path/to/composable_kernel
+   ```
+
+2. Build the required example targets (see the comments in the config), then run
+   the comparison:
+
+   ```bash
+   python -m Magpie compare \
+     --kernel-config examples/ck_grouped_gemm_compare.yaml
+   ```
+
+   The config lists the two kernels to compare:
+
+   ```yaml
+   kernels:
+     - id: "grouped_gemm_xdl_bf16"
+       type: hip
+       source_files:
+         - "${CK_HOME}/example/15_grouped_gemm/grouped_gemm_xdl_bf16.cpp"
+       working_dir: "${CK_HOME}/build"
+       testcase_command: "bin/example_grouped_gemm_xdl_bf16"
+     - id: "grouped_gemm_xdl_fp16"
+       type: hip
+       source_files:
+         - "${CK_HOME}/example/15_grouped_gemm/grouped_gemm_xdl_fp16.cpp"
+       working_dir: "${CK_HOME}/build"
+       testcase_command: "bin/example_grouped_gemm_xdl_fp16"
+   ```
+
+**Expected output**
+
+Magpie evaluates both kernels, prints a ranked comparison against the baseline
+(index `0` by default), and writes a JSON report identifying the winning
+implementation. See [Analyze and compare kernels](../how-to/analyze-compare.md)
+for how scores and rankings are computed.
+
+## Example 3: Benchmark vLLM with TraceLens analysis
+
+This example runs a framework-level benchmark of vLLM and analyzes the resulting
+traces.
+
+**Prerequisites**
+
+- Docker (for the default `docker` run mode), or run with `--run-mode local`
+  inside a prepared container.
+- Access to the model referenced by the benchmark config.
+
+**Steps**
+
+1. Run the benchmark from a config file:
+
+   ```bash
+   python -m Magpie benchmark \
+     --benchmark-config examples/benchmarks/benchmark_vllm_dsr1.yaml
+   ```
+
+2. To include TraceLens trace analysis, use the TraceLens example config:
+
+   ```bash
+   python -m Magpie benchmark \
+     --benchmark-config examples/benchmarks/benchmark_vllm_tracelens.yaml
+   ```
+
+**Expected output**
+
+Magpie launches the benchmark, collects throughput and latency metrics, and (for
+the TraceLens config) produces a trace analysis report under the benchmark
+workspace in `./results`. See [Benchmark frameworks](../how-to/benchmark.md) for
+the full result layout and metric descriptions.
+
+## Example 4: Standalone gap analysis on existing traces
+
+If you already have torch profiler traces, you can run gap analysis without
+launching a benchmark to find the kernels that dominate runtime.
+
+**Steps**
+
+```bash
+python -m Magpie benchmark \
+  --trace-dir /path/to/torch_trace \
+  --top-k 20
+```
+
+**Expected output**
+
+Magpie writes a `gap_analysis/gap_analysis.csv` file (plus optional per-rank
+CSVs) under the trace directory, listing the top bottleneck kernels by
+aggregated duration. Add `--find-kernel-sources` to also locate kernel source
+files and test commands for AMD kernels; see
+[Find kernel sources](../how-to/kernel-source-finder.md).
+
+## More examples
+
+The [`examples/benchmarks/`](https://github.com/AMD-AGI/Magpie/tree/main/examples/benchmarks)
+directory contains many additional ready-to-run benchmark configurations,
+including SGLang, Atom, Ray-based runs, and a range of models and precisions.

--- a/docs/how-to/analyze-compare.md
+++ b/docs/how-to/analyze-compare.md
@@ -13,7 +13,7 @@ Magpie’s **Analyze** and **Compare** modes both evaluate GPU kernels (HIP, CUD
 | **CLI** | `magpie analyze …` | `magpie compare …` |
 | **Report file** | `analyze_report.json` | `compare_report.json` |
 
-For architecture and diagrams, see the [README](../README.md) (Analyze & Compare pipeline image).
+For architecture and diagrams, see the [README](https://github.com/AMD-AGI/Magpie#readme) (Analyze & Compare pipeline image).
 
 ## When to use which
 
@@ -98,5 +98,5 @@ Analyze and compare runs create timestamped workspaces under `--output-dir` (def
 ## Related documentation
 
 - [Benchmark mode](benchmark.md) — vLLM/SGLang framework benchmarks (separate from kernel analyze/compare).
-- [Skills install](skills-install.md) — using Magpie without MCP.
-- [Ray scheduling (EN)](ray-magpie.md) — remote execution when `scheduler.environment: ray`.
+- [Skills install](mcp-and-skills.md) — using Magpie without MCP.
+- [Ray scheduling (EN)](ray.md) — remote execution when `scheduler.environment: ray`.

--- a/docs/how-to/benchmark.md
+++ b/docs/how-to/benchmark.md
@@ -2,7 +2,7 @@
 
 Benchmark mode enables framework-level performance benchmarking for LLM inference engines (vLLM, SGLang, Atom) with integrated trace analysis capabilities. Atom support is single-node only in v1 (no Ray multi-node TP, no torch-profiler wiring).
 
-**Execution:** Benchmarks use `run_mode`: **`docker`** (default), **`local`** (host / in-pod, via YAML or `--run-mode local`), or **`ray`** (driver submits `RayJobExecutor`; a **GPU worker** runs the same InferenceX → vLLM/SGLang flow—see [Magpie + Ray](ray-magpie.md)). InferenceX is cloned automatically when `inferencex_path` is empty (see `Magpie/config.yaml` `benchmark.inferencex_path`).
+**Execution:** Benchmarks use `run_mode`: **`docker`** (default), **`local`** (host / in-pod, via YAML or `--run-mode local`), or **`ray`** (driver submits `RayJobExecutor`; a **GPU worker** runs the same InferenceX → vLLM/SGLang flow—see [Magpie + Ray](ray.md)). InferenceX is cloned automatically when `inferencex_path` is empty (see `Magpie/config.yaml` `benchmark.inferencex_path`).
 
 ## Overview
 
@@ -24,7 +24,7 @@ Benchmark mode enables framework-level performance benchmarking for LLM inferenc
 │  │  └─────────────┘        └─────────────────────────────────┘  │   │
 │  │  Ray: Magpie driver → RayJobExecutor → GPU worker runs the   │   │
 │  │        same stack (local/docker on worker; NFS for cache/     │   │
-│  │        results). See docs/ray-magpie.md                       │   │
+│  │        results). See ray.md                                   │   │
 │  └──────────────────────────────────────────────────────────────┘   │
 │                               │                                     │
 │                      ┌────────┴────────┐                            │
@@ -355,9 +355,9 @@ results/benchmark_vllm_<timestamp>/
 
 ## Benchmark report
 
-The primary summary file is **`benchmark_report.json`** in the run workspace (see `WorkspaceManager.save_report`). It aggregates throughput, latency, and optional `gap_analysis` / `tracelens_analysis` sections. A typical shape:
+The primary summary file is **`benchmark_report.json`** in the run workspace (see `WorkspaceManager.save_report`). It aggregates throughput, latency, and optional `gap_analysis` / `tracelens_analysis` sections. A typical shape (abbreviated, with `...` marking elided values):
 
-```json
+```text
 {
   "success": true,
   "framework": "vllm",
@@ -533,10 +533,10 @@ python -m Magpie benchmark --benchmark-config config.yaml --log-level DEBUG
 
 ## Related
 
-- [Analyze vs Compare](analysis_compare.md) — kernel evaluation modes (orthogonal to Benchmark)
+- [Analyze vs Compare](analyze-compare.md) — kernel evaluation modes (orthogonal to Benchmark)
 - [TraceLens](https://github.com/AMD-AIG-AIMA/TraceLens) — Trace analysis library
 - [InferenceX](https://github.com/SemiAnalysisAI/InferenceX) — Benchmark scripts (auto-clone target in default config)
 - [vLLM](https://github.com/vllm-project/vllm) — LLM inference engine
 - [SGLang](https://github.com/sgl-project/sglang) — LLM serving framework
-- [Ray + Magpie](ray-magpie.md) — optional remote benchmark scheduling
+- [Ray + Magpie](ray.md) — optional remote benchmark scheduling
 

--- a/docs/how-to/kernel-source-finder.md
+++ b/docs/how-to/kernel-source-finder.md
@@ -64,7 +64,7 @@ The searcher looks up source files using:
 
 Results are written to `gap_analysis.csv`:
 
-```csv
+```text
 Name,Calls,Self CUDA total (us),...,kind,category,source_repo,source_file,upstream_url,test_file,test_cmd,notes
 _matmul_ogs_NNT_bf16.kd,24552,5631747.87,...,triton_jit,gemm,triton_kernels,$TRITON_KERNELS_DIR/matmul_details/_matmul.py,https://github.com/...,$TRITON_KERNELS_DIR/tests/test_matmul.py,cd $TRITON_KERNELS_DIR && pytest tests/test_matmul.py -v,dtype=bf16
 ```

--- a/docs/how-to/mcp-and-skills.md
+++ b/docs/how-to/mcp-and-skills.md
@@ -1,4 +1,23 @@
-# Installing the Magpie skill
+# MCP server and agent skills
+
+Magpie can be driven by AI agents in two ways: the Model Context Protocol (MCP)
+server, or the Magpie agent skill for editors that do not support MCP.
+
+## Run the MCP server
+
+The MCP server exposes Magpie's evaluation capabilities (analyze, compare,
+benchmark, gap analysis, hardware queries, and more) as MCP tools. Start it
+with:
+
+```bash
+python -m Magpie.mcp
+```
+
+A sample client configuration is provided at `Magpie/mcp/config.json`. For the
+full list of tools and their parameters, see the
+[API reference](../reference/api-reference.md).
+
+## Installing the Magpie skill
 
 The Magpie skill lets AI agents (Cursor, Claude Code, Codex, etc.) drive Magpie through documented CLI patterns when MCP is not available. The skill lives in this repo under **`skills/magpie/`** (IDE-neutral). Install it into each editor’s skills directory with the script below, or follow the manual copy steps.
 
@@ -31,7 +50,7 @@ chmod +x skills/install-skill.sh
 
 **Behavior:** The script removes any existing destination folder named `magpie` and copies `skills/magpie` there. No editor restart is usually required.
 
-**Related docs:** [Analyze vs Compare](analysis_compare.md), [Benchmark mode](benchmark.md), [README](../README.md) (MCP vs skill).
+**Related docs:** [Analyze vs Compare](analyze-compare.md), [Benchmark mode](benchmark.md), [README](https://github.com/AMD-AGI/Magpie#readme) (MCP vs skill).
 
 ## Manual install
 
@@ -73,7 +92,7 @@ Same `SKILL.md` format and layout.
   cp -r /path/to/Magpie/skills/magpie ~/.codex/skills/magpie
   ```
   Use the path your IDE documents for custom skills.
-- If the IDE only has a **single “custom instructions”** or “rules” field, paste the body of [skills/magpie/SKILL.md](../skills/magpie/SKILL.md) (the markdown after the YAML frontmatter) into that field, and add a note that these instructions apply when working with Magpie, GPU kernel analysis/compare, or vLLM/SGLang benchmarks.
+- If the IDE only has a **single “custom instructions”** or “rules” field, paste the body of [skills/magpie/SKILL.md](https://github.com/AMD-AGI/Magpie/blob/main/skills/magpie/SKILL.md) (the markdown after the YAML frontmatter) into that field, and add a note that these instructions apply when working with Magpie, GPU kernel analysis/compare, or vLLM/SGLang benchmarks.
 
 ## Verifying the skill
 

--- a/docs/how-to/ray.md
+++ b/docs/how-to/ray.md
@@ -2,7 +2,7 @@
 
 This document describes how [Ray](https://www.ray.io/) is integrated into Magpie so that **analyze**, **compare**, and **benchmark** workloads can run on **remote GPU nodes** instead of (or in addition to) the machine where you invoke the CLI or MCP.
 
-It is a **reference manual** for operators and contributors. For Benchmark-mode diagrams and YAML examples, see [benchmark.md](benchmark.md). For kernel analyze vs compare semantics, see [analysis_compare.md](analysis_compare.md).
+It is a **reference manual** for operators and contributors. For Benchmark-mode diagrams and YAML examples, see [benchmark.md](benchmark.md). For kernel analyze vs compare semantics, see [analyze-compare.md](analyze-compare.md).
 
 ---
 
@@ -274,4 +274,4 @@ Derived helpers: `results_dir`, `hf_cache_dir`, `inferencex_dir`.
 ## 13. Related material
 
 - [benchmark.md](benchmark.md) — Benchmark mode, TraceLens, gap analysis, `run_mode` overview.
-- [analysis_compare.md](analysis_compare.md) — Kernel analyze vs compare.
+- [analyze-compare.md](analyze-compare.md) — Kernel analyze vs compare.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,95 @@
+.. meta::
+   :description: Magpie is a lightweight, general-purpose framework for evaluating GPU kernel correctness and performance on AMD and NVIDIA GPUs.
+   :keywords: Magpie, ROCm, GPU, kernel, evaluation, benchmark, HIP, CUDA, profiling, AMD
+
+********************
+Magpie documentation
+********************
+
+Magpie is a lightweight, general-purpose framework for evaluating GPU kernel
+correctness and performance. It provides a single, reproducible workflow for
+checking that a kernel is correct, comparing competing implementations, and
+benchmarking full inference frameworks, on both AMD (HIP/ROCm) and NVIDIA
+(CUDA) hardware.
+
+Magpie is a component of the Hyperloom toolkit. The Magpie source code is
+hosted in the `AMD-AGI/Magpie <https://github.com/AMD-AGI/Magpie>`_ GitHub
+repository.
+
+What Magpie does
+================
+
+Magpie organizes kernel evaluation into three modes:
+
+* **Analyze** -- Evaluate a single kernel against a testcase for correctness,
+  then optionally profile its performance.
+* **Compare** -- Evaluate and rank multiple kernel implementations against a
+  baseline to find the fastest correct variant.
+* **Benchmark** -- Run framework-level benchmarks (vLLM, SGLang, Atom) with
+  optional torch and system profiling, including TraceLens trace analysis and
+  kernel-level gap analysis.
+
+Key features
+============
+
+* **Three evaluation modes**: analyze, compare, and benchmark.
+* **Heterogeneous hardware**: AMD (HIP) and NVIDIA (CUDA) GPUs.
+* **Multiple execution environments**: local host, sandboxed container, and
+  remote Ray cluster.
+* **Hardware-aware evaluation**: controlled execution with optional power and
+  frequency settings.
+* **Automatic GPU selection**: benchmark mode picks idle GPUs before launching.
+* **Trace analysis**: TraceLens integration for performance profiling and gap
+  analysis.
+* **MCP server**: Model Context Protocol integration for AI agents.
+* **Structured reports**: JSON output for pipeline integration.
+
+Use cases
+=========
+
+* Validate hand-written or AI-generated GPU kernels for correctness before
+  promoting them.
+* Rank competing kernel implementations to pick the fastest correct one.
+* Benchmark and profile LLM inference frameworks on AMD GPUs and locate the
+  kernels that dominate runtime.
+* Drive kernel evaluation from an AI agent through the MCP server.
+
+Documentation
+=============
+
+The Magpie documentation is organized into the following categories.
+
+.. grid:: 2
+   :gutter: 3
+
+   .. grid-item-card:: Install
+
+      * :doc:`Install Magpie <install/install>`
+
+   .. grid-item-card:: Reference
+
+      * :doc:`Release notes <reference/release-notes>`
+      * :doc:`Compatibility matrix <reference/compatibility-matrix>`
+      * :doc:`API reference <reference/api-reference>`
+
+   .. grid-item-card:: How to
+
+      * :doc:`Analyze and compare kernels <how-to/analyze-compare>`
+      * :doc:`Benchmark frameworks <how-to/benchmark>`
+      * :doc:`Run on a Ray cluster <how-to/ray>`
+      * :doc:`MCP server and agent skills <how-to/mcp-and-skills>`
+      * :doc:`Find kernel sources <how-to/kernel-source-finder>`
+
+   .. grid-item-card:: Examples
+
+      * :doc:`Examples <examples/examples>`
+
+   .. grid-item-card:: About
+
+      * :doc:`License <about/license>`
+
+To contribute to the documentation, see the
+`Magpie GitHub repository <https://github.com/AMD-AGI/Magpie>`_.
+
+Magpie is released under the MIT license. For details, see the
+:doc:`License <about/license>` page.

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -1,0 +1,132 @@
+# Install Magpie
+
+This page provides step-by-step instructions to install Magpie and verify the
+installation on your system. Choose the method that best fits your workflow:
+install directly from GitHub (recommended for most users), install from source
+(recommended for development), or install into a managed virtual environment
+with `make`.
+
+## Prerequisites
+
+Before installing Magpie, make sure your system meets the following
+requirements:
+
+- Python 3.10 or newer
+- `pip` (and optionally `git` for source/GitHub installs)
+- An AMD ROCm (HIP) or NVIDIA CUDA toolchain, if you plan to compile or profile
+  GPU kernels
+- (Optional) `rocprof-compute` (AMD) or `ncu` (NVIDIA) for performance profiling
+- (Optional) Docker, used by Benchmark mode when `run_mode` is `docker`
+
+For the full list of verified hardware and software versions, see the
+[Compatibility matrix](../reference/compatibility-matrix.md).
+
+## Install from GitHub (recommended)
+
+This installs the latest published Magpie package and its core dependencies.
+
+```bash
+pip install git+https://github.com/AMD-AGI/Magpie.git
+```
+
+To also install the optional Model Context Protocol (MCP) server dependencies,
+request the `mcp` extra:
+
+```bash
+pip install "magpie-eval[mcp] @ git+https://github.com/AMD-AGI/Magpie.git"
+```
+
+## Install from source (development)
+
+Use an editable install when you want to modify Magpie or follow the latest
+changes on a branch.
+
+```bash
+# Clone the repository
+git clone https://github.com/AMD-AGI/Magpie.git
+cd Magpie
+
+# Editable install (recommended for development)
+pip install -e .
+
+# Optional: include the MCP server extra
+pip install -e ".[mcp]"
+
+# Optional: include development tools (pytest, black, isort, mypy)
+pip install -e ".[dev]"
+```
+
+## Install with make (managed virtual environment)
+
+The provided `Makefile` creates a `.venv` virtual environment and installs the
+runtime dependencies from `requirements.txt`.
+
+```bash
+git clone https://github.com/AMD-AGI/Magpie.git
+cd Magpie
+
+# Create .venv and install runtime dependencies
+make install
+
+# Or install runtime + development tools
+make install-dev
+
+# Activate the environment
+source .venv/bin/activate
+```
+
+## Optional dependencies
+
+Some Magpie features rely on additional packages that are not installed by
+default. Install them based on the features you need:
+
+- **GPU frameworks**: `torch`, `triton`, `vllm`, or `sglang` for kernel
+  compilation and framework benchmarks.
+- **AMD profiling**: `rocprof-compute` (version 3.40 or newer). See the
+  [rocprofiler-compute install guide](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/install/core-install.html).
+- **NVIDIA profiling**: `ncu` (Nsight Compute). See the
+  [Nsight Compute CLI documentation](https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html).
+- **IntelliKit Metrix** (human-readable AMD profiling metrics):
+
+  ```bash
+  pip install "git+https://github.com/AMDResearch/intellikit.git#subdirectory=metrix"
+  ```
+
+- **IntelliKit Accordo** (AMD kernel correctness validation via HSA
+  interception):
+
+  ```bash
+  pip install "git+https://github.com/AMDResearch/intellikit.git#subdirectory=accordo"
+  ```
+
+## Verify the installation
+
+After installing, confirm that the package imports and the CLI is available:
+
+```bash
+# Confirm the package imports
+python -c "import Magpie; print('Magpie import OK')"
+
+# Confirm the CLI is on your PATH
+magpie --help
+
+# Show detected GPU and toolchain information
+magpie --gpu-info
+```
+
+```{note}
+You can use `python -m Magpie` in place of the `magpie` CLI for the same
+subcommands.
+```
+
+A successful `magpie --gpu-info` run prints the detected GPU vendor,
+architecture, and device count. If no GPU is detected, kernel compilation and
+profiling features are unavailable, but the CLI still installs and runs.
+
+## Next steps
+
+- Run your first evaluation with the [Analyze and compare](../how-to/analyze-compare.md)
+  guide.
+- Benchmark an inference framework with the [Benchmark](../how-to/benchmark.md)
+  guide.
+- Browse the [Examples](../examples/examples.md) for end-to-end walkthroughs.

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -1,0 +1,237 @@
+# API reference
+
+Magpie exposes three public interfaces: a command-line interface (CLI), a set of
+configuration files, and a Model Context Protocol (MCP) server for AI agents.
+This page documents each interface, including command names, parameters, and
+expected behavior.
+
+```{note}
+You can invoke the CLI either as `magpie <command>` or as
+`python -m Magpie <command>`. Both forms accept the same arguments.
+```
+
+## Command-line interface
+
+### Global options
+
+These options apply to every command and are passed before the subcommand.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--config`, `-c` | path | `Magpie/config.yaml` | Framework configuration file. |
+| `--verbose`, `-v` | flag | off | Enable verbose (DEBUG) logging. |
+| `--gpu-info` | flag | off | Print detected GPU and toolchain info, then exit. |
+| `--environment`, `-e` | `local` \| `container` \| `ray` | `local` | Execution environment. |
+| `--workers`, `-w` | int | from config | Number of concurrent workers. |
+| `--docker-image` | string | from config | Docker image for the container environment. |
+
+Example:
+
+```bash
+# Show detected GPU information and exit
+magpie --gpu-info
+```
+
+### `magpie analyze`
+
+Evaluate a single kernel for correctness against a testcase, then optionally
+profile its performance.
+
+```bash
+magpie analyze [kernels ...] [options]
+```
+
+| Argument / option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `kernels` | path(s) | none | Kernel source file(s) to analyze. |
+| `--kernel-config`, `-k` | path | none | Kernel configuration file (alternative to positional kernels). |
+| `--testcase`, `-t` | string | none | Testcase command used to verify correctness. |
+| `--type` | `hip` \| `cuda` \| `pytorch` \| `triton` | `hip` | Kernel type. |
+| `--compile-cmd` | string | auto | Custom compile command. |
+| `--no-perf` | flag | off | Skip performance profiling. |
+| `--output-dir`, `-o` | path | `./results` | Output directory for reports. |
+
+Example:
+
+```bash
+magpie analyze --kernel-config Magpie/kernel_config.yaml.example
+```
+
+### `magpie compare`
+
+Evaluate and rank multiple kernel implementations against a baseline.
+
+```bash
+magpie compare [kernels ...] [options]
+```
+
+| Argument / option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `kernels` | path(s) | none | Kernel files to compare. |
+| `--kernel-config`, `-k` | path | none | Kernel configuration file. |
+| `--testcase`, `-t` | string | none | Testcase command (optional). |
+| `--type` | `hip` \| `cuda` \| `pytorch` \| `triton` | `hip` | Kernel type. |
+| `--baseline` | int | `0` | Index of the baseline kernel. |
+| `--no-perf` | flag | off | Skip performance profiling. |
+| `--output-dir`, `-o` | path | `./results` | Output directory for reports. |
+
+Example:
+
+```bash
+magpie compare --kernel-config examples/ck_grouped_gemm_compare.yaml
+```
+
+### `magpie benchmark`
+
+Run a framework-level benchmark (vLLM, SGLang, or Atom) with optional profiling,
+or run standalone gap analysis on existing traces.
+
+```bash
+magpie benchmark [framework] [options]
+```
+
+| Argument / option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `framework` | `vllm` \| `sglang` \| `atom` | none | Framework to benchmark. |
+| `--benchmark-config`, `-b` | path | none | Benchmark configuration file. |
+| `--model`, `-m` | string | none | Model name or path. |
+| `--precision`, `-p` | `fp8` \| `fp16` \| `bf16` \| `fp4` | `fp8` | Model precision. |
+| `--tp` | int | `1` | Tensor parallel size. |
+| `--concurrency` | int | `32` | Request concurrency. |
+| `--input-len` | int | `1024` | Input sequence length. |
+| `--output-len` | int | `512` | Output sequence length. |
+| `--torch-profiler` | flag | off | Enable the torch profiler. |
+| `--system-profiler` | flag | off | Enable the system profiler (rocprof/ncu). |
+| `--run-mode` | `docker` \| `local` | `docker` | Run in a container or directly on the host. |
+| `--docker-image` | string | from config | Override the Docker image. |
+| `--inferencex-path` | string | auto-clone | Path to an InferenceX installation. |
+| `--benchmark-script` | string | none | InferenceX benchmark script name. |
+| `--timeout` | int | `3600` | Benchmark timeout in seconds. |
+| `--output-dir`, `-o` | path | `./results` | Output directory for reports. |
+
+#### Standalone gap analysis options
+
+When `--trace-dir` is provided, `benchmark` runs gap analysis on existing torch
+traces instead of launching a benchmark.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--trace-dir` | path | none | Run gap analysis on this `torch_trace` directory (or a workspace containing one). |
+| `--top-k` | int | `20` | Number of top bottleneck kernels to report. |
+| `--start-pct` | float | `0.0` | Start of the analysis window (0-100). |
+| `--end-pct` | float | `100.0` | End of the analysis window (0-100). |
+| `--min-duration-us` | float | `0.0` | Minimum event duration to include, in microseconds. |
+| `--categories` | string(s) | all | Event categories to include (for example, `kernel gpu`). |
+| `--ignore-categories` | string(s) | none | Event categories to exclude. |
+| `--no-rank-csv` | flag | off | Skip per-rank CSV generation. |
+| `--find-kernel-sources` | flag | off | Find kernel source files and test commands (AMD kernels). |
+| `--kernel-source-repos` | string(s) | none | Repository paths to search for kernel sources. |
+
+Example:
+
+```bash
+magpie benchmark --benchmark-config examples/benchmarks/benchmark_vllm_dsr1.yaml
+```
+
+## Configuration reference
+
+Magpie is driven by YAML configuration files. See
+[`Magpie/config.yaml`](https://github.com/AMD-AGI/Magpie/blob/main/Magpie/config.yaml)
+and
+[`Magpie/kernel_config.yaml.example`](https://github.com/AMD-AGI/Magpie/blob/main/Magpie/kernel_config.yaml.example)
+for complete, commented examples.
+
+### Framework configuration (`config.yaml`)
+
+| Section | Purpose |
+| --- | --- |
+| `gpu` | Device selection and hardware control (power/frequency). |
+| `scheduler` | Execution environment (local, container, or Ray) and worker settings. |
+| `compiling` | Default compile behavior. |
+| `correctness` | Correctness backend (testcase or Accordo) and tolerances. |
+| `performance` | Profiler backend (`rocprof-compute`, `ncu`, Metrix), timeouts, and metric blocks. |
+| `compare` | Performance metric weights and winner selection for compare mode. |
+| `benchmark` | InferenceX path, image mapping, and default profiler flags. |
+| `logging` | Log levels and optional file output. |
+
+### Kernel configuration
+
+A kernel configuration file may define a single `kernel:` or multiple
+`kernels:`, plus optional override sections:
+
+| Key | Purpose |
+| --- | --- |
+| `kernel` | A single kernel entry (path, type, testcase, compile command). |
+| `kernels` | A list of kernel entries for compare mode. |
+| `performance` | Overrides framework-level profiler settings. |
+| `correctness` | Overrides framework-level correctness settings. |
+| `ray_config` | Ray cluster settings (implies `environment: ray`). |
+| `scheduler` | Scheduler-level overrides (environment, workers, and so on). |
+
+## MCP server
+
+Start the MCP server with:
+
+```bash
+python -m Magpie.mcp
+```
+
+A sample client configuration is available at
+[`Magpie/mcp/config.json`](https://github.com/AMD-AGI/Magpie/blob/main/Magpie/mcp/config.json).
+All tools return JSON-formatted strings.
+
+### Available tools
+
+| Tool | Description |
+| --- | --- |
+| `analyze` | Analyze a kernel for correctness and performance. |
+| `compare` | Compare multiple kernel implementations. |
+| `hardware_spec` | Query GPU hardware specifications. |
+| `configure_gpu` | Configure GPU power and frequency. |
+| `discover_kernels` | Scan a project and suggest analyzable kernels/configs. |
+| `suggest_optimizations` | Suggest performance optimizations from analyze output. |
+| `create_kernel_config` | Generate a kernel config YAML for analyze. |
+| `benchmark` | Run a vLLM/SGLang/Atom benchmark with optional profiling. |
+| `gap_analysis` | Run gap analysis on existing torch profiler traces. |
+| `list_benchmark_images` | List available Docker images per framework/architecture. |
+| `list_benchmark_results` | List previous benchmark workspaces and summaries. |
+| `get_benchmark_result` | Read detailed results from a specific benchmark run. |
+| `compare_benchmark_reports` | Compare TraceLens reports across benchmark runs. |
+
+### Selected tool signatures
+
+The following examples show key parameters. All parameters have sensible
+defaults unless noted.
+
+**`hardware_spec`**
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `device_id` | int | `0` | GPU device ID to query. |
+| `include_all` | bool | `false` | Return info for all available GPUs. |
+
+Returns JSON with vendor, architecture, power, clocks, temperature, and memory.
+
+**`analyze`**
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `kernel_path` | string | required | Path to the kernel source file (`.hip`, `.cu`, `.py`). |
+| `testcase_command` | string | required | Command to run the testcase. |
+| `kernel_type` | string | `hip` | `hip`, `cuda`, `pytorch`, or `triton`. |
+| `working_dir` | string | kernel's dir | Working directory. |
+| `compile_command` | string | auto | Custom compile command. |
+| `check_performance` | bool | `true` | Run performance profiling. |
+| `environment` | string | `local` | `local` or `container`. |
+| `performance_backend` | string | auto | `metrix`, `rocprof_compute`, or `ncu`. |
+| `correctness_backend` | string | auto | `accordo` or `testcase`. |
+| `accordo_*` | various | see defaults | Accordo kernel name, binaries, tolerances, and timeout. |
+
+Returns JSON with `compiling_state`, `correctness_state`, `performance_state`, a
+`score` (0.0-1.0), and detailed per-stage results.
+
+```{note}
+For the full parameter list of every tool, inspect the tool docstrings in
+[`Magpie/mcp/server.py`](https://github.com/AMD-AGI/Magpie/blob/main/Magpie/mcp/server.py),
+which are surfaced to MCP clients automatically.
+```

--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -1,0 +1,62 @@
+# Compatibility matrix
+
+This page lists the known version requirements for Magpie. It covers hardware
+and software requirements and is intended to capture only versions that have
+been verified and tested.
+
+```{note}
+The entries marked **TODO (verify)** must be confirmed by the Magpie team
+against tested configurations before publication. Only verified versions should
+remain in this table.
+```
+
+## Software requirements
+
+| Component | Supported / tested versions | Notes |
+| --- | --- | --- |
+| Python | 3.10, 3.11, 3.12, 3.13 | Declared in `pyproject.toml`. Minimum is 3.10. |
+| Operating system | Linux | TODO (verify): list tested distributions and versions. |
+| PyYAML | >= 6.0 | Core dependency. |
+| NumPy | >= 1.24.0 | Core dependency. |
+| MCP (`mcp`) | >= 1.0.0 | Required only for the MCP server. |
+
+## GPU toolchains
+
+| Toolchain | Supported / tested versions | Notes |
+| --- | --- | --- |
+| AMD ROCm (HIP) | TODO (verify) | Required for HIP kernel compilation and profiling on AMD GPUs. |
+| NVIDIA CUDA | TODO (verify) | Required for CUDA kernel compilation and profiling on NVIDIA GPUs. |
+
+## Profilers and optional tools
+
+| Tool | Supported / tested versions | Notes |
+| --- | --- | --- |
+| `rocprof-compute` | >= 3.40 | AMD performance profiling. See the [install guide](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/install/core-install.html). |
+| `ncu` (Nsight Compute) | TODO (verify) | NVIDIA performance profiling. |
+| IntelliKit Metrix | TODO (verify) | Optional human-readable AMD profiling metrics. |
+| IntelliKit Accordo | TODO (verify) | Optional AMD kernel correctness validation. |
+| Docker | TODO (verify) | Required for Benchmark mode when `run_mode` is `docker`. |
+| Ray | TODO (verify) | Required for the Ray execution environment. |
+
+## Hardware
+
+| Hardware | Supported / tested | Notes |
+| --- | --- | --- |
+| AMD Instinct GPUs | TODO (verify) | List verified architectures (for example, MI300 series). |
+| NVIDIA GPUs | TODO (verify) | List verified architectures. |
+
+## Framework benchmark compatibility
+
+Benchmark mode runs against external inference frameworks. List the verified
+versions of each framework and the supported model precisions.
+
+| Framework | Tested versions | Supported precisions | Notes |
+| --- | --- | --- | --- |
+| vLLM | TODO (verify) | fp8, fp16, bf16, fp4 | Default precision is fp8. |
+| SGLang | TODO (verify) | fp8, fp16, bf16, fp4 | |
+| Atom | TODO (verify) | fp8, fp16, bf16, fp4 | Single-node v1. |
+
+```{note}
+As a Hyperloom component, the Hyperloom compatibility matrix should record which
+version of Magpie is captured in each Hyperloom release.
+```

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -1,0 +1,62 @@
+# Release notes
+
+This page summarizes the features included in each Magpie release. For the
+initial release, the notes provide an overview of all features available in the
+tool.
+
+## Magpie 0.1.0 (initial release)
+
+The initial public release of Magpie establishes a lightweight, general-purpose
+framework for evaluating GPU kernel correctness and performance across AMD and
+NVIDIA hardware.
+
+### Evaluation modes
+
+- **Analyze**: Single-kernel evaluation against a testcase, with optional
+  performance profiling.
+- **Compare**: Multi-kernel comparison and ranking against a configurable
+  baseline to identify the fastest correct implementation.
+- **Benchmark**: Framework-level benchmarking for vLLM, SGLang, and Atom, with
+  optional torch profiler and system profiler runs.
+
+### Hardware and execution
+
+- Support for AMD (HIP/ROCm) and NVIDIA (CUDA) GPUs.
+- Three execution environments: local host, sandboxed container, and remote
+  Ray cluster.
+- Hardware-aware evaluation with optional GPU power and frequency control.
+- Automatic idle-GPU selection in Benchmark mode for both AMD and NVIDIA
+  devices.
+
+### Kernel types
+
+- HIP, CUDA, PyTorch, and Triton kernels.
+
+### Profiling and trace analysis
+
+- Pluggable performance profiler backends: `rocprof-compute` (AMD), `ncu`
+  (NVIDIA), and IntelliKit Metrix.
+- Optional correctness validation via testcase or IntelliKit Accordo.
+- TraceLens integration for performance trace analysis.
+- Kernel-level gap analysis from torch profiler traces, including a standalone
+  mode that runs on existing traces.
+- Kernel source finder to locate kernel source files and test commands for AMD
+  kernels.
+
+### Integration
+
+- Model Context Protocol (MCP) server exposing Magpie capabilities to AI
+  agents.
+- Agent skill packaging for environments without MCP.
+- Structured JSON reports for pipeline integration.
+
+### Configuration
+
+- Framework-level configuration via `config.yaml`.
+- Per-evaluation kernel configuration files for analyze and compare modes.
+- Benchmark configuration files for framework benchmarks.
+
+```{note}
+Update this page with each new Magpie release, listing added, changed, and
+fixed features for that version.
+```

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -1,0 +1,46 @@
+# Table of contents for the Magpie documentation site.
+# Processed by rocm-docs-core into sphinx/_toc.yml at build time.
+# https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/
+
+defaults:
+  numbered: false
+
+root: index
+
+subtrees:
+  - caption: Install
+    entries:
+      - file: install/install
+        title: Install Magpie
+
+  - caption: Reference
+    entries:
+      - file: reference/release-notes
+        title: Release notes
+      - file: reference/compatibility-matrix
+        title: Compatibility matrix
+      - file: reference/api-reference
+        title: API reference
+
+  - caption: How to
+    entries:
+      - file: how-to/analyze-compare
+        title: Analyze and compare kernels
+      - file: how-to/benchmark
+        title: Benchmark frameworks
+      - file: how-to/ray
+        title: Run on a Ray cluster
+      - file: how-to/mcp-and-skills
+        title: MCP server and agent skills
+      - file: how-to/kernel-source-finder
+        title: Find kernel sources
+
+  - caption: Examples
+    entries:
+      - file: examples/examples
+        title: Examples
+
+  - caption: About
+    entries:
+      - file: about/license
+        title: License

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,0 +1,2 @@
+rocm-docs-core==1.35.0
+sphinxcontrib-mermaid==1.0.0

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,0 +1,5 @@
+# Documentation build requirements for Magpie.
+# rocm-docs-core pulls in Sphinx, the ROCm theme, MyST parser, and the
+# external-toc extension. Pin matches docs/sphinx/requirements.in.
+rocm-docs-core==1.35.0
+sphinxcontrib-mermaid==1.0.0

--- a/examples/benchmarks/benchmark_atom_dsr1.yaml
+++ b/examples/benchmarks/benchmark_atom_dsr1.yaml
@@ -54,7 +54,7 @@ benchmark:
     top_k: 20
 
   # Optional: auto-pick idle GPU(s) before launching. Enabled by default;
-  # uncomment to override (see docs/benchmark.md#automatic-gpu-selection).
+  # uncomment to override (see docs/how-to/benchmark.md#automatic-gpu-selection).
   # gpu_selection:
   #   auto: true
   #   min_free_memory_gb: 8.0

--- a/examples/benchmarks/benchmark_sqlang_amd_dsr1_fp4.yaml
+++ b/examples/benchmarks/benchmark_sqlang_amd_dsr1_fp4.yaml
@@ -37,7 +37,7 @@ benchmark:
     top_k: 100
 
   # Optional: auto-pick idle GPU(s) before launching. Enabled by default;
-  # uncomment to override (see docs/benchmark.md#automatic-gpu-selection).
+  # uncomment to override (see docs/how-to/benchmark.md#automatic-gpu-selection).
   # gpu_selection:
   #   auto: true
   #   min_free_memory_gb: 8.0

--- a/examples/benchmarks/benchmark_vllm_dsr1.yaml
+++ b/examples/benchmarks/benchmark_vllm_dsr1.yaml
@@ -39,7 +39,7 @@ benchmark:
     top_k: 100
 
   # Optional: auto-pick idle GPU(s) before launching. Enabled by default;
-  # uncomment to override (see docs/benchmark.md#automatic-gpu-selection).
+  # uncomment to override (see docs/how-to/benchmark.md#automatic-gpu-selection).
   # gpu_selection:
   #   auto: true
   #   min_free_memory_gb: 8.0

--- a/skills/magpie/SKILL.md
+++ b/skills/magpie/SKILL.md
@@ -81,7 +81,7 @@ magpie benchmark --benchmark-config examples/benchmarks/benchmark_vllm_dsr1.yaml
 - `--run-mode`: `docker` (default) or `local`.
 - `--docker-image`, `--timeout`, `-o`: Override image, timeout (seconds), output dir.
 
-Example configs: [examples/benchmarks/benchmark_vllm_dsr1.yaml](examples/benchmarks/benchmark_vllm_dsr1.yaml), [docs/benchmark.md](docs/benchmark.md).
+Example configs: [examples/benchmarks/benchmark_vllm_dsr1.yaml](examples/benchmarks/benchmark_vllm_dsr1.yaml), [docs/how-to/benchmark.md](docs/how-to/benchmark.md).
 
 ## Gap analysis (standalone)
 

--- a/skills/magpie/reference.md
+++ b/skills/magpie/reference.md
@@ -100,4 +100,4 @@ kernels:
 
 ## Benchmark config YAML
 
-Top-level key `benchmark:` with `framework`, `model`, `precision`, `envs`, `profiler`, `gap_analysis`, `timeout_seconds`, etc. See `examples/benchmarks/benchmark_vllm_dsr1.yaml` and `docs/benchmark.md`.
+Top-level key `benchmark:` with `framework`, `model`, `precision`, `envs`, `profiler`, `gap_analysis`, `timeout_seconds`, etc. See `examples/benchmarks/benchmark_vllm_dsr1.yaml` and `docs/how-to/benchmark.md`.


### PR DESCRIPTION
Adds a Sphinx + rocm-docs-core docs tree for Magpie following the ROCm-LLMExt structure for rocm.docs.amd.com.