### PR TITLE
add switch for rocprof_compute roofline

### DIFF
--- a/Magpie/config.yaml
+++ b/Magpie/config.yaml
@@ -121,7 +121,9 @@ performance:
     # Directory to save profiling workloads (relative to kernel working_dir)
     workload_dir: "./workloads"
 
-    profile_args: ["--no-roof"]
+    # Generate rocprof-compute roofline data. When false, Magpie passes --no-roof.
+    roofline: false
+    profile_args: []
     analyze_args: []
 
     # Additional arguments both for profile and analyze

--- a/Magpie/kernel_config.yaml.example
+++ b/Magpie/kernel_config.yaml.example
@@ -132,6 +132,12 @@ kernel:
 #   metrix            - IntelliKit Metrix specific options
 #   rocprof_compute   - rocprof-compute specific options
 #   ncu               - NVIDIA Nsight Compute specific options
+#
+# Example: enable rocprof-compute roofline for this analyze/compare config
+# performance:
+#   rocprof_compute:
+#     roofline: true              # false adds --no-roof; true removes it
+#     profile_args: []            # optional extra rocprof-compute profile args
 
 # Example: use Metrix for this kernel config
 # performance:

--- a/Magpie/main.py
+++ b/Magpie/main.py
@@ -36,6 +36,8 @@ from .utils import get_gpu_info
 
 logger = logging.getLogger(__name__)
 
+ROCPROF_NO_ROOF_ARG = "--no-roof"
+
 
 def load_yaml(path: Path) -> Dict[str, Any]:
     """Load YAML file."""
@@ -325,6 +327,9 @@ def _get_performance_config(
             "profile_args": rocprof_cfg.get("profile_args", []),
             "analyze_args": rocprof_cfg.get("analyze_args", []),
         }
+        if "roofline" in rocprof_cfg:
+            rocprof_config["roofline"] = rocprof_cfg["roofline"]
+        rocprof_config = _apply_rocprof_roofline_switch(rocprof_config)
 
         # Metrix config (available for HIP/Triton on AMD)
         mtx_cfg = perf_cfg.get("metrix", {})
@@ -353,6 +358,34 @@ def _get_performance_config(
         "ncu_config": ncu_config,
         "metrix_config": metrix_config,
     }
+
+
+def _apply_rocprof_roofline_switch(rocprof_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Translate ``roofline`` into rocprof-compute's ``--no-roof`` flag."""
+    config = dict(rocprof_config)
+    if "roofline" not in config:
+        return config
+
+    roofline_enabled = _coerce_bool(config.pop("roofline"))
+    raw_args = config.get("profile_args", [])
+    profile_args = [raw_args] if isinstance(raw_args, str) else list(raw_args or [])
+
+    if roofline_enabled:
+        profile_args = [arg for arg in profile_args if arg != ROCPROF_NO_ROOF_ARG]
+    elif ROCPROF_NO_ROOF_ARG not in profile_args:
+        profile_args.append(ROCPROF_NO_ROOF_ARG)
+
+    config["profile_args"] = profile_args
+    return config
+
+
+def _coerce_bool(value: Any) -> bool:
+    """Parse YAML-style boolean values that may arrive as strings."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
 
 
 def _apply_perf_overrides(
@@ -394,7 +427,7 @@ def _apply_perf_overrides(
         rpc = overrides["rocprof_compute"]
         existing = settings.get("rocprof_config", {})
         existing.update(rpc)
-        settings["rocprof_config"] = existing
+        settings["rocprof_config"] = _apply_rocprof_roofline_switch(existing)
 
     # ncu overrides
     if "ncu" in overrides:

--- a/tests/test_main_and_kernel_config.py
+++ b/tests/test_main_and_kernel_config.py
@@ -3,7 +3,9 @@ import yaml
 
 from Magpie.config import KernelEvalConfig, KernelType
 from Magpie.main import (
+    _apply_perf_overrides,
     _expand_env_vars,
+    _get_performance_config,
     _parse_command_list,
     _parse_kernel_entry,
     load_kernel_config,
@@ -171,3 +173,57 @@ def test_load_kernel_config_rejects_unknown_kernel_type(tmp_path):
 
     with pytest.raises(ValueError, match="Unsupported kernel type 'mystery'"):
         load_kernel_config(config_path)
+
+
+def test_rocprof_roofline_config_removes_no_roof_flag():
+    settings = {
+        "timeout_seconds": 600,
+        "profiler_args": [],
+        "rocprof_config": {
+            "profile_args": ["--no-roof", "--kernel-names"],
+            "analyze_args": [],
+        },
+        "ncu_config": {},
+        "metrix_config": {},
+    }
+
+    updated = _apply_perf_overrides(
+        settings,
+        {"rocprof_compute": {"roofline": True}},
+        KernelType.HIP,
+    )
+
+    assert updated["rocprof_config"]["profile_args"] == ["--kernel-names"]
+    assert "roofline" not in updated["rocprof_config"]
+
+
+def test_rocprof_roofline_config_adds_no_roof_when_disabled():
+    settings = {
+        "timeout_seconds": 600,
+        "profiler_args": [],
+        "rocprof_config": {"profile_args": ["--kernel-names"], "analyze_args": []},
+        "ncu_config": {},
+        "metrix_config": {},
+    }
+
+    updated = _apply_perf_overrides(
+        settings,
+        {"rocprof_compute": {"roofline": "false"}},
+        KernelType.HIP,
+    )
+
+    assert updated["rocprof_config"]["profile_args"] == [
+        "--kernel-names",
+        "--no-roof",
+    ]
+    assert "roofline" not in updated["rocprof_config"]
+
+
+def test_global_rocprof_roofline_default_maps_to_no_roof_flag():
+    settings = _get_performance_config(
+        {"performance": {"rocprof_compute": {"roofline": False}}},
+        KernelType.HIP,
+    )
+
+    assert "--no-roof" in settings["rocprof_config"]["profile_args"]
+    assert "roofline" not in settings["rocprof_config"]


### PR DESCRIPTION
## Summary
- Add `performance.rocprof_compute.roofline` to control whether Magpie passes `--no-roof`.
- Keep the default behavior unchanged with `roofline: false`.
- Document the new analyze/compare YAML option and add unit coverage.

## Example
```yaml
performance:
  rocprof_compute:
    roofline: true
```

## Test
- `python3 -m py_compile Magpie/main.py tests/test_main_and_kernel_config.py`
- `python3 -m pytest tests/test_main_and_kernel_config.py` not run: `pytest` is not installed in this environment.