### PR TITLE
update TraceLens inference integration for benchmarks

### DIFF
--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -36,6 +36,7 @@ from .tracelens_inference import (
     TraceLensInferencePipeline,
     is_tracelens_inference_enabled,
 )
+from .tracelens_runtime import prepare_tracelens_runtime_image
 
 from ...utils.gpu import detect_gpu, find_idle_gpus, GPUVendor
 from ...utils.gpu_monitor import GPUMonitor
@@ -162,7 +163,49 @@ class BenchmarkMode:
         # 4. Create workspace
         workspace = self.workspace_mgr.create(self.config.to_dict())
 
-        # 4a. TraceLens inference mode needs to adjust profiler envs and a
+        # 4a. For Docker benchmarks, TraceLens inference can derive a patched
+        # framework runtime image from supported official vLLM/SGLang images.
+        tracelens_runtime_result: Optional[Dict[str, Any]] = None
+        if is_tracelens_inference_enabled(self.config) and not self.config.is_local:
+            try:
+                base_image = self._select_image()
+                tracelens_runtime_result = prepare_tracelens_runtime_image(
+                    config=self.config,
+                    base_image=base_image,
+                    runner_type=runner_type,
+                )
+                self.config.docker_image = str(
+                    tracelens_runtime_result.get("image") or base_image
+                )
+                logger.info(
+                    "TraceLens runtime image: %s (%s)",
+                    self.config.docker_image,
+                    tracelens_runtime_result.get("reason", "ready"),
+                )
+                self.workspace_mgr._save_config_snapshot(
+                    workspace,
+                    self.config.to_dict(),
+                )
+            except Exception as e:
+                result = BenchmarkResult(
+                    success=False,
+                    framework=self.config.framework,
+                    model=self.config.model,
+                    workspace_dir=str(workspace),
+                    execution_time=time.time() - start_time,
+                    profiling_enabled=self.config.profiler.torch_profiler.enabled,
+                )
+                result.errors.append(f"TraceLens runtime image setup failed: {e}")
+                result.tracelens_analysis = {
+                    "enabled": True,
+                    "analysis_mode": "inference",
+                    "runtime_error": str(e),
+                }
+                self.workspace_mgr.save_report(result.to_dict())
+                self.workspace_mgr.save_summary(result.get_summary())
+                return result
+
+        # 4b. TraceLens inference mode needs to adjust profiler envs and a
         # small number of InferenceX helper files before the benchmark starts.
         tracelens_inference_pipeline: Optional[TraceLensInferencePipeline] = None
         tracelens_preprocess_result: Optional[Dict[str, Any]] = None
@@ -173,6 +216,8 @@ class BenchmarkMode:
                 tracelens_preprocess_result = tracelens_inference_pipeline.prepare(
                     workspace
                 )
+                if tracelens_runtime_result is not None:
+                    tracelens_preprocess_result["runtime"] = tracelens_runtime_result
                 for warning in tracelens_preprocess_result.get("warnings", []):
                     logger.warning("TraceLens preprocess warning: %s", warning)
                 # Refresh the config snapshot after preprocess mutates envs.
@@ -374,6 +419,11 @@ class BenchmarkMode:
                     "enabled": True,
                     "analysis_mode": "inference",
                 }
+            if (
+                tracelens_preprocess_result is not None
+                and "preprocess" not in result.tracelens_analysis
+            ):
+                result.tracelens_analysis["preprocess"] = tracelens_preprocess_result
             result.tracelens_analysis["restore"] = restore_result
             for warning in restore_result.get("warnings", []):
                 logger.warning("TraceLens restore warning: %s", warning)

--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -169,7 +169,10 @@ class BenchmarkMode:
         # 4a. For Docker benchmarks, TraceLens inference can derive a patched
         # framework runtime image from supported official vLLM/SGLang images.
         tracelens_runtime_result: Optional[Dict[str, Any]] = None
-        if is_tracelens_inference_enabled(self.config) and not self.config.is_local:
+        if (
+            is_tracelens_inference_enabled(self.config)
+            and self.config.run_mode == "docker"
+        ):
             try:
                 base_image = self._select_image()
                 tracelens_runtime_result = prepare_tracelens_runtime_image(
@@ -1668,16 +1671,31 @@ class BenchmarkMode:
 
         This split/report workflow is the default TraceLens mode for Magpie
         benchmark because vLLM/SGLang traces need inference-phase handling.
+        For Docker benchmarks, run the TraceLens CLI inside the resolved
+        runtime image so host Python does not need TraceLens installed.
         """
-        logger.info("Running TraceLens inference analysis on host...")
-
         try:
             analyzer = pipeline or TraceLensInferencePipeline(self.config)
-            results = analyzer.analyze(
-                torch_trace_dir=torch_trace_dir,
-                output_dir=workspace,
-                runner_type=runner_type,
-            )
+            if self.config.run_mode == "docker":
+                docker_image = self.config.docker_image or self._select_image()
+                logger.info(
+                    "Running TraceLens inference analysis in container: %s",
+                    docker_image,
+                )
+                results = analyzer.analyze_in_container(
+                    torch_trace_dir=torch_trace_dir,
+                    output_dir=workspace,
+                    runner_type=runner_type,
+                    docker_image=docker_image,
+                    workspace=workspace,
+                )
+            else:
+                logger.info("Running TraceLens inference analysis on host...")
+                results = analyzer.analyze(
+                    torch_trace_dir=torch_trace_dir,
+                    output_dir=workspace,
+                    runner_type=runner_type,
+                )
 
             if results.get("output_files"):
                 logger.info(

--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -32,6 +32,10 @@ from .inferencex import ensure_inferencex_available
 from .workspace import WorkspaceManager
 from .result import BenchmarkResult, LatencyMetrics, ResultParser, ThroughputMetrics
 from .tracelens import TraceLensAnalyzer
+from .tracelens_inference import (
+    TraceLensInferencePipeline,
+    is_tracelens_inference_enabled,
+)
 
 from ...utils.gpu import detect_gpu, find_idle_gpus, GPUVendor
 from ...utils.gpu_monitor import GPUMonitor
@@ -157,6 +161,45 @@ class BenchmarkMode:
         
         # 4. Create workspace
         workspace = self.workspace_mgr.create(self.config.to_dict())
+
+        # 4a. TraceLens inference mode needs to adjust profiler envs and a
+        # small number of InferenceX helper files before the benchmark starts.
+        tracelens_inference_pipeline: Optional[TraceLensInferencePipeline] = None
+        tracelens_preprocess_result: Optional[Dict[str, Any]] = None
+        if is_tracelens_inference_enabled(self.config):
+            logger.info("Preparing TraceLens inference-mode benchmark hooks")
+            tracelens_inference_pipeline = TraceLensInferencePipeline(self.config)
+            try:
+                tracelens_preprocess_result = tracelens_inference_pipeline.prepare(
+                    workspace
+                )
+                for warning in tracelens_preprocess_result.get("warnings", []):
+                    logger.warning("TraceLens preprocess warning: %s", warning)
+                # Refresh the config snapshot after preprocess mutates envs.
+                self.workspace_mgr._save_config_snapshot(
+                    workspace,
+                    self.config.to_dict(),
+                )
+            except Exception as e:
+                restore_result = tracelens_inference_pipeline.restore()
+                result = BenchmarkResult(
+                    success=False,
+                    framework=self.config.framework,
+                    model=self.config.model,
+                    workspace_dir=str(workspace),
+                    execution_time=time.time() - start_time,
+                    profiling_enabled=self.config.profiler.torch_profiler.enabled,
+                )
+                result.errors.append(f"TraceLens preprocess failed: {e}")
+                result.tracelens_analysis = {
+                    "enabled": True,
+                    "analysis_mode": "inference",
+                    "preprocess_error": str(e),
+                    "restore": restore_result,
+                }
+                self.workspace_mgr.save_report(result.to_dict())
+                self.workspace_mgr.save_summary(result.get_summary())
+                return result
         
         # 4b. Start GPU monitor if enabled
         gpu_monitor = None
@@ -305,14 +348,35 @@ class BenchmarkMode:
                 result.top_bottlenecks = [k.name for k in kernels[:10]]
 
                 if self.config.profiler.tracelens.enabled:
-                    tracelens_result = self._run_tracelens_analysis(
-                        torch_trace_dir, workspace
-                    )
+                    if is_tracelens_inference_enabled(self.config):
+                        tracelens_result = self._run_tracelens_inference_analysis(
+                            torch_trace_dir=torch_trace_dir,
+                            workspace=workspace,
+                            runner_type=runner_type,
+                            pipeline=tracelens_inference_pipeline,
+                        )
+                    else:
+                        tracelens_result = self._run_tracelens_analysis(
+                            torch_trace_dir, workspace
+                        )
+                    if tracelens_preprocess_result is not None:
+                        tracelens_result["preprocess"] = tracelens_preprocess_result
                     result.tracelens_analysis = tracelens_result
 
                 if self.config.gap_analysis.enabled:
                     gap_result = self._run_gap_analysis(torch_trace_dir, workspace)
                     result.gap_analysis = gap_result
+
+        if tracelens_inference_pipeline is not None:
+            restore_result = tracelens_inference_pipeline.restore()
+            if result.tracelens_analysis is None:
+                result.tracelens_analysis = {
+                    "enabled": True,
+                    "analysis_mode": "inference",
+                }
+            result.tracelens_analysis["restore"] = restore_result
+            for warning in restore_result.get("warnings", []):
+                logger.warning("TraceLens restore warning: %s", warning)
 
         # Save report
         self.workspace_mgr.save_report(result.to_dict())
@@ -1508,6 +1572,50 @@ class BenchmarkMode:
         except Exception as e:
             logger.exception(f"TraceLens analysis failed: {e}")
             return {"enabled": True, "error": str(e)}
+
+    def _run_tracelens_inference_analysis(
+        self,
+        torch_trace_dir: Path,
+        workspace: Path,
+        runner_type: str,
+        pipeline: Optional[TraceLensInferencePipeline] = None,
+    ) -> Dict[str, Any]:
+        """
+        Run TraceLens inference analysis on torch profiler traces.
+
+        This split/report workflow is the default TraceLens mode for Magpie
+        benchmark because vLLM/SGLang traces need inference-phase handling.
+        """
+        logger.info("Running TraceLens inference analysis on host...")
+
+        try:
+            analyzer = pipeline or TraceLensInferencePipeline(self.config)
+            results = analyzer.analyze(
+                torch_trace_dir=torch_trace_dir,
+                output_dir=workspace,
+                runner_type=runner_type,
+            )
+
+            if results.get("output_files"):
+                logger.info(
+                    "TraceLens inference analysis complete: %s output files",
+                    len(results["output_files"]),
+                )
+
+            for warning in results.get("warnings", []):
+                logger.warning("TraceLens inference warning: %s", warning)
+            for error in results.get("errors", []):
+                logger.warning("TraceLens inference error: %s", error)
+
+            return results
+
+        except Exception as e:
+            logger.exception(f"TraceLens inference analysis failed: {e}")
+            return {
+                "enabled": True,
+                "analysis_mode": "inference",
+                "error": str(e),
+            }
     
     def _run_gap_analysis(
         self,

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -108,6 +108,13 @@ class TraceLensConfig:
         analysis_stages: Inference stages to analyze. Accepts "all" or any
             combination of "prefilldecode"/"mixed", "decode", and "prefill".
         cli_timeout_seconds: Timeout for each TraceLens CLI postprocess command.
+        auto_patch_runtime: Build a TraceLens-ready Docker image from supported
+            official vLLM/SGLang images when needed.
+        tracelens_repo_path: Path to a public TraceLens source checkout used
+            for runtime image patching. Defaults to $TRACELENS_REPO_PATH or
+            common sibling checkout locations.
+        runtime_patch_image_tag: Optional Docker tag for the derived image.
+        runtime_patch_force_rebuild: Rebuild the derived image even if the tag exists.
         export_format: Export format - "csv" or "excel" (default: "csv")
         perf_report_enabled: Enable single-rank performance report (default: True)
         multi_rank_report_enabled: Enable multi-rank collective report (default: True)
@@ -121,6 +128,10 @@ class TraceLensConfig:
     )
     num_steps: int = 32
     cli_timeout_seconds: int = 1800
+    auto_patch_runtime: bool = True
+    tracelens_repo_path: Optional[str] = None
+    runtime_patch_image_tag: Optional[str] = None
+    runtime_patch_force_rebuild: bool = False
     restore_patches: bool = True
     export_format: str = "csv"  # "csv" or "excel"
 
@@ -236,6 +247,10 @@ class TraceLensConfig:
             "analysis_stages": self.analysis_stages,
             "num_steps": self.num_steps,
             "cli_timeout_seconds": self.cli_timeout_seconds,
+            "auto_patch_runtime": self.auto_patch_runtime,
+            "tracelens_repo_path": self.tracelens_repo_path,
+            "runtime_patch_image_tag": self.runtime_patch_image_tag,
+            "runtime_patch_force_rebuild": self.runtime_patch_force_rebuild,
             "restore_patches": self.restore_patches,
             "export_format": self.export_format,
             "perf_report_enabled": self.perf_report_enabled,
@@ -263,6 +278,12 @@ class TraceLensConfig:
             analysis_stages=data.get("analysis_stages", "all"),
             num_steps=int(data.get("num_steps", 32)),
             cli_timeout_seconds=int(data.get("cli_timeout_seconds", 1800)),
+            auto_patch_runtime=bool(data.get("auto_patch_runtime", True)),
+            tracelens_repo_path=data.get("tracelens_repo_path"),
+            runtime_patch_image_tag=data.get("runtime_patch_image_tag"),
+            runtime_patch_force_rebuild=bool(
+                data.get("runtime_patch_force_rebuild", False)
+            ),
             restore_patches=bool(data.get("restore_patches", True)),
             export_format=export_format,
             perf_report_enabled=data.get("perf_report_enabled", True),

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -34,6 +34,9 @@ class TraceLensExportFormat(Enum):
     EXCEL = "excel"
 
 
+TRACELENS_INFERENCE_STAGES = ("prefilldecode", "decode", "prefill")
+
+
 # Default root on Ray workers for HF cache, InferenceX, and benchmark results.
 # Use the same mount on driver and workers (NFS, Lustre, parallel filesystem, etc.).
 DEFAULT_SHARED_STORAGE_PATH = "/shared_nfs/magpie"
@@ -100,6 +103,11 @@ class TraceLensConfig:
 
     Attributes:
         enabled: Master switch for TraceLens analysis (default: False)
+        analysis_mode: TraceLens analysis mode: "inference" (default) or
+            "pytorch"/"classic" for the legacy direct PyTorch report flow.
+        analysis_stages: Inference stages to analyze. Accepts "all" or any
+            combination of "prefilldecode"/"mixed", "decode", and "prefill".
+        cli_timeout_seconds: Timeout for each TraceLens CLI postprocess command.
         export_format: Export format - "csv" or "excel" (default: "csv")
         perf_report_enabled: Enable single-rank performance report (default: True)
         multi_rank_report_enabled: Enable multi-rank collective report (default: True)
@@ -107,6 +115,13 @@ class TraceLensConfig:
     """
 
     enabled: bool = False
+    analysis_mode: str = "inference"
+    analysis_stages: List[str] = field(
+        default_factory=lambda: list(TRACELENS_INFERENCE_STAGES)
+    )
+    num_steps: int = 32
+    cli_timeout_seconds: int = 1800
+    restore_patches: bool = True
     export_format: str = "csv"  # "csv" or "excel"
 
     # Command-specific enable/disable
@@ -117,11 +132,79 @@ class TraceLensConfig:
     gpu_arch_config: Optional[str] = None
 
     def __post_init__(self):
-        """Validate export format."""
+        """Validate TraceLens config."""
+        self.analysis_mode = (self.analysis_mode or "inference").lower()
+        if self.analysis_mode == "classic":
+            self.analysis_mode = "pytorch"
+        if self.analysis_mode not in ["inference", "pytorch"]:
+            raise ValueError(
+                f"Invalid analysis_mode: {self.analysis_mode}. "
+                "Use 'inference' or 'pytorch'."
+            )
+        self.analysis_stages = self._normalize_analysis_stages(
+            self.analysis_stages
+        )
+        if self.num_steps <= 0:
+            raise ValueError(f"num_steps must be positive, got {self.num_steps}")
+        if self.cli_timeout_seconds <= 0:
+            raise ValueError(
+                "cli_timeout_seconds must be positive, "
+                f"got {self.cli_timeout_seconds}"
+            )
         if self.export_format not in ["csv", "excel"]:
             raise ValueError(
                 f"Invalid export_format: {self.export_format}. Use 'csv' or 'excel'."
             )
+
+    @property
+    def is_inference_mode(self) -> bool:
+        """Check whether TraceLens should run inference-specific analysis."""
+        return self.analysis_mode == "inference"
+
+    @staticmethod
+    def _normalize_analysis_stages(value: Any) -> List[str]:
+        """Normalize user stage aliases to canonical inference stage names."""
+        if value in (None, "", "all"):
+            return list(TRACELENS_INFERENCE_STAGES)
+
+        if isinstance(value, str):
+            raw_stages = [part.strip() for part in value.split(",")]
+        elif isinstance(value, (list, tuple, set)):
+            raw_stages = [str(part).strip() for part in value]
+        else:
+            raise ValueError(
+                "analysis_stages must be 'all', a comma-separated string, "
+                "or a list of stages"
+            )
+
+        aliases = {
+            "all": list(TRACELENS_INFERENCE_STAGES),
+            "pd": ["prefilldecode"],
+            "mixed": ["prefilldecode"],
+            "prefilldecode": ["prefilldecode"],
+            "prefill_decode": ["prefilldecode"],
+            "prefill-decode": ["prefilldecode"],
+            "decode": ["decode"],
+            "decode_only": ["decode"],
+            "decode-only": ["decode"],
+            "prefill": ["prefill"],
+            "prefill_only": ["prefill"],
+            "prefill-only": ["prefill"],
+        }
+
+        normalized: List[str] = []
+        for raw in raw_stages:
+            key = raw.lower()
+            if not key:
+                continue
+            if key not in aliases:
+                valid = ", ".join(["all", "prefilldecode", "decode", "prefill"])
+                raise ValueError(f"Invalid analysis stage '{raw}'. Use one of: {valid}")
+            for stage in aliases[key]:
+                if stage not in normalized:
+                    normalized.append(stage)
+
+        return normalized or list(TRACELENS_INFERENCE_STAGES)
 
     @property
     def export_csv(self) -> bool:
@@ -149,6 +232,11 @@ class TraceLensConfig:
         """Convert to dictionary."""
         return {
             "enabled": self.enabled,
+            "analysis_mode": self.analysis_mode,
+            "analysis_stages": self.analysis_stages,
+            "num_steps": self.num_steps,
+            "cli_timeout_seconds": self.cli_timeout_seconds,
+            "restore_patches": self.restore_patches,
             "export_format": self.export_format,
             "perf_report_enabled": self.perf_report_enabled,
             "multi_rank_report_enabled": self.multi_rank_report_enabled,
@@ -171,6 +259,11 @@ class TraceLensConfig:
 
         return cls(
             enabled=data.get("enabled", False),
+            analysis_mode=data.get("analysis_mode", "inference"),
+            analysis_stages=data.get("analysis_stages", "all"),
+            num_steps=int(data.get("num_steps", 32)),
+            cli_timeout_seconds=int(data.get("cli_timeout_seconds", 1800)),
+            restore_patches=bool(data.get("restore_patches", True)),
             export_format=export_format,
             perf_report_enabled=data.get("perf_report_enabled", True),
             multi_rank_report_enabled=data.get("multi_rank_report_enabled", True),

--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -1,0 +1,887 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""
+TraceLens inference-mode integration for benchmark mode.
+
+This module ports the Magpie-facing preprocess/postprocess workflow into
+Magpie so TraceLens public inference analysis, and optional TL_EXTENSION based
+internal extensions, can be driven directly by ``magpie benchmark``.
+"""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import importlib.util
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from .config import BenchmarkConfig
+from .tracelens import ensure_tracelens_installed
+from ...utils.gpu import detect_gpu
+
+logger = logging.getLogger(__name__)
+
+BACKUP_SUFFIX = ".tracelens.bak"
+CLI_SPLIT_INFERENCE_TRACE = "TraceLens_split_inference_trace"
+CLI_INFERENCE_REPORT = "TraceLens_generate_perf_report_pytorch_inference"
+
+
+@dataclass
+class InferencePhasePick:
+    """Selected single-iteration trace for one inference phase."""
+
+    stage: str
+    csv_kind: str
+    output_label: str
+    batch_size: float
+    trace_path: Optional[Path]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "stage": self.stage,
+            "csv_kind": self.csv_kind,
+            "output_label": self.output_label,
+            "batch_size": self.batch_size,
+            "trace_path": str(self.trace_path) if self.trace_path else None,
+        }
+
+
+def resolve_tl_extension(envs: Dict[str, Any]) -> Optional[str]:
+    """Resolve TL_EXTENSION from host env first, then benchmark envs."""
+    host_value = os.environ.get("TL_EXTENSION", "").strip()
+    if host_value:
+        return host_value
+
+    cfg_value = str(envs.get("TL_EXTENSION", "") or "").strip()
+    return cfg_value or None
+
+
+def validate_tl_extension_importable(tl_extension: Optional[str]) -> None:
+    """Fail early when TL_EXTENSION names a package not importable on host."""
+    if not tl_extension:
+        return
+
+    missing = []
+    for package_name in tl_extension.split(":"):
+        package_name = package_name.strip()
+        if not package_name:
+            continue
+        if importlib.util.find_spec(package_name) is None:
+            missing.append(package_name)
+
+    if missing:
+        raise RuntimeError(
+            "TL_EXTENSION is set but the extension package(s) are not importable: "
+            f"{', '.join(missing)}. Install the matching TraceLens extension "
+            "package in the Python environment that runs Magpie."
+        )
+
+
+def compute_steady_state_iters(
+    osl: Any,
+    conc: Any,
+    random_range_ratio: Any = 1.0,
+) -> Tuple[int, int]:
+    """Compute TraceLens-friendly steady-state profiler iteration bounds."""
+    osl_i = int(float(osl))
+    conc_i = int(float(conc))
+    ratio = float(random_range_ratio)
+    if osl_i <= 0 or conc_i <= 0:
+        raise ValueError(
+            f"OSL and CONC must be positive, got OSL={osl}, CONC={conc}"
+        )
+
+    max_iters = min(1024, max(256, (osl_i * 16) // conc_i))
+    delay_iters = int(osl_i * (ratio + 1.0) * 3 - max_iters / 2)
+    return int(max_iters), max(0, delay_iters)
+
+
+def append_flag_value_args(
+    envs: Dict[str, Any],
+    key: str,
+    pairs: Sequence[Tuple[str, Any]],
+) -> None:
+    """Append flag/value pairs to an EXTRA_*_ARGS env without duplicating flags."""
+    current = str(envs.get(key, "") or "").strip()
+    parts = current.split()
+    appended: List[str] = []
+    for flag, value in pairs:
+        if flag in parts or flag in appended:
+            continue
+        appended.append(flag)
+        if value not in (None, ""):
+            appended.append(str(value))
+
+    if not appended:
+        return
+
+    addition = " ".join(appended)
+    envs[key] = f"{current} {addition}".strip() if current else addition
+
+
+def trace_arch_platform_from_runner(runner_type: Optional[str]) -> Optional[str]:
+    """Map Magpie runner/GPU architecture naming to TraceLens platform names."""
+    if runner_type:
+        runner = runner_type.lower()
+        aliases = {
+            "mi300": "MI300X",
+            "mi300x": "MI300X",
+            "mi325": "MI325X",
+            "mi325x": "MI325X",
+            "mi350": "MI350X",
+            "mi350x": "MI350X",
+            "mi355": "MI355X",
+            "mi355x": "MI355X",
+            "mi455": "MI455X",
+            "mi455x": "MI455X",
+        }
+        return aliases.get(runner, runner_type.upper())
+
+    try:
+        _, arch = detect_gpu()
+    except Exception as exc:
+        logger.warning("Could not auto-detect GPU arch for TraceLens: %s", exc)
+        return None
+
+    arch_map = {
+        "gfx942": "MI300X",
+        "gfx950": "MI355X",
+        "gfx1100": "MI325X",
+    }
+    return arch_map.get(arch)
+
+
+class TraceLensInferencePipeline:
+    """Preprocess and postprocess TraceLens inference benchmark traces."""
+
+    def __init__(self, benchmark_config: BenchmarkConfig):
+        self.config = benchmark_config
+        self.tl_config = benchmark_config.profiler.tracelens
+        self.tl_extension = resolve_tl_extension(benchmark_config.envs)
+        self._created_backups: List[Path] = []
+
+    def prepare(self, workspace: Path) -> Dict[str, Any]:
+        """Patch config/envs and mutable InferenceX files before benchmark."""
+        validate_tl_extension_importable(self.tl_extension)
+
+        result: Dict[str, Any] = {
+            "enabled": True,
+            "analysis_mode": self.tl_config.analysis_mode,
+            "tl_extension": self.tl_extension,
+            "patched_files": [],
+            "env_updates": {},
+            "warnings": [],
+        }
+
+        envs = self.config.envs
+        self.config.profiler.torch_profiler.enabled = True
+        if self.tl_extension:
+            envs["TL_EXTENSION"] = self.tl_extension
+
+        max_iters, delay_iters = compute_steady_state_iters(
+            envs.get("OSL", 512),
+            envs.get("CONC", 32),
+            envs.get("RANDOM_RANGE_RATIO", 1.0),
+        )
+        result["max_iterations"] = max_iters
+        result["delay_iterations"] = delay_iters
+
+        if "NUM_PROMPTS" not in envs:
+            envs["NUM_PROMPTS"] = str(int(float(envs.get("CONC", 32))) * 10)
+
+        self._patch_benchmark_lib(result)
+
+        trace_root = self._runtime_torch_trace_dir(workspace)
+        capture_dir = f"{trace_root}/capture_traces"
+
+        if self.config.framework == "vllm":
+            self._prepare_vllm_env(envs, capture_dir, max_iters, delay_iters)
+        elif self.config.framework == "sglang":
+            self._prepare_sglang_env(envs, max_iters, delay_iters, result)
+
+        result["env_updates"] = {
+            key: envs.get(key)
+            for key in sorted(
+                {
+                    "NUM_PROMPTS",
+                    "TL_EXTENSION",
+                    "EXTRA_VLLM_ARGS",
+                    "EXTRA_SGLANG_ARGS",
+                    "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS",
+                    "SGLANG_PROFILE_WITH_STACK",
+                    "SGLANG_PROFILE_RECORD_SHAPE",
+                }
+            )
+            if key in envs
+        }
+        return result
+
+    def analyze(
+        self,
+        torch_trace_dir: Path,
+        output_dir: Path,
+        runner_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Split inference traces and run TraceLens perf reports per stage."""
+        results: Dict[str, Any] = {
+            "enabled": True,
+            "analysis_mode": "inference",
+            "analysis_stages": self.tl_config.analysis_stages,
+            "tl_extension": self.tl_extension,
+            "trace_dir": str(torch_trace_dir),
+            "output_files": [],
+            "stage_results": {},
+            "errors": [],
+            "warnings": [],
+        }
+
+        if not ensure_tracelens_installed():
+            results["errors"].append("TraceLens is not installed")
+            return results
+
+        missing_cli = [
+            name
+            for name in (CLI_SPLIT_INFERENCE_TRACE, CLI_INFERENCE_REPORT)
+            if shutil.which(name) is None
+        ]
+        if missing_cli:
+            results["errors"].append(
+                "Required TraceLens inference CLI command(s) not found on PATH: "
+                + ", ".join(missing_cli)
+            )
+            return results
+
+        try:
+            validate_tl_extension_importable(self.tl_extension)
+        except RuntimeError as exc:
+            results["errors"].append(str(exc))
+            return results
+
+        split_dir = torch_trace_dir / "trace_split"
+        capture_folder = torch_trace_dir / "capture_traces"
+        output_csvs_dir = output_dir / "tracelens"
+        gpu_arch_platform = trace_arch_platform_from_runner(runner_type)
+
+        results["split_dir"] = str(split_dir)
+        results["capture_folder"] = str(capture_folder)
+        results["output_dir"] = str(output_csvs_dir)
+        results["gpu_arch_platform"] = gpu_arch_platform
+
+        rank0_trace = self._locate_rank0_trace(torch_trace_dir)
+        if rank0_trace is None:
+            results["errors"].append(
+                f"Could not locate rank-0 trace for framework={self.config.framework} "
+                f"in {torch_trace_dir}"
+            )
+            return results
+        results["rank0_trace"] = str(rank0_trace)
+
+        split_error = self._run_splitter(rank0_trace, split_dir)
+        if split_error:
+            results["errors"].append(split_error)
+            return results
+
+        validation_warnings = self._validate_trace_layout(torch_trace_dir, split_dir)
+        results["warnings"].extend(validation_warnings)
+
+        execution_csv = split_dir / "execution_details.csv"
+        if not execution_csv.exists():
+            if self.config.framework == "sglang":
+                fallback_warning = (
+                    "TraceLens splitter did not produce execution_details.csv; "
+                    "trying SGLang step marker fallback"
+                )
+                logger.warning(fallback_warning)
+                results["warnings"].append(fallback_warning)
+                results["warnings"].extend(
+                    self._split_sglang_step_markers(rank0_trace, split_dir)
+                )
+
+        execution_csv = split_dir / "execution_details.csv"
+        if not execution_csv.exists():
+            results["errors"].append(f"Missing TraceLens split CSV: {execution_csv}")
+            return results
+
+        picks = self._pick_largest_batch_traces(execution_csv)
+        results["phase_picks"] = {
+            stage: pick.to_dict()
+            for stage, pick in picks.items()
+        }
+
+        for stage in self.tl_config.analysis_stages:
+            pick = picks.get(stage)
+            if pick is None or pick.trace_path is None:
+                warning = f"{stage}: no candidate trace found; skipping perf report"
+                logger.warning(warning)
+                results["warnings"].append(warning)
+                continue
+
+            stage_result = self._run_perf_report(
+                stage=stage,
+                trace_path=pick.trace_path,
+                capture_folder=capture_folder,
+                output_root=output_csvs_dir,
+                output_label=pick.output_label,
+                gpu_arch_platform=gpu_arch_platform,
+            )
+            results["stage_results"][stage] = stage_result
+            results["output_files"].extend(stage_result.get("files", []))
+            if stage_result.get("error"):
+                results["errors"].append(stage_result["error"])
+
+        return results
+
+    def restore(self) -> Dict[str, Any]:
+        """Restore files backed up during prepare()."""
+        result = {"restored_files": [], "warnings": []}
+        if not self.tl_config.restore_patches:
+            result["warnings"].append("restore_patches=false; leaving patched files in place")
+            return result
+
+        for path in reversed(self._created_backups):
+            backup = Path(str(path) + BACKUP_SUFFIX)
+            if not backup.exists():
+                result["warnings"].append(f"backup missing for restore: {backup}")
+                continue
+            shutil.move(str(backup), str(path))
+            result["restored_files"].append(str(path))
+            logger.info("Restored TraceLens preprocess patch: %s", path)
+        return result
+
+    def _runtime_torch_trace_dir(self, workspace: Path) -> str:
+        if self.config.is_local:
+            return str(workspace / "torch_trace")
+        return "/workspace/torch_trace"
+
+    def _prepare_vllm_env(
+        self,
+        envs: Dict[str, Any],
+        capture_dir: str,
+        max_iters: int,
+        delay_iters: int,
+    ) -> None:
+        append_flag_value_args(
+            envs,
+            "EXTRA_VLLM_ARGS",
+            [
+                ("--profiler-config.capture_torch_profiler_dir", capture_dir),
+                ("--profiler-config.detailed_trace_annotation", "True"),
+                ("--profiler-config.delay_iterations", delay_iters),
+                ("--profiler-config.max_iterations", max_iters),
+                ("--profiler-config.ignore_frontend", "True"),
+            ],
+        )
+        envs.setdefault("VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS", "1200")
+
+    def _prepare_sglang_env(
+        self,
+        envs: Dict[str, Any],
+        max_iters: int,
+        delay_iters: int,
+        result: Dict[str, Any],
+    ) -> None:
+        envs["SGLANG_PROFILE_WITH_STACK"] = "True"
+        envs["SGLANG_PROFILE_RECORD_SHAPE"] = "True"
+        append_flag_value_args(
+            envs,
+            "EXTRA_SGLANG_ARGS",
+            [
+                ("--enable-profile-cuda-graph", None),
+            ],
+        )
+        self._patch_sglang_benchmark_serving(max_iters, delay_iters, result)
+
+    def _patch_benchmark_lib(self, result: Dict[str, Any]) -> None:
+        path = Path(self.config.inferencex_path) / "benchmarks" / "benchmark_lib.sh"
+        if not path.exists():
+            warning = f"benchmark_lib.sh not found, skipping TraceLens preprocess patch: {path}"
+            logger.warning(warning)
+            result["warnings"].append(warning)
+            return
+
+        text = path.read_text(encoding="utf-8")
+        old = 'num_prompts="$max_concurrency"'
+        new = 'num_prompts="$num_prompts"'
+        if new in text:
+            return
+        if old not in text:
+            warning = f"benchmark_lib.sh profile num_prompts anchor not found: {path}"
+            logger.warning(warning)
+            result["warnings"].append(warning)
+            return
+
+        self._backup_file(path)
+        path.write_text(text.replace(old, new, 1), encoding="utf-8")
+        result["patched_files"].append(str(path))
+        logger.info("Patched benchmark_lib.sh for TraceLens inference profiling")
+
+    def _patch_sglang_benchmark_serving(
+        self,
+        max_iters: int,
+        delay_iters: int,
+        result: Dict[str, Any],
+    ) -> None:
+        path = (
+            Path(self.config.inferencex_path)
+            / "utils"
+            / "bench_serving"
+            / "benchmark_serving.py"
+        )
+        if not path.exists():
+            warning = f"benchmark_serving.py not found, skipping SGLang TraceLens patch: {path}"
+            logger.warning(warning)
+            result["warnings"].append(warning)
+            return
+
+        text = path.read_text(encoding="utf-8")
+        common_anchor = '"num_steps": 1, "merge_profiles": True, "profile_by_stage": True'
+        common_repl = (
+            '"shape_discovery": False, "roofline_annotations": True, '
+            '"num_steps": 1, "merge_profiles": True, "profile_by_stage": True'
+        )
+        steady_repl = (
+            f'"start_step": {delay_iters}, "num_steps": {max_iters}, '
+            '"merge_profiles": False, "profile_by_stage": False'
+        )
+
+        if steady_repl in text and "roofline_annotations" in text:
+            return
+
+        if "roofline_annotations" not in text:
+            if common_anchor not in text:
+                warning = f"SGLang benchmark_serving.py common patch anchor not found: {path}"
+                logger.warning(warning)
+                result["warnings"].append(warning)
+                return
+            self._backup_file(path)
+            text = text.replace(common_anchor, common_repl, 1)
+
+        if common_anchor not in text:
+            warning = f"SGLang benchmark_serving.py steady-state patch anchor not found: {path}"
+            logger.warning(warning)
+            result["warnings"].append(warning)
+            return
+
+        self._backup_file(path)
+        text = text.replace(common_anchor, steady_repl, 1)
+        path.write_text(text, encoding="utf-8")
+        result["patched_files"].append(str(path))
+        logger.info("Patched SGLang benchmark_serving.py for TraceLens inference profiling")
+
+    def _backup_file(self, path: Path) -> None:
+        if path in self._created_backups:
+            return
+        backup = Path(str(path) + BACKUP_SUFFIX)
+        if backup.exists():
+            logger.warning(
+                "TraceLens backup already exists; keeping existing restore point: %s",
+                backup,
+            )
+            return
+        shutil.copy2(path, backup)
+        self._created_backups.append(path)
+
+    def _locate_rank0_trace(self, torch_trace_dir: Path) -> Optional[Path]:
+        if self.config.framework == "vllm":
+            patterns = [
+                "*-rank_0.*trace.json.gz",
+                "*rank0*.pt.trace.json.gz",
+                "*rank-0*.trace.json.gz",
+                "*.trace.json.gz",
+                "*.json.gz",
+            ]
+        else:
+            patterns = [
+                "merged-*.trace.json.gz",
+                "*TP-0*.trace.json.gz",
+                "*-TP-0-DECODE.trace.json.gz",
+                "*-TP-0-EXTEND.trace.json.gz",
+                "*.trace.json.gz",
+                "*.json.gz",
+            ]
+
+        for pattern in patterns:
+            matches = sorted(torch_trace_dir.glob(pattern))
+            if matches:
+                return matches[0]
+        return None
+
+    def _run_splitter(self, rank0_trace: Path, split_dir: Path) -> Optional[str]:
+        envs = self.config.envs
+        split_dir.mkdir(parents=True, exist_ok=True)
+        cmd = [
+            CLI_SPLIT_INFERENCE_TRACE,
+            str(rank0_trace),
+            "-o",
+            str(split_dir),
+            "--find-steady-state",
+            "--store-single-iteration",
+            "--num-steps",
+            str(self.tl_config.num_steps),
+            "--CONC",
+            str(envs.get("CONC", 32)),
+            "--OSL",
+            str(envs.get("OSL", 512)),
+            "--R",
+            str(envs.get("RANDOM_RANGE_RATIO", 1.0)),
+        ]
+        logger.info("Running TraceLens inference splitter: %s", " ".join(cmd))
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=self.tl_config.cli_timeout_seconds,
+            env=self._subprocess_env(),
+        )
+        if proc.returncode != 0:
+            return f"TraceLens inference split failed: {proc.stderr or proc.stdout}"
+        return None
+
+    def _validate_trace_layout(self, torch_trace_dir: Path, split_dir: Path) -> List[str]:
+        warnings: List[str] = []
+        capture_dir = torch_trace_dir / "capture_traces"
+        if not capture_dir.is_dir() or not any(capture_dir.iterdir()):
+            warnings.append(f"capture_traces directory is missing or empty: {capture_dir}")
+        if not (split_dir / "execution_details.csv").exists():
+            warnings.append(f"execution_details.csv missing under split dir: {split_dir}")
+        return warnings
+
+    def _split_sglang_step_markers(
+        self,
+        rank0_trace: Path,
+        split_dir: Path,
+    ) -> List[str]:
+        """Fallback split for SGLang traces annotated with step[...] spans."""
+        warnings: List[str] = []
+        split_dir.mkdir(parents=True, exist_ok=True)
+
+        trace = self._load_trace(rank0_trace)
+        events = trace.get("traceEvents", [])
+        if not isinstance(events, list):
+            return ["SGLang fallback splitter: traceEvents is not a list"]
+
+        picks = self._pick_sglang_step_events(events)
+        if not picks:
+            return ["SGLang fallback splitter: no step[...] user annotations found"]
+
+        rows: List[Dict[str, Any]] = []
+        for kind, event in picks.items():
+            stage, output_label = {
+                "DECODE": ("decode", "decode_only"),
+                "PREFILL": ("prefill", "prefill_only"),
+                "PD": ("prefilldecode", "prefilldecode"),
+            }[kind]
+            marker_name = str(event.get("name", ""))
+            ts = float(event.get("ts", 0.0) or 0.0)
+            dur = float(event.get("dur", 0.0) or 0.0)
+            if dur <= 0:
+                warnings.append(
+                    f"SGLang fallback splitter: {marker_name} has no duration"
+                )
+                continue
+
+            end_ts = self._next_sglang_step_ts(events, ts) or (ts + dur)
+            out_path = split_dir / f"{output_label}_step.trace.json.gz"
+            self._write_trace_window(trace, out_path, ts, end_ts)
+            rows.append(
+                {
+                    "output_path": str(out_path),
+                    "num_steps": 1,
+                    "phase_avg_bs": self._sglang_step_batch_size(marker_name),
+                    "phase_num_prefilldecode": 1 if kind == "PD" else 0,
+                    "phase_num_decode": 1 if kind == "DECODE" else 0,
+                    "phase_num_prefill": 1 if kind == "PREFILL" else 0,
+                    "stage": stage,
+                    "source_marker": marker_name,
+                    "start_ts": ts,
+                    "end_ts": end_ts,
+                }
+            )
+
+        if not rows:
+            return warnings or ["SGLang fallback splitter: no trace windows written"]
+
+        execution_csv = split_dir / "execution_details.csv"
+        with execution_csv.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+
+        warnings.append(
+            f"SGLang fallback splitter wrote {len(rows)} trace window(s) to {split_dir}"
+        )
+        return warnings
+
+    @staticmethod
+    def _load_trace(trace_path: Path) -> Dict[str, Any]:
+        opener = gzip.open if trace_path.suffix == ".gz" else open
+        with opener(trace_path, "rt", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    @staticmethod
+    def _pick_sglang_step_events(
+        events: Sequence[Dict[str, Any]],
+    ) -> Dict[str, Dict[str, Any]]:
+        candidates: Dict[str, List[Tuple[float, float, Dict[str, Any]]]] = {
+            "DECODE": [],
+            "PREFILL": [],
+            "PD": [],
+        }
+        for event in events:
+            if str(event.get("cat", "")) != "user_annotation":
+                continue
+            marker_name = str(event.get("name", ""))
+            if not marker_name.startswith("step["):
+                continue
+            kind = TraceLensInferencePipeline._classify_sglang_step_name(marker_name)
+            if kind is None:
+                continue
+            batch_size = TraceLensInferencePipeline._sglang_step_batch_size(marker_name)
+            ts = float(event.get("ts", 0.0) or 0.0)
+            candidates[kind].append((batch_size, ts, event))
+
+        picks: Dict[str, Dict[str, Any]] = {}
+        for kind, kind_candidates in candidates.items():
+            if not kind_candidates:
+                continue
+            max_bs = max(item[0] for item in kind_candidates)
+            best_batch = [
+                item for item in kind_candidates
+                if item[0] == max_bs
+            ]
+            best_batch.sort(key=lambda item: item[1])
+            picks[kind] = best_batch[len(best_batch) // 2][2]
+        return picks
+
+    @staticmethod
+    def _classify_sglang_step_name(name: str) -> Optional[str]:
+        upper = name.upper()
+        if "DECODE" in upper:
+            return "DECODE"
+        if "PREFILLDECODE" in upper or "PREFILL_DECODE" in upper or "MIX" in upper:
+            return "PD"
+        if "EXTEND" in upper or "PREFILL" in upper:
+            return "PREFILL"
+        return None
+
+    @staticmethod
+    def _sglang_step_batch_size(name: str) -> float:
+        match = re.search(r"\bbs=(\d+(?:\.\d+)?)", name)
+        if match:
+            return float(match.group(1))
+        return 0.0
+
+    @staticmethod
+    def _next_sglang_step_ts(
+        events: Sequence[Dict[str, Any]],
+        start_ts: float,
+    ) -> Optional[float]:
+        next_ts: Optional[float] = None
+        for event in events:
+            if str(event.get("cat", "")) != "user_annotation":
+                continue
+            if not str(event.get("name", "")).startswith("step["):
+                continue
+            try:
+                ts = float(event.get("ts", 0.0) or 0.0)
+            except (TypeError, ValueError):
+                continue
+            if ts <= start_ts:
+                continue
+            if next_ts is None or ts < next_ts:
+                next_ts = ts
+        return next_ts
+
+    @staticmethod
+    def _write_trace_window(
+        trace: Dict[str, Any],
+        out_path: Path,
+        start_ts: float,
+        end_ts: float,
+    ) -> None:
+        window_events = []
+        for event in trace.get("traceEvents", []):
+            ts_raw = event.get("ts")
+            if ts_raw is None:
+                window_events.append(event)
+                continue
+            try:
+                ts = float(ts_raw)
+                dur = float(event.get("dur", 0.0) or 0.0)
+            except (TypeError, ValueError):
+                continue
+            event_end = ts + max(dur, 0.0)
+            if ts <= end_ts and event_end >= start_ts:
+                window_events.append(event)
+
+        out_trace = dict(trace)
+        out_trace["traceEvents"] = window_events
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with gzip.open(out_path, "wt", encoding="utf-8") as handle:
+            json.dump(out_trace, handle)
+
+    def _pick_largest_batch_traces(
+        self,
+        execution_csv: Path,
+    ) -> Dict[str, InferencePhasePick]:
+        by_kind: Dict[str, Tuple[float, Path]] = {}
+        split_dir = execution_csv.parent
+
+        with execution_csv.open(newline="", encoding="utf-8") as handle:
+            for row in csv.DictReader(handle):
+                output_path = row.get("output_path", "")
+                if not output_path or not self._is_single_iteration_row(row):
+                    continue
+
+                kind = self._classify_split_row(row)
+                if kind is None:
+                    continue
+
+                try:
+                    batch_size = float(row.get("phase_avg_bs") or 0.0)
+                except ValueError:
+                    batch_size = 0.0
+
+                path = Path(output_path)
+                if not path.is_absolute():
+                    path = split_dir / path
+
+                current = by_kind.get(kind)
+                if current is None or batch_size > current[0]:
+                    by_kind[kind] = (batch_size, path)
+
+        kind_to_stage = {
+            "PD": ("prefilldecode", "prefilldecode"),
+            "DECODE": ("decode", "decode_only"),
+            "PREFILL": ("prefill", "prefill_only"),
+        }
+        picks: Dict[str, InferencePhasePick] = {}
+        for kind, (stage, output_label) in kind_to_stage.items():
+            batch_size, path = by_kind.get(kind, (0.0, None))  # type: ignore[assignment]
+            picks[stage] = InferencePhasePick(
+                stage=stage,
+                csv_kind=kind,
+                output_label=output_label,
+                batch_size=batch_size,
+                trace_path=path,
+            )
+        return picks
+
+    @staticmethod
+    def _is_single_iteration_row(row: Dict[str, str]) -> bool:
+        base = os.path.basename(row.get("output_path", ""))
+        if base.startswith(
+            ("mixed_steady_state_", "prefilldecode_steady_state_", "decode_only_steady_state_")
+        ):
+            return False
+        try:
+            return int(float(row.get("num_steps") or 1)) <= 1
+        except ValueError:
+            return True
+
+    @staticmethod
+    def _classify_split_row(row: Dict[str, str]) -> Optional[str]:
+        def col(name: str) -> int:
+            try:
+                return int(float(row.get(name) or 0))
+            except ValueError:
+                return 0
+
+        if col("phase_num_prefilldecode") == 1:
+            return "PD"
+        if col("phase_num_decode") == 1:
+            return "DECODE"
+        if col("phase_num_prefill") == 1:
+            return "PREFILL"
+        return None
+
+    def _run_perf_report(
+        self,
+        stage: str,
+        trace_path: Path,
+        capture_folder: Path,
+        output_root: Path,
+        output_label: str,
+        gpu_arch_platform: Optional[str],
+    ) -> Dict[str, Any]:
+        out_dir = output_root / output_label
+        out_dir.mkdir(parents=True, exist_ok=True)
+        cmd = [
+            CLI_INFERENCE_REPORT,
+            "--profile_json_path",
+            str(trace_path),
+            "--output_csvs_dir",
+            str(out_dir),
+            "--group_by_parent_module",
+            "--enable_pseudo_ops",
+            "--group_by_num_kernels",
+        ]
+        if capture_folder.is_dir() and any(capture_folder.iterdir()):
+            cmd.extend(["--capture_folder", str(capture_folder)])
+        else:
+            logger.warning(
+                "TraceLens capture folder missing or empty; "
+                "running report without it: %s",
+                capture_folder,
+            )
+        if gpu_arch_platform:
+            cmd.extend(["--gpu_arch_platform", gpu_arch_platform])
+
+        logger.info("Running TraceLens inference perf report (%s): %s", stage, " ".join(cmd))
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=self.tl_config.cli_timeout_seconds,
+            env=self._subprocess_env(),
+        )
+
+        result: Dict[str, Any] = {
+            "stage": stage,
+            "trace_path": str(trace_path),
+            "output_dir": str(out_dir),
+            "files": [str(path) for path in sorted(out_dir.glob("*.csv"))],
+        }
+        if proc.returncode != 0:
+            result["error"] = (
+                f"TraceLens inference perf report failed for {stage}: "
+                f"{proc.stderr or proc.stdout}"
+            )
+        return result
+
+    def _subprocess_env(self) -> Dict[str, str]:
+        env = os.environ.copy()
+        if self.tl_extension:
+            env["TL_EXTENSION"] = self.tl_extension
+        return env
+
+
+def is_tracelens_inference_enabled(config: BenchmarkConfig) -> bool:
+    """Return True when benchmark config requests TraceLens inference mode."""
+    tl_config = config.profiler.tracelens
+    return bool(tl_config.enabled and tl_config.is_inference_mode)
+
+
+__all__ = [
+    "CLI_INFERENCE_REPORT",
+    "CLI_SPLIT_INFERENCE_TRACE",
+    "InferencePhasePick",
+    "TraceLensInferencePipeline",
+    "append_flag_value_args",
+    "compute_steady_state_iters",
+    "is_tracelens_inference_enabled",
+    "resolve_tl_extension",
+    "trace_arch_platform_from_runner",
+    "validate_tl_extension_importable",
+]

--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -566,7 +566,7 @@ class TraceLensInferencePipeline:
         text = path.read_text(encoding="utf-8")
         common_anchor = '"num_steps": 1, "merge_profiles": True, "profile_by_stage": True'
         common_repl = (
-            '"shape_discovery": False, "roofline_annotations": True, '
+            '"shape_discovery": True, "roofline_annotations": True, '
             '"num_steps": 1, "merge_profiles": True, "profile_by_stage": True'
         )
         steady_repl = (

--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -333,6 +334,123 @@ class TraceLensInferencePipeline:
 
         return results
 
+    def analyze_in_container(
+        self,
+        torch_trace_dir: Path,
+        output_dir: Path,
+        runner_type: Optional[str],
+        docker_image: str,
+        workspace: Path,
+    ) -> Dict[str, Any]:
+        """Run TraceLens inference postprocess inside a TraceLens-ready image.
+
+        Docker benchmark traces are produced inside the runtime container, so
+        the matching TraceLens CLI should be resolved from that same runtime
+        image instead of the host environment. This method starts short-lived,
+        CPU-only containers after the benchmark container has exited and writes
+        all outputs back to the mounted benchmark workspace.
+        """
+        results = self._base_analysis_result(torch_trace_dir)
+        results["postprocess_runtime"] = {
+            "mode": "docker",
+            "image": docker_image,
+            "workspace_mount": "/workspace",
+        }
+
+        if not docker_image:
+            results["errors"].append("TraceLens Docker image is not configured")
+            return results
+
+        workspace = workspace.resolve()
+        torch_trace_dir = torch_trace_dir.resolve()
+        output_dir = output_dir.resolve()
+
+        split_dir = torch_trace_dir / "trace_split"
+        capture_folder = torch_trace_dir / "capture_traces"
+        output_csvs_dir = output_dir / "tracelens"
+        gpu_arch_platform = trace_arch_platform_from_runner(runner_type)
+
+        results["split_dir"] = str(split_dir)
+        results["capture_folder"] = str(capture_folder)
+        results["output_dir"] = str(output_csvs_dir)
+        results["gpu_arch_platform"] = gpu_arch_platform
+
+        rank0_trace = self._locate_rank0_trace(torch_trace_dir)
+        if rank0_trace is None:
+            results["errors"].append(
+                f"Could not locate rank-0 trace for framework={self.config.framework} "
+                f"in {torch_trace_dir}"
+            )
+            return results
+        results["rank0_trace"] = str(rank0_trace)
+
+        split_error = self._run_splitter_in_container(
+            docker_image=docker_image,
+            workspace=workspace,
+            rank0_trace=rank0_trace.resolve(),
+            split_dir=split_dir,
+        )
+        if split_error:
+            results["errors"].append(split_error)
+            return results
+
+        self._rewrite_container_split_paths(
+            split_dir / "execution_details.csv",
+            workspace,
+        )
+
+        validation_warnings = self._validate_trace_layout(torch_trace_dir, split_dir)
+        results["warnings"].extend(validation_warnings)
+
+        execution_csv = split_dir / "execution_details.csv"
+        if not execution_csv.exists():
+            if self.config.framework == "sglang":
+                fallback_warning = (
+                    "TraceLens splitter did not produce execution_details.csv; "
+                    "trying SGLang step marker fallback"
+                )
+                logger.warning(fallback_warning)
+                results["warnings"].append(fallback_warning)
+                results["warnings"].extend(
+                    self._split_sglang_step_markers(rank0_trace, split_dir)
+                )
+
+        execution_csv = split_dir / "execution_details.csv"
+        if not execution_csv.exists():
+            results["errors"].append(f"Missing TraceLens split CSV: {execution_csv}")
+            return results
+
+        picks = self._pick_largest_batch_traces(execution_csv)
+        results["phase_picks"] = {
+            stage: pick.to_dict()
+            for stage, pick in picks.items()
+        }
+
+        for stage in self.tl_config.analysis_stages:
+            pick = picks.get(stage)
+            if pick is None or pick.trace_path is None:
+                warning = f"{stage}: no candidate trace found; skipping perf report"
+                logger.warning(warning)
+                results["warnings"].append(warning)
+                continue
+
+            stage_result = self._run_perf_report_in_container(
+                docker_image=docker_image,
+                workspace=workspace,
+                stage=stage,
+                trace_path=pick.trace_path.resolve(),
+                capture_folder=capture_folder,
+                output_root=output_csvs_dir,
+                output_label=pick.output_label,
+                gpu_arch_platform=gpu_arch_platform,
+            )
+            results["stage_results"][stage] = stage_result
+            results["output_files"].extend(stage_result.get("files", []))
+            if stage_result.get("error"):
+                results["errors"].append(stage_result["error"])
+
+        return results
+
     def restore(self) -> Dict[str, Any]:
         """Restore files backed up during prepare()."""
         result = {"restored_files": [], "warnings": []}
@@ -547,6 +665,44 @@ class TraceLensInferencePipeline:
         )
         if proc.returncode != 0:
             return f"TraceLens inference split failed: {proc.stderr or proc.stdout}"
+        return None
+
+    def _run_splitter_in_container(
+        self,
+        docker_image: str,
+        workspace: Path,
+        rank0_trace: Path,
+        split_dir: Path,
+    ) -> Optional[str]:
+        envs = self.config.envs
+        split_dir.mkdir(parents=True, exist_ok=True)
+        cmd = [
+            CLI_SPLIT_INFERENCE_TRACE,
+            self._container_path(rank0_trace, workspace),
+            "-o",
+            self._container_path(split_dir, workspace),
+            "--find-steady-state",
+            "--store-single-iteration",
+            "--num-steps",
+            str(self.tl_config.num_steps),
+            "--CONC",
+            str(envs.get("CONC", 32)),
+            "--OSL",
+            str(envs.get("OSL", 512)),
+            "--R",
+            str(envs.get("RANDOM_RANGE_RATIO", 1.0)),
+        ]
+        logger.info(
+            "Running TraceLens inference splitter in container %s: %s",
+            docker_image,
+            " ".join(cmd),
+        )
+        proc = self._run_container_command(docker_image, workspace, cmd)
+        if proc.returncode != 0:
+            return (
+                "TraceLens inference split failed in container "
+                f"{docker_image}: {proc.stderr or proc.stdout}"
+            )
         return None
 
     def _validate_trace_layout(self, torch_trace_dir: Path, split_dir: Path) -> List[str]:
@@ -860,6 +1016,173 @@ class TraceLensInferencePipeline:
                 f"{proc.stderr or proc.stdout}"
             )
         return result
+
+    def _run_perf_report_in_container(
+        self,
+        docker_image: str,
+        workspace: Path,
+        stage: str,
+        trace_path: Path,
+        capture_folder: Path,
+        output_root: Path,
+        output_label: str,
+        gpu_arch_platform: Optional[str],
+    ) -> Dict[str, Any]:
+        out_dir = output_root / output_label
+        out_dir.mkdir(parents=True, exist_ok=True)
+        cmd = [
+            CLI_INFERENCE_REPORT,
+            "--profile_json_path",
+            self._container_path(trace_path, workspace),
+            "--output_csvs_dir",
+            self._container_path(out_dir, workspace),
+            "--group_by_parent_module",
+            "--enable_pseudo_ops",
+            "--group_by_num_kernels",
+        ]
+        if capture_folder.is_dir() and any(capture_folder.iterdir()):
+            cmd.extend(
+                [
+                    "--capture_folder",
+                    self._container_path(capture_folder, workspace),
+                ]
+            )
+        else:
+            logger.warning(
+                "TraceLens capture folder missing or empty; "
+                "running report without it: %s",
+                capture_folder,
+            )
+        if gpu_arch_platform:
+            cmd.extend(["--gpu_arch_platform", gpu_arch_platform])
+
+        logger.info(
+            "Running TraceLens inference perf report in container %s (%s): %s",
+            docker_image,
+            stage,
+            " ".join(cmd),
+        )
+        proc = self._run_container_command(docker_image, workspace, cmd)
+
+        result: Dict[str, Any] = {
+            "stage": stage,
+            "trace_path": str(trace_path),
+            "output_dir": str(out_dir),
+            "files": [str(path) for path in sorted(out_dir.glob("*.csv"))],
+        }
+        if proc.returncode != 0:
+            result["error"] = (
+                f"TraceLens inference perf report failed for {stage} in container "
+                f"{docker_image}: {proc.stderr or proc.stdout}"
+            )
+        return result
+
+    def _run_container_command(
+        self,
+        docker_image: str,
+        workspace: Path,
+        cmd: Sequence[str],
+    ) -> subprocess.CompletedProcess[str]:
+        docker_cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "--network",
+            "none",
+            "-v",
+            f"{workspace}:/workspace",
+            "-w",
+            "/workspace",
+        ]
+        if hasattr(os, "getuid") and hasattr(os, "getgid"):
+            docker_cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+        docker_cmd.extend(["-e", "HOME=/tmp", "-e", "PYTHONUNBUFFERED=1"])
+        if self.tl_extension:
+            docker_cmd.extend(["-e", f"TL_EXTENSION={self.tl_extension}"])
+        docker_cmd.extend(
+            ["--entrypoint", "/bin/bash", docker_image, "-lc", shlex.join(cmd)]
+        )
+
+        logger.debug("Running TraceLens container command: %s", " ".join(docker_cmd))
+        try:
+            return subprocess.run(
+                docker_cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.tl_config.cli_timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return subprocess.CompletedProcess(
+                docker_cmd,
+                124,
+                stdout=exc.stdout or "",
+                stderr=(
+                    exc.stderr
+                    or f"TraceLens container command timed out after "
+                    f"{self.tl_config.cli_timeout_seconds}s"
+                ),
+            )
+        except FileNotFoundError as exc:
+            return subprocess.CompletedProcess(
+                docker_cmd,
+                127,
+                stdout="",
+                stderr=f"Docker command not found: {exc}",
+            )
+
+    def _base_analysis_result(self, torch_trace_dir: Path) -> Dict[str, Any]:
+        return {
+            "enabled": True,
+            "analysis_mode": "inference",
+            "analysis_stages": self.tl_config.analysis_stages,
+            "tl_extension": self.tl_extension,
+            "trace_dir": str(torch_trace_dir),
+            "output_files": [],
+            "stage_results": {},
+            "errors": [],
+            "warnings": [],
+        }
+
+    def _container_path(self, path: Path, workspace: Path) -> str:
+        path = path.resolve()
+        workspace = workspace.resolve()
+        try:
+            rel = path.relative_to(workspace)
+        except ValueError as exc:
+            raise ValueError(
+                f"TraceLens container postprocess path must be inside workspace: "
+                f"{path} (workspace={workspace})"
+            ) from exc
+        return "/workspace" if str(rel) == "." else f"/workspace/{rel.as_posix()}"
+
+    @staticmethod
+    def _rewrite_container_split_paths(execution_csv: Path, workspace: Path) -> None:
+        if not execution_csv.exists():
+            return
+        with execution_csv.open(newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            rows = list(reader)
+            fieldnames = reader.fieldnames
+        if not fieldnames:
+            return
+
+        changed = False
+        for row in rows:
+            output_path = row.get("output_path", "")
+            if output_path == "/workspace":
+                row["output_path"] = str(workspace)
+                changed = True
+            elif output_path.startswith("/workspace/"):
+                rel = output_path[len("/workspace/"):]
+                row["output_path"] = str(workspace / rel)
+                changed = True
+
+        if not changed:
+            return
+        with execution_csv.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
 
     def _subprocess_env(self) -> Dict[str, str]:
         env = os.environ.copy()

--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -7,15 +7,15 @@
 TraceLens inference-mode integration for benchmark mode.
 
 This module ports the Magpie-facing preprocess/postprocess workflow into
-Magpie so TraceLens public inference analysis, and optional TL_EXTENSION based
-internal extensions, can be driven directly by ``magpie benchmark``.
+Magpie so TraceLens public inference analysis can be driven directly by
+``magpie benchmark``. TL_EXTENSION is passed through to TraceLens without
+Magpie interpreting the extension value.
 """
 
 from __future__ import annotations
 
 import csv
 import gzip
-import importlib.util
 import json
 import logging
 import os
@@ -67,39 +67,6 @@ def resolve_tl_extension(envs: Dict[str, Any]) -> Optional[str]:
 
     cfg_value = str(envs.get("TL_EXTENSION", "") or "").strip()
     return cfg_value or None
-
-
-def validate_tl_extension_importable(tl_extension: Optional[str]) -> None:
-    """Fail early when TL_EXTENSION names a package not importable on host."""
-    if not tl_extension:
-        return
-
-    missing = []
-    for package_name in tl_extension.split(":"):
-        package_name = package_name.strip()
-        if not package_name:
-            continue
-        if importlib.util.find_spec(package_name) is None:
-            missing.append(package_name)
-
-    if missing:
-        raise RuntimeError(
-            "TL_EXTENSION is set but the extension package(s) are not importable: "
-            f"{', '.join(missing)}. Install the matching TraceLens extension "
-            "package in the Python environment that runs Magpie."
-        )
-
-
-def uses_tracelens_nda_extension(tl_extension: Optional[str]) -> bool:
-    """Return whether TL_EXTENSION names the internal TraceLens NDA package."""
-    if not tl_extension:
-        return False
-
-    for package_name in tl_extension.split(":"):
-        normalized = package_name.strip().lower().replace("-", "_")
-        if normalized == "tracelens_nda" or normalized.startswith("tracelens_nda."):
-            return True
-    return False
 
 
 def is_tracelens_patched_sglang_image(image_name: Optional[str]) -> bool:
@@ -205,8 +172,6 @@ class TraceLensInferencePipeline:
 
     def prepare(self, workspace: Path) -> Dict[str, Any]:
         """Patch config/envs and mutable InferenceX files before benchmark."""
-        validate_tl_extension_importable(self.tl_extension)
-
         result: Dict[str, Any] = {
             "enabled": True,
             "analysis_mode": self.tl_config.analysis_mode,
@@ -292,12 +257,6 @@ class TraceLensInferencePipeline:
                 "Required TraceLens inference CLI command(s) not found on PATH: "
                 + ", ".join(missing_cli)
             )
-            return results
-
-        try:
-            validate_tl_extension_importable(self.tl_extension)
-        except RuntimeError as exc:
-            results["errors"].append(str(exc))
             return results
 
         split_dir = torch_trace_dir / "trace_split"
@@ -929,6 +888,4 @@ __all__ = [
     "is_tracelens_patched_sglang_image",
     "resolve_tl_extension",
     "trace_arch_platform_from_runner",
-    "uses_tracelens_nda_extension",
-    "validate_tl_extension_importable",
 ]

--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 BACKUP_SUFFIX = ".tracelens.bak"
 CLI_SPLIT_INFERENCE_TRACE = "TraceLens_split_inference_trace"
 CLI_INFERENCE_REPORT = "TraceLens_generate_perf_report_pytorch_inference"
+SGLANG_PROFILE_CUDA_GRAPH_FLAG = "--enable-profile-cuda-graph"
+SGLANG_SHAPE_DISCOVERY_FLAG = "--enable-shape-discovery-for-cuda-graph-profile"
 
 
 @dataclass
@@ -86,6 +88,36 @@ def validate_tl_extension_importable(tl_extension: Optional[str]) -> None:
             f"{', '.join(missing)}. Install the matching TraceLens extension "
             "package in the Python environment that runs Magpie."
         )
+
+
+def uses_tracelens_nda_extension(tl_extension: Optional[str]) -> bool:
+    """Return whether TL_EXTENSION names the internal TraceLens NDA package."""
+    if not tl_extension:
+        return False
+
+    for package_name in tl_extension.split(":"):
+        normalized = package_name.strip().lower().replace("-", "_")
+        if normalized == "tracelens_nda" or normalized.startswith("tracelens_nda."):
+            return True
+    return False
+
+
+def is_tracelens_patched_sglang_image(image_name: Optional[str]) -> bool:
+    """Detect image names that are expected to carry TraceLens SGLang patches."""
+    if not image_name:
+        return False
+
+    lowered = image_name.lower()
+    return "tracelens" in lowered and "sglang" in lowered
+
+
+def host_sglang_supports_shape_discovery() -> bool:
+    """Detect whether the host SGLang install supports the patched flag."""
+    try:
+        from sglang.srt.server_args import ServerArgs  # type: ignore[import-not-found]
+    except Exception:
+        return False
+    return hasattr(ServerArgs, "enable_shape_discovery_for_cuda_graph_profile")
 
 
 def compute_steady_state_iters(
@@ -393,14 +425,24 @@ class TraceLensInferencePipeline:
     ) -> None:
         envs["SGLANG_PROFILE_WITH_STACK"] = "True"
         envs["SGLANG_PROFILE_RECORD_SHAPE"] = "True"
+        sglang_args: List[Tuple[str, Any]] = [
+            (SGLANG_PROFILE_CUDA_GRAPH_FLAG, None),
+        ]
+        if self._should_enable_sglang_shape_discovery():
+            sglang_args.append((SGLANG_SHAPE_DISCOVERY_FLAG, None))
+
         append_flag_value_args(
             envs,
             "EXTRA_SGLANG_ARGS",
-            [
-                ("--enable-profile-cuda-graph", None),
-            ],
+            sglang_args,
         )
         self._patch_sglang_benchmark_serving(max_iters, delay_iters, result)
+
+    def _should_enable_sglang_shape_discovery(self) -> bool:
+        """Only enable TraceLens-patched SGLang flags for known patched runtimes."""
+        return is_tracelens_patched_sglang_image(
+            self.config.docker_image
+        ) or (self.config.is_local and host_sglang_supports_shape_discovery())
 
     def _patch_benchmark_lib(self, result: Dict[str, Any]) -> None:
         path = Path(self.config.inferencex_path) / "benchmarks" / "benchmark_lib.sh"
@@ -877,11 +919,16 @@ __all__ = [
     "CLI_INFERENCE_REPORT",
     "CLI_SPLIT_INFERENCE_TRACE",
     "InferencePhasePick",
+    "SGLANG_PROFILE_CUDA_GRAPH_FLAG",
+    "SGLANG_SHAPE_DISCOVERY_FLAG",
     "TraceLensInferencePipeline",
     "append_flag_value_args",
     "compute_steady_state_iters",
+    "host_sglang_supports_shape_discovery",
     "is_tracelens_inference_enabled",
+    "is_tracelens_patched_sglang_image",
     "resolve_tl_extension",
     "trace_arch_platform_from_runner",
+    "uses_tracelens_nda_extension",
     "validate_tl_extension_importable",
 ]

--- a/Magpie/modes/benchmark/tracelens_runtime.py
+++ b/Magpie/modes/benchmark/tracelens_runtime.py
@@ -1,0 +1,312 @@
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""
+TraceLens-ready benchmark runtime image preparation.
+
+TraceLens inference mode needs framework runtime patches for some vLLM/SGLang
+versions. This module uses the public TraceLens workflow build scripts to derive
+patched Docker images from supported official runtime images.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .config import BenchmarkConfig
+
+logger = logging.getLogger(__name__)
+
+
+TRACELENS_INFERENCE_WORKFLOW = Path("examples/custom_workflows/inference_analysis")
+SUPPORTED_SGLANG_PATCH_VERSIONS = ("0.5.9", "0.5.11", "0.5.12")
+SUPPORTED_VLLM_PATCH_VERSIONS = tuple(range(14, 22))
+
+
+def is_tracelens_ready_runtime_image(framework: str, image_name: Optional[str]) -> bool:
+    """Return whether the Docker image name already looks TraceLens-ready."""
+    if not image_name:
+        return False
+
+    lowered = image_name.lower()
+    return "tracelens" in lowered and framework.lower() in lowered
+
+
+def infer_sglang_patch_version(image_name: str) -> Optional[str]:
+    """Infer supported TraceLens SGLang patch version from an image tag."""
+    lowered = image_name.lower()
+    for version in SUPPORTED_SGLANG_PATCH_VERSIONS:
+        if version in lowered:
+            return version
+    return None
+
+
+def infer_vllm_patch_version(image_name: str) -> Optional[str]:
+    """Infer TraceLens vLLM patch shorthand such as v19 from an image tag."""
+    lowered = image_name.lower()
+    match = re.search(r"(?:^|[^0-9])v?0\.(1[4-9]|2[0-1])(?:\.\d+)?", lowered)
+    if not match:
+        return None
+
+    minor = int(match.group(1))
+    if minor not in SUPPORTED_VLLM_PATCH_VERSIONS:
+        return None
+    return f"v{minor}"
+
+
+def runner_type_to_gpu_type(runner_type: str) -> str:
+    """Map Magpie/InferenceX runner type to TraceLens build script gpu type."""
+    normalized = (runner_type or "").lower()
+    if normalized.startswith("mi300"):
+        return "mi300"
+    if normalized.startswith("mi350"):
+        return "mi350"
+    if normalized.startswith("mi355"):
+        return "mi355"
+    raise ValueError(
+        "TraceLens runtime auto patch currently supports AMD MI300/MI350/MI355 "
+        f"runners, got runner_type={runner_type!r}"
+    )
+
+
+def resolve_tracelens_repo_path(configured_path: Optional[str] = None) -> Path:
+    """Find a public TraceLens source checkout containing inference workflows."""
+    candidates = []
+    if configured_path:
+        candidates.append(Path(configured_path).expanduser())
+
+    for env_key in ("TRACELENS_REPO_PATH", "TRACELENS_PATH"):
+        env_value = os.environ.get(env_key)
+        if env_value:
+            candidates.append(Path(env_value).expanduser())
+
+    magpie_repo = Path(__file__).resolve().parents[3]
+    candidates.extend(
+        [
+            magpie_repo / "TraceLens",
+            magpie_repo.parent / "TraceLens",
+            Path.cwd() / "TraceLens",
+            Path.home() / "TraceLens",
+        ]
+    )
+
+    for candidate in candidates:
+        workflow_dir = candidate / TRACELENS_INFERENCE_WORKFLOW
+        if workflow_dir.is_dir():
+            return candidate.resolve()
+
+    searched = ", ".join(str(path) for path in candidates)
+    raise RuntimeError(
+        "TraceLens auto_patch_runtime requires a public TraceLens source checkout "
+        "with examples/custom_workflows/inference_analysis. Set "
+        "profiler.tracelens.tracelens_repo_path or TRACELENS_REPO_PATH. "
+        f"Searched: {searched}"
+    )
+
+
+def derive_tracelens_image_tag(
+    framework: str,
+    base_image: str,
+    runner_type: str,
+    patch_version: str,
+) -> str:
+    """Create a deterministic local Docker tag for a derived runtime image."""
+    digest = hashlib.sha256(base_image.encode("utf-8")).hexdigest()[:10]
+    safe_base = re.sub(r"[^a-z0-9_.-]+", "-", base_image.lower()).strip(".-")
+    safe_base = safe_base[:72].strip(".-") or framework
+    safe_runner = re.sub(r"[^a-z0-9_.-]+", "-", runner_type.lower()).strip(".-")
+    safe_version = patch_version.replace(".", "_")
+    return (
+        f"magpie-tracelens-{framework}:"
+        f"{safe_version}-{safe_runner}-{digest}-{safe_base}"
+    )
+
+
+def docker_image_exists(image_tag: str) -> bool:
+    """Return True when Docker can inspect the image tag locally."""
+    proc = subprocess.run(
+        ["docker", "image", "inspect", image_tag],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return proc.returncode == 0
+
+
+def _build_command(
+    config: BenchmarkConfig,
+    base_image: str,
+    runner_type: str,
+    derived_image: str,
+    tracelens_repo: Path,
+) -> list[str]:
+    workflow_dir = tracelens_repo / TRACELENS_INFERENCE_WORKFLOW
+    if config.framework == "sglang":
+        patch_version = infer_sglang_patch_version(base_image)
+        if patch_version is None:
+            raise RuntimeError(
+                "TraceLens auto_patch_runtime cannot infer a supported SGLang "
+                f"version from image {base_image!r}. Supported versions: "
+                f"{', '.join(SUPPORTED_SGLANG_PATCH_VERSIONS)}. Set docker_image "
+                "to a supported official SGLang tag, use a TraceLens-ready image, "
+                "or set auto_patch_runtime=false."
+            )
+        return [
+            "bash",
+            str(workflow_dir / "build_docker_sglang.sh"),
+            str(tracelens_repo),
+            "--sglang-version",
+            patch_version,
+            "--gpu-type",
+            runner_type_to_gpu_type(runner_type),
+            "--base-image",
+            base_image,
+            "-t",
+            derived_image,
+        ]
+
+    if config.framework == "vllm":
+        patch_version = infer_vllm_patch_version(base_image)
+        if patch_version is None:
+            raise RuntimeError(
+                "TraceLens auto_patch_runtime cannot infer a supported vLLM "
+                f"version from image {base_image!r}. Supported versions: "
+                "v0.14.x through v0.21.x. Set docker_image to a supported "
+                "official vLLM tag, use a TraceLens-ready image, or set "
+                "auto_patch_runtime=false."
+            )
+        return [
+            "bash",
+            str(workflow_dir / "build_docker_vllm.sh"),
+            patch_version,
+            str(tracelens_repo),
+            "--base-image",
+            base_image,
+            "-t",
+            derived_image,
+        ]
+
+    raise RuntimeError(f"Unsupported TraceLens runtime framework: {config.framework}")
+
+
+def prepare_tracelens_runtime_image(
+    config: BenchmarkConfig,
+    base_image: str,
+    runner_type: str,
+) -> Dict[str, Any]:
+    """
+    Ensure the Docker runtime image is TraceLens-ready when requested.
+
+    Returns a serializable metadata dict. The caller should use the returned
+    ``image`` value for the benchmark Docker run.
+    """
+    tl_config = config.profiler.tracelens
+    result: Dict[str, Any] = {
+        "enabled": bool(tl_config.enabled and tl_config.is_inference_mode),
+        "auto_patch_runtime": tl_config.auto_patch_runtime,
+        "framework": config.framework,
+        "base_image": base_image,
+        "image": base_image,
+        "built": False,
+        "skipped": True,
+    }
+
+    if not result["enabled"]:
+        result["reason"] = "TraceLens inference mode is not enabled"
+        return result
+
+    if config.is_local or config.is_ray:
+        result["reason"] = f"run_mode={config.run_mode} does not use Docker image patching"
+        return result
+
+    if is_tracelens_ready_runtime_image(config.framework, base_image):
+        result["reason"] = "image already appears TraceLens-ready"
+        return result
+
+    if not tl_config.auto_patch_runtime:
+        result["reason"] = "auto_patch_runtime=false"
+        return result
+
+    tracelens_repo = resolve_tracelens_repo_path(tl_config.tracelens_repo_path)
+
+    patch_version = (
+        infer_sglang_patch_version(base_image)
+        if config.framework == "sglang"
+        else infer_vllm_patch_version(base_image)
+    )
+    if patch_version is None:
+        # Let _build_command raise the framework-specific error text.
+        patch_version = "unknown"
+
+    derived_image = tl_config.runtime_patch_image_tag or derive_tracelens_image_tag(
+        framework=config.framework,
+        base_image=base_image,
+        runner_type=runner_type,
+        patch_version=patch_version,
+    )
+
+    result.update(
+        {
+            "image": derived_image,
+            "tracelens_repo_path": str(tracelens_repo),
+            "patch_version": patch_version,
+        }
+    )
+
+    if docker_image_exists(derived_image) and not tl_config.runtime_patch_force_rebuild:
+        result["reason"] = "derived image already exists"
+        return result
+
+    cmd = _build_command(
+        config=config,
+        base_image=base_image,
+        runner_type=runner_type,
+        derived_image=derived_image,
+        tracelens_repo=tracelens_repo,
+    )
+    result["command"] = cmd
+    result["skipped"] = False
+
+    logger.info(
+        "Building TraceLens-ready %s image from %s as %s",
+        config.framework,
+        base_image,
+        derived_image,
+    )
+    proc = subprocess.run(
+        cmd,
+        cwd=str(tracelens_repo),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if proc.returncode != 0:
+        tail = (proc.stdout or "")[-4000:]
+        raise RuntimeError(
+            "TraceLens runtime image build failed with exit code "
+            f"{proc.returncode}. Command: {' '.join(cmd)}\n{tail}"
+        )
+
+    result["built"] = True
+    result["reason"] = "derived image built"
+    return result
+
+
+__all__ = [
+    "derive_tracelens_image_tag",
+    "docker_image_exists",
+    "infer_sglang_patch_version",
+    "infer_vllm_patch_version",
+    "is_tracelens_ready_runtime_image",
+    "prepare_tracelens_runtime_image",
+    "resolve_tracelens_repo_path",
+    "runner_type_to_gpu_type",
+]

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -328,8 +328,8 @@ profiler:
 ```
 
 To enable an internal TraceLens extension, set `TL_EXTENSION` either in the
-shell environment or under benchmark envs. Magpie verifies that the package is
-importable before launching the benchmark and passes the variable to TraceLens
+shell environment or under benchmark envs. Magpie does not interpret the value;
+it only passes the variable through to the benchmark and TraceLens
 post-processing commands:
 
 ```yaml
@@ -574,7 +574,7 @@ pip install git+https://github.com/AMD-AIG-AIMA/TraceLens.git
 ```
 
 If `TL_EXTENSION=TraceLens_NDA` is set, install the matching internal extension
-package in the same Python environment that runs Magpie.
+package wherever the TraceLens runtime/post-processing commands need it.
 
 **4. Timeout During Model Loading**
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -264,10 +264,67 @@ TraceLens provides automated analysis of torch profiler traces:
 
 | Command | Description | Output |
 |---------|-------------|--------|
+| `TraceLens_split_inference_trace` | Split vLLM/SGLang inference traces into phase windows | `torch_trace/trace_split/` |
+| `TraceLens_generate_perf_report_pytorch_inference` | Inference-aware prefill/decode reports | `tracelens/` |
 | `TraceLens_generate_perf_report_pytorch` | Single-rank performance report | `tracelens_rank0_csvs/` |
 | `TraceLens_generate_multi_rank_collective_report_pytorch` | Multi-rank collective analysis | `tracelens_collective_csvs/` |
 
+`analysis_mode` defaults to `inference`, which is the recommended mode for
+vLLM/SGLang benchmarks. It automatically enables the torch profiler, patches the
+needed InferenceX profiling helpers for the run, splits the rank-0 trace, and
+runs reports for all inference stages. Use `analysis_mode: pytorch` to keep the
+legacy direct PyTorch report flow.
+
+`analysis_stages` defaults to `all`:
+
+```yaml
+profiler:
+  tracelens:
+    enabled: true
+    analysis_stages: all
+```
+
+To run only selected stages:
+
+```yaml
+profiler:
+  tracelens:
+    enabled: true
+    analysis_stages: [prefill, decode]
+```
+
+Supported stage names are `prefilldecode` (alias: `mixed`), `prefill`, and
+`decode`. GPU architecture is detected through Magpie's existing runner/GPU
+mapping and passed to TraceLens as `--gpu_arch_platform`.
+
+Each TraceLens inference postprocess command uses `cli_timeout_seconds`, which
+defaults to `1800`. Increase it for long-output runs where splitting the full
+decode trace can take longer:
+
+```yaml
+profiler:
+  tracelens:
+    enabled: true
+    cli_timeout_seconds: 2400
+```
+
+To enable an internal TraceLens extension, set `TL_EXTENSION` either in the
+shell environment or under benchmark envs. Magpie verifies that the package is
+importable before launching the benchmark and passes the variable to TraceLens
+post-processing commands:
+
+```yaml
+benchmark:
+  envs:
+    TL_EXTENSION: "TraceLens_NDA"
+```
+
 #### TraceLens Output Files
+
+**Inference reports (`tracelens/`):**
+- `prefilldecode/` - Mixed prefill+decode phase report
+- `decode_only/` - Pure decode phase report
+- `prefill_only/` - Pure prefill phase report
 
 **Single-rank report (`tracelens_rank0_csvs/`):**
 - `gpu_timeline.csv` - GPU kernel timeline
@@ -408,6 +465,9 @@ benchmark:
       enabled: true
     tracelens:
       enabled: true
+      # analysis_mode defaults to inference
+      # analysis_stages defaults to all (prefilldecode, decode, prefill)
+      # cli_timeout_seconds defaults to 1800
       export_format: csv
       multi_rank_report_enabled: false  # Skip multi-rank for speed
       
@@ -434,6 +494,9 @@ benchmark:
       enabled: true
     tracelens:
       enabled: true
+      analysis_mode: inference
+      analysis_stages: all
+      cli_timeout_seconds: 2400
       export_format: csv
       perf_report_enabled: true
       multi_rank_report_enabled: true
@@ -480,12 +543,15 @@ Solution: Add user to docker group or run with sudo
 
 **3. TraceLens Not Found**
 ```
-TraceLens CLI command 'TraceLens_generate_perf_report_pytorch' not found
+Required TraceLens inference CLI command(s) not found on PATH
 ```
 Solution: TraceLens will be auto-installed. If issues persist:
 ```bash
 pip install git+https://github.com/AMD-AIG-AIMA/TraceLens.git
 ```
+
+If `TL_EXTENSION=TraceLens_NDA` is set, install the matching internal extension
+package in the same Python environment that runs Magpie.
 
 **4. Timeout During Model Loading**
 
@@ -539,4 +605,3 @@ python -m Magpie benchmark --benchmark-config config.yaml --log-level DEBUG
 - [vLLM](https://github.com/vllm-project/vllm) — LLM inference engine
 - [SGLang](https://github.com/sgl-project/sglang) — LLM serving framework
 - [Ray + Magpie](ray-magpie.md) — optional remote benchmark scheduling
-

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -117,6 +117,8 @@ benchmark:
     # TraceLens trace analysis
     tracelens:
       enabled: true            # Enable TraceLens analysis
+      auto_patch_runtime: true # Build TraceLens-ready Docker image if needed
+      tracelens_repo_path: null # Optional public TraceLens source checkout
       export_format: csv       # "csv" or "excel"
       perf_report_enabled: true      # Single-rank performance report
       multi_rank_report_enabled: true # Multi-rank collective report
@@ -275,6 +277,14 @@ needed InferenceX profiling helpers for the run, splits the rank-0 trace, and
 runs reports for all inference stages. Use `analysis_mode: pytorch` to keep the
 legacy direct PyTorch report flow.
 
+For Docker benchmarks, `auto_patch_runtime` defaults to `true`. When TraceLens
+inference mode is enabled and the selected runtime image is not already
+TraceLens-ready, Magpie builds a derived image from supported official
+vLLM/SGLang tags using the public TraceLens workflow scripts. The derived image
+is tagged locally as `magpie-tracelens-<framework>:...` and reused on later runs.
+Set `profiler.tracelens.tracelens_repo_path` or `TRACELENS_REPO_PATH` to a public
+TraceLens source checkout if Magpie cannot auto-locate it.
+
 `analysis_stages` defaults to `all`:
 
 ```yaml
@@ -296,6 +306,15 @@ profiler:
 Supported stage names are `prefilldecode` (alias: `mixed`), `prefill`, and
 `decode`. GPU architecture is detected through Magpie's existing runner/GPU
 mapping and passed to TraceLens as `--gpu_arch_platform`.
+
+For SGLang, TraceLens inference mode automatically adds
+`--enable-profile-cuda-graph`. It also adds
+`--enable-shape-discovery-for-cuda-graph-profile` when the configured Docker
+image name looks like a TraceLens-patched SGLang image, such as
+`tracelens-sglang:*` or `magpie-tracelens-sglang:*`. For local runs, Magpie also
+detects whether the installed SGLang exposes the patched server argument. For
+other SGLang builds, keep patched-runtime-only flags explicit in
+`EXTRA_SGLANG_ARGS`.
 
 Each TraceLens inference postprocess command uses `cli_timeout_seconds`, which
 defaults to `1800`. Increase it for long-output runs where splitting the full
@@ -467,6 +486,8 @@ benchmark:
       enabled: true
       # analysis_mode defaults to inference
       # analysis_stages defaults to all (prefilldecode, decode, prefill)
+      # auto_patch_runtime defaults to true for Docker runs
+      # tracelens_repo_path can point to a public TraceLens checkout
       # cli_timeout_seconds defaults to 1800
       export_format: csv
       multi_rank_report_enabled: false  # Skip multi-rank for speed
@@ -496,6 +517,8 @@ benchmark:
       enabled: true
       analysis_mode: inference
       analysis_stages: all
+      auto_patch_runtime: true
+      # tracelens_repo_path: /path/to/TraceLens
       cli_timeout_seconds: 2400
       export_format: csv
       perf_report_enabled: true

--- a/docs/how-to/benchmark.md
+++ b/docs/how-to/benchmark.md
@@ -288,6 +288,12 @@ is tagged locally as `magpie-tracelens-<framework>:...` and reused on later runs
 Set `profiler.tracelens.tracelens_repo_path` or `TRACELENS_REPO_PATH` to a public
 TraceLens source checkout if Magpie cannot auto-locate it.
 
+For `run_mode: docker`, TraceLens inference post-processing also runs inside the
+resolved runtime image after the benchmark container exits. The post-processing
+container is CPU-only, mounts the benchmark workspace at `/workspace`, and writes
+CSV outputs under `tracelens/`. Host Python only needs Docker; it does not need
+the TraceLens CLI on `PATH`.
+
 `analysis_stages` defaults to `all`:
 
 ```yaml
@@ -571,13 +577,15 @@ Solution: Add user to docker group or run with sudo
 ```
 Required TraceLens inference CLI command(s) not found on PATH
 ```
-Solution: TraceLens will be auto-installed. If issues persist:
+Solution: This applies to `run_mode: local` or classic host post-processing.
+TraceLens will be auto-installed. If issues persist:
 ```bash
 pip install git+https://github.com/AMD-AIG-AIMA/TraceLens.git
 ```
 
 If `TL_EXTENSION=TraceLens_NDA` is set, install the matching internal extension
-package wherever the TraceLens runtime/post-processing commands need it.
+package wherever the TraceLens runtime/post-processing commands need it. For
+`run_mode: docker`, those commands are resolved from the runtime image.
 
 **4. Timeout During Model Loading**
 
@@ -619,7 +627,8 @@ python -m Magpie benchmark --benchmark-config config.yaml --log-level DEBUG
 3. **Server Launch**: Start vLLM/SGLang server (in container or on host per `run_mode`)
 4. **Client Execution**: Run benchmark client with profiling enabled
 5. **Trace Collection**: Torch profiler traces saved to workspace
-6. **TraceLens Analysis**: Run TraceLens CLI commands on host (if enabled)
+6. **TraceLens Analysis**: Run TraceLens CLI commands inside the runtime image
+   for Docker inference mode, or on host for local/classic mode (if enabled)
 7. **Gap Analysis**: Analyze kernel bottlenecks within time window (if enabled)
 8. **Result Generation**: Aggregate metrics and generate reports
 

--- a/examples/benchmarks/benchmark_sqlang_amd_dsr1_fp4.yaml
+++ b/examples/benchmarks/benchmark_sqlang_amd_dsr1_fp4.yaml
@@ -21,32 +21,26 @@ benchmark:
     CONC: 64
     ISL: 1024
     OSL: 1024
-    RANDOM_RANGE_RATIO: 0.8
-    PROFILER_ENABLED: true
-    
+    RANDOM_RANGE_RATIO: 1
+    TL_EXTENSION: "TraceLens_NDA" # Optional: specify TraceLens extension to load
+  
   # Profiler configuration
   profiler:
     torch_profiler:
       enabled: true
     system_profiler:
       enabled: false
+    tracelens:
+      enabled: true
       
   gap_analysis:
     enabled: false
     find_kernel_sources: false
     top_k: 100
 
-  # Optional: auto-pick idle GPU(s) before launching. Enabled by default;
-  # uncomment to override (see docs/how-to/benchmark.md#automatic-gpu-selection).
-  # gpu_selection:
-  #   auto: true
-  #   min_free_memory_gb: 8.0
-  #   count: null              # null -> use envs.TP
-  #   candidates: [0, 1, 2, 3] # whitelist physical GPU ids (rocm-smi/nvidia-smi)
-
   # Will auto-clone InferenceX if not specified
   # inferencex_path: ""
-  # image: "lmsysorg/sglang:v0.5.12-rocm720-mi35x"
-  benchmark_script: "dsr1_fp4_mi355x.sh" 
+  # image: "image with TraceLens_NDA extension pre-installed" 
+  benchmark_script: "dsr1_fp4_mi355x.sh"
 
   timeout_seconds: 3600

--- a/examples/benchmarks/benchmark_vllm_tracelens.yaml
+++ b/examples/benchmarks/benchmark_vllm_tracelens.yaml
@@ -7,7 +7,7 @@
 #
 # Output:
 #   - Torch profiler traces: results/benchmark_vllm_<timestamp>/torch_trace/
-#   - TraceLens CSV reports: results/benchmark_vllm_<timestamp>/tracelens_rank0_csvs/
+#   - TraceLens CSV reports: results/benchmark_vllm_<timestamp>/tracelens/
 #
 # Note: 
 #   - num_prompts = CONC * 10 (hardcoded in script), so CONC=4 gives 40 prompts
@@ -48,6 +48,8 @@ benchmark:
       enabled: true               # Enable TraceLens analysis
       analysis_mode: inference    # Default: inference
       analysis_stages: all        # all | [prefilldecode, decode, prefill]
+      auto_patch_runtime: true    # Build TraceLens-ready Docker image if needed
+      # tracelens_repo_path: /path/to/TraceLens
       export_format: csv          # "csv" or "excel"
       perf_report_enabled: true   # Single-rank performance report
       multi_rank_report_enabled: true   # Multi-rank collective report

--- a/examples/benchmarks/benchmark_vllm_tracelens.yaml
+++ b/examples/benchmarks/benchmark_vllm_tracelens.yaml
@@ -41,10 +41,13 @@ benchmark:
       
     # TraceLens trace analysis - generates reports from torch traces
     # Commands:
-    #   - TraceLens_generate_perf_report_pytorch (single rank)
-    #   - TraceLens_generate_multi_rank_collective_report_pytorch (multi-rank)
+    #   - TraceLens_split_inference_trace
+    #   - TraceLens_generate_perf_report_pytorch_inference
+    # Set analysis_mode: pytorch for the legacy direct PyTorch report flow.
     tracelens:
       enabled: true               # Enable TraceLens analysis
+      analysis_mode: inference    # Default: inference
+      analysis_stages: all        # all | [prefilldecode, decode, prefill]
       export_format: csv          # "csv" or "excel"
       perf_report_enabled: true   # Single-rank performance report
       multi_rank_report_enabled: true   # Multi-rank collective report
@@ -52,4 +55,3 @@ benchmark:
       
   # Shorter timeout for minimal run
   timeout_seconds: 1200
-

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -1,6 +1,7 @@
 import csv
 import gzip
 import json
+import subprocess
 
 import pytest
 import yaml
@@ -386,6 +387,178 @@ def test_tracelens_inference_sglang_step_marker_fallback(tmp_path):
     assert any(event.get("name") == "inside_decode" for event in decode_events)
     assert any(event.get("name") == "decode_kernel" for event in decode_events)
     assert not any(event.get("name") == "outside" for event in decode_events)
+
+
+def test_tracelens_inference_analysis_runs_in_cpu_only_container(
+    tmp_path,
+    monkeypatch,
+):
+    workspace = tmp_path / "workspace"
+    torch_trace_dir = workspace / "torch_trace"
+    capture_dir = torch_trace_dir / "capture_traces"
+    capture_dir.mkdir(parents=True)
+
+    rank0_trace = torch_trace_dir / "rank0-TP-0.trace.json.gz"
+    with gzip.open(rank0_trace, "wt", encoding="utf-8") as handle:
+        json.dump({"traceEvents": []}, handle)
+    with gzip.open(
+        capture_dir / "bs_64_rank0.json.gz",
+        "wt",
+        encoding="utf-8",
+    ) as handle:
+        json.dump({"traceEvents": []}, handle)
+
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "sglang",
+            "model": "demo",
+            "run_mode": "docker",
+            "docker_image": "tracelens-sglang:0.5.12-mi355-fix",
+            "envs": {
+                "CONC": 64,
+                "OSL": 1024,
+                "RANDOM_RANGE_RATIO": 1,
+                "TL_EXTENSION": "TraceLens_NDA",
+            },
+            "profiler": {
+                "tracelens": {
+                    "enabled": True,
+                    "analysis_stages": ["decode"],
+                }
+            },
+        }
+    )
+    docker_cmds = []
+
+    def fake_run(cmd, **_kwargs):
+        docker_cmds.append(cmd)
+        bash_cmd = cmd[-1]
+        if "TraceLens_split_inference_trace" in bash_cmd:
+            split_dir = torch_trace_dir / "trace_split"
+            split_dir.mkdir(parents=True, exist_ok=True)
+            decode_trace = split_dir / "decode.trace.json.gz"
+            with gzip.open(decode_trace, "wt", encoding="utf-8") as handle:
+                json.dump({"traceEvents": []}, handle)
+            with (split_dir / "execution_details.csv").open(
+                "w",
+                newline="",
+                encoding="utf-8",
+            ) as handle:
+                writer = csv.DictWriter(
+                    handle,
+                    fieldnames=[
+                        "output_path",
+                        "num_steps",
+                        "phase_avg_bs",
+                        "phase_num_prefilldecode",
+                        "phase_num_decode",
+                        "phase_num_prefill",
+                    ],
+                )
+                writer.writeheader()
+                writer.writerow(
+                    {
+                        "output_path": (
+                            "/workspace/torch_trace/trace_split/"
+                            "decode.trace.json.gz"
+                        ),
+                        "num_steps": "1",
+                        "phase_avg_bs": "64",
+                        "phase_num_prefilldecode": "0",
+                        "phase_num_decode": "1",
+                        "phase_num_prefill": "0",
+                    }
+                )
+        elif "TraceLens_generate_perf_report_pytorch_inference" in bash_cmd:
+            out_dir = workspace / "tracelens" / "decode_only"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / "summary.csv").write_text(
+                "name,value\nok,1\n",
+                encoding="utf-8",
+            )
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_inference.subprocess.run",
+        fake_run,
+    )
+
+    result = TraceLensInferencePipeline(cfg).analyze_in_container(
+        torch_trace_dir=torch_trace_dir,
+        output_dir=workspace,
+        runner_type="mi355x",
+        docker_image=cfg.docker_image,
+        workspace=workspace,
+    )
+
+    assert result["errors"] == []
+    assert result["analysis_stages"] == ["decode"]
+    assert result["tl_extension"] == "TraceLens_NDA"
+    assert result["postprocess_runtime"]["mode"] == "docker"
+    assert str(workspace / "tracelens" / "decode_only" / "summary.csv") in result[
+        "output_files"
+    ]
+    assert len(docker_cmds) == 2
+    assert all(
+        cmd[:5] == ["docker", "run", "--rm", "--network", "none"]
+        for cmd in docker_cmds
+    )
+    assert all(
+        "--gpus" not in cmd and "--device=/dev/kfd" not in cmd
+        for cmd in docker_cmds
+    )
+    assert any("TL_EXTENSION=TraceLens_NDA" in cmd for cmd in docker_cmds)
+
+    rows = list(
+        csv.DictReader(
+            (torch_trace_dir / "trace_split" / "execution_details.csv").open()
+        )
+    )
+    assert rows[0]["output_path"] == str(
+        torch_trace_dir / "trace_split" / "decode.trace.json.gz"
+    )
+
+
+def test_benchmark_mode_uses_container_for_docker_tracelens_inference(tmp_path):
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "sglang",
+            "model": "demo",
+            "run_mode": "docker",
+            "docker_image": "tracelens-sglang:0.5.12-mi355-fix",
+            "profiler": {"tracelens": {"enabled": True}},
+        }
+    )
+    mode = BenchmarkMode(cfg)
+
+    class FakePipeline:
+        def analyze(self, **_kwargs):
+            raise AssertionError("host TraceLens analysis should not run")
+
+        def analyze_in_container(self, **kwargs):
+            return {
+                "enabled": True,
+                "analysis_mode": "inference",
+                "postprocess_runtime": {
+                    "mode": "docker",
+                    "image": kwargs["docker_image"],
+                },
+                "output_files": [],
+                "warnings": [],
+                "errors": [],
+            }
+
+    result = mode._run_tracelens_inference_analysis(
+        torch_trace_dir=tmp_path / "torch_trace",
+        workspace=tmp_path,
+        runner_type="mi355x",
+        pipeline=FakePipeline(),
+    )
+
+    assert result["postprocess_runtime"] == {
+        "mode": "docker",
+        "image": "tracelens-sglang:0.5.12-mi355-fix",
+    }
 
 
 def test_gap_analysis_config_validates_window():

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -17,10 +17,21 @@ from Magpie.modes.benchmark.config import (
 from Magpie.modes.benchmark.image_selector import ImageSelector
 from Magpie.modes.benchmark.result import BenchmarkResult, ResultParser
 from Magpie.modes.benchmark.tracelens_inference import (
+    SGLANG_SHAPE_DISCOVERY_FLAG,
     TraceLensInferencePipeline,
     append_flag_value_args,
     compute_steady_state_iters,
+    is_tracelens_patched_sglang_image,
     trace_arch_platform_from_runner,
+    uses_tracelens_nda_extension,
+)
+from Magpie.modes.benchmark.tracelens_runtime import (
+    derive_tracelens_image_tag,
+    infer_sglang_patch_version,
+    infer_vllm_patch_version,
+    is_tracelens_ready_runtime_image,
+    prepare_tracelens_runtime_image,
+    runner_type_to_gpu_type,
 )
 from Magpie.utils.gpu import GPUVendor
 
@@ -108,6 +119,7 @@ def test_tracelens_config_supports_legacy_export_flags():
     assert cfg.analysis_mode == "inference"
     assert cfg.analysis_stages == ["prefilldecode", "decode", "prefill"]
     assert cfg.cli_timeout_seconds == 1800
+    assert cfg.auto_patch_runtime is True
     assert cfg.export_format == "excel"
     assert cfg.export_excel is True
     assert cfg.export_csv is False
@@ -119,11 +131,13 @@ def test_tracelens_config_normalizes_inference_stages():
             "enabled": True,
             "analysis_stages": ["decode", "mixed", "prefill"],
             "cli_timeout_seconds": 2400,
+            "auto_patch_runtime": False,
         }
     )
 
     assert cfg.analysis_stages == ["decode", "prefilldecode", "prefill"]
     assert cfg.cli_timeout_seconds == 2400
+    assert cfg.auto_patch_runtime is False
 
     cfg = TraceLensConfig.from_dict(
         {"enabled": True, "analysis_mode": "classic", "analysis_stages": "all"}
@@ -152,6 +166,70 @@ def test_tracelens_inference_iteration_and_arg_helpers():
     assert envs["EXTRA_VLLM_ARGS"] == "--existing true --new-flag value"
     assert trace_arch_platform_from_runner("mi355x") == "MI355X"
     assert trace_arch_platform_from_runner("mi300") == "MI300X"
+    assert uses_tracelens_nda_extension("TraceLens_NDA")
+    assert not uses_tracelens_nda_extension("TraceLens_Public")
+    assert is_tracelens_patched_sglang_image("tracelens-sglang:0.5.12")
+    assert not is_tracelens_patched_sglang_image("lmsysorg/sglang:latest")
+
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "sglang",
+            "model": "demo",
+            "envs": {"TL_EXTENSION": "TraceLens_NDA"},
+        }
+    )
+    assert not TraceLensInferencePipeline(cfg)._should_enable_sglang_shape_discovery()
+
+
+def test_tracelens_runtime_image_helpers():
+    assert infer_sglang_patch_version("lmsysorg/sglang:v0.5.12-rocm720-mi35x") == "0.5.12"
+    assert infer_sglang_patch_version("lmsysorg/sglang:v0.5.8") is None
+    assert infer_vllm_patch_version("vllm/vllm-openai-rocm:v0.19.1") == "v19"
+    assert infer_vllm_patch_version("vllm/vllm-openai-rocm:v0.13.0") is None
+    assert runner_type_to_gpu_type("mi355x") == "mi355"
+    assert is_tracelens_ready_runtime_image("sglang", "tracelens-sglang:0.5.12")
+    assert not is_tracelens_ready_runtime_image("vllm", "lmsysorg/sglang:v0.5.12")
+
+    tag = derive_tracelens_image_tag(
+        "sglang",
+        "lmsysorg/sglang:v0.5.12-rocm720-mi35x",
+        "mi355x",
+        "0.5.12",
+    )
+    assert tag.startswith("magpie-tracelens-sglang:0_5_12-mi355x-")
+
+
+def test_prepare_tracelens_runtime_image_reuses_existing_derived_image(
+    tmp_path,
+    monkeypatch,
+):
+    tracelens_repo = tmp_path / "TraceLens"
+    workflow_dir = tracelens_repo / "examples/custom_workflows/inference_analysis"
+    workflow_dir.mkdir(parents=True)
+    monkeypatch.setenv("TRACELENS_REPO_PATH", str(tracelens_repo))
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.docker_image_exists",
+        lambda _image: True,
+    )
+
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "sglang",
+            "model": "demo",
+            "docker_image": "lmsysorg/sglang:v0.5.12-rocm720-mi35x",
+            "profiler": {"tracelens": {"enabled": True}},
+        }
+    )
+
+    result = prepare_tracelens_runtime_image(
+        cfg,
+        base_image=cfg.docker_image,
+        runner_type="mi355x",
+    )
+
+    assert result["built"] is False
+    assert result["reason"] == "derived image already exists"
+    assert result["image"].startswith("magpie-tracelens-sglang:0_5_12-mi355x-")
 
 
 def test_tracelens_inference_prepare_patches_and_restores(tmp_path):
@@ -202,10 +280,7 @@ def test_tracelens_inference_prepare_patches_and_restores(tmp_path):
     assert '"num_steps": 256' in patched_serving
     assert cfg.envs["SGLANG_PROFILE_WITH_STACK"] == "True"
     assert "--enable-profile-cuda-graph" in cfg.envs["EXTRA_SGLANG_ARGS"]
-    assert (
-        "--enable-shape-discovery-for-cuda-graph-profile"
-        not in cfg.envs["EXTRA_SGLANG_ARGS"]
-    )
+    assert SGLANG_SHAPE_DISCOVERY_FLAG not in cfg.envs["EXTRA_SGLANG_ARGS"]
 
     restore = pipeline.restore()
 
@@ -213,6 +288,48 @@ def test_tracelens_inference_prepare_patches_and_restores(tmp_path):
     assert str(benchmark_serving) in restore["restored_files"]
     assert 'num_prompts="$max_concurrency"' in benchmark_lib.read_text(encoding="utf-8")
     assert "roofline_annotations" not in benchmark_serving.read_text(encoding="utf-8")
+
+
+def test_tracelens_inference_prepare_enables_sglang_shape_discovery_for_patched_image(
+    tmp_path,
+):
+    inferencex = tmp_path / "InferenceX"
+    bench_dir = inferencex / "benchmarks"
+    serving_dir = inferencex / "utils" / "bench_serving"
+    bench_dir.mkdir(parents=True)
+    serving_dir.mkdir(parents=True)
+
+    (bench_dir / "benchmark_lib.sh").write_text(
+        'if [[ "${PROFILE:-}" == "1" ]]; then\n'
+        '    num_prompts="$max_concurrency"\n'
+        "fi\n",
+        encoding="utf-8",
+    )
+    (serving_dir / "benchmark_serving.py").write_text(
+        'extra_body={"num_steps": 1, "merge_profiles": True, '
+        '"profile_by_stage": True},\n',
+        encoding="utf-8",
+    )
+
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "sglang",
+            "model": "demo",
+            "docker_image": "tracelens-sglang:0.5.12-mi355-fix",
+            "inferencex_path": str(inferencex),
+            "envs": {
+                "CONC": 64,
+                "OSL": 1024,
+                "RANDOM_RANGE_RATIO": 1,
+            },
+            "profiler": {"tracelens": {"enabled": True}},
+        }
+    )
+
+    result = TraceLensInferencePipeline(cfg).prepare(tmp_path / "workspace")
+
+    assert SGLANG_SHAPE_DISCOVERY_FLAG in cfg.envs["EXTRA_SGLANG_ARGS"]
+    assert SGLANG_SHAPE_DISCOVERY_FLAG in result["env_updates"]["EXTRA_SGLANG_ARGS"]
 
 
 def test_tracelens_inference_sglang_step_marker_fallback(tmp_path):

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -274,6 +274,7 @@ def test_tracelens_inference_prepare_patches_and_restores(tmp_path):
     assert result["delay_iterations"] == 6016
     assert 'num_prompts="$num_prompts"' in benchmark_lib.read_text(encoding="utf-8")
     patched_serving = benchmark_serving.read_text(encoding="utf-8")
+    assert '"shape_discovery": True' in patched_serving
     assert '"roofline_annotations": True' in patched_serving
     assert '"start_step": 6016' in patched_serving
     assert '"num_steps": 256' in patched_serving

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -23,7 +23,6 @@ from Magpie.modes.benchmark.tracelens_inference import (
     compute_steady_state_iters,
     is_tracelens_patched_sglang_image,
     trace_arch_platform_from_runner,
-    uses_tracelens_nda_extension,
 )
 from Magpie.modes.benchmark.tracelens_runtime import (
     derive_tracelens_image_tag,
@@ -166,8 +165,6 @@ def test_tracelens_inference_iteration_and_arg_helpers():
     assert envs["EXTRA_VLLM_ARGS"] == "--existing true --new-flag value"
     assert trace_arch_platform_from_runner("mi355x") == "MI355X"
     assert trace_arch_platform_from_runner("mi300") == "MI300X"
-    assert uses_tracelens_nda_extension("TraceLens_NDA")
-    assert not uses_tracelens_nda_extension("TraceLens_Public")
     assert is_tracelens_patched_sglang_image("tracelens-sglang:0.5.12")
     assert not is_tracelens_patched_sglang_image("lmsysorg/sglang:latest")
 

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -1,3 +1,4 @@
+import csv
 import gzip
 import json
 
@@ -15,6 +16,12 @@ from Magpie.modes.benchmark.config import (
 )
 from Magpie.modes.benchmark.image_selector import ImageSelector
 from Magpie.modes.benchmark.result import BenchmarkResult, ResultParser
+from Magpie.modes.benchmark.tracelens_inference import (
+    TraceLensInferencePipeline,
+    append_flag_value_args,
+    compute_steady_state_iters,
+    trace_arch_platform_from_runner,
+)
 from Magpie.utils.gpu import GPUVendor
 
 
@@ -98,9 +105,172 @@ def test_tracelens_config_supports_legacy_export_flags():
     cfg = TraceLensConfig.from_dict({"enabled": True, "export_excel": True})
 
     assert cfg.enabled is True
+    assert cfg.analysis_mode == "inference"
+    assert cfg.analysis_stages == ["prefilldecode", "decode", "prefill"]
+    assert cfg.cli_timeout_seconds == 1800
     assert cfg.export_format == "excel"
     assert cfg.export_excel is True
     assert cfg.export_csv is False
+
+
+def test_tracelens_config_normalizes_inference_stages():
+    cfg = TraceLensConfig.from_dict(
+        {
+            "enabled": True,
+            "analysis_stages": ["decode", "mixed", "prefill"],
+            "cli_timeout_seconds": 2400,
+        }
+    )
+
+    assert cfg.analysis_stages == ["decode", "prefilldecode", "prefill"]
+    assert cfg.cli_timeout_seconds == 2400
+
+    cfg = TraceLensConfig.from_dict(
+        {"enabled": True, "analysis_mode": "classic", "analysis_stages": "all"}
+    )
+
+    assert cfg.analysis_mode == "pytorch"
+    assert cfg.analysis_stages == ["prefilldecode", "decode", "prefill"]
+
+
+def test_tracelens_inference_iteration_and_arg_helpers():
+    max_iters, delay_iters = compute_steady_state_iters(1024, 64, 1)
+
+    assert max_iters == 256
+    assert delay_iters == 6016
+
+    envs = {"EXTRA_VLLM_ARGS": "--existing true"}
+    append_flag_value_args(
+        envs,
+        "EXTRA_VLLM_ARGS",
+        [
+            ("--existing", "false"),
+            ("--new-flag", "value"),
+        ],
+    )
+
+    assert envs["EXTRA_VLLM_ARGS"] == "--existing true --new-flag value"
+    assert trace_arch_platform_from_runner("mi355x") == "MI355X"
+    assert trace_arch_platform_from_runner("mi300") == "MI300X"
+
+
+def test_tracelens_inference_prepare_patches_and_restores(tmp_path):
+    inferencex = tmp_path / "InferenceX"
+    bench_dir = inferencex / "benchmarks"
+    serving_dir = inferencex / "utils" / "bench_serving"
+    bench_dir.mkdir(parents=True)
+    serving_dir.mkdir(parents=True)
+
+    benchmark_lib = bench_dir / "benchmark_lib.sh"
+    benchmark_lib.write_text(
+        'if [[ "${PROFILE:-}" == "1" ]]; then\n'
+        '    num_prompts="$max_concurrency"\n'
+        "fi\n",
+        encoding="utf-8",
+    )
+
+    benchmark_serving = serving_dir / "benchmark_serving.py"
+    benchmark_serving.write_text(
+        'extra_body={"num_steps": 1, "merge_profiles": True, '
+        '"profile_by_stage": True},\n',
+        encoding="utf-8",
+    )
+
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "sglang",
+            "model": "demo",
+            "inferencex_path": str(inferencex),
+            "envs": {
+                "CONC": 64,
+                "OSL": 1024,
+                "RANDOM_RANGE_RATIO": 1,
+            },
+            "profiler": {"tracelens": {"enabled": True}},
+        }
+    )
+    pipeline = TraceLensInferencePipeline(cfg)
+
+    result = pipeline.prepare(tmp_path / "workspace")
+
+    assert result["max_iterations"] == 256
+    assert result["delay_iterations"] == 6016
+    assert 'num_prompts="$num_prompts"' in benchmark_lib.read_text(encoding="utf-8")
+    patched_serving = benchmark_serving.read_text(encoding="utf-8")
+    assert '"roofline_annotations": True' in patched_serving
+    assert '"start_step": 6016' in patched_serving
+    assert '"num_steps": 256' in patched_serving
+    assert cfg.envs["SGLANG_PROFILE_WITH_STACK"] == "True"
+    assert "--enable-profile-cuda-graph" in cfg.envs["EXTRA_SGLANG_ARGS"]
+    assert (
+        "--enable-shape-discovery-for-cuda-graph-profile"
+        not in cfg.envs["EXTRA_SGLANG_ARGS"]
+    )
+
+    restore = pipeline.restore()
+
+    assert str(benchmark_lib) in restore["restored_files"]
+    assert str(benchmark_serving) in restore["restored_files"]
+    assert 'num_prompts="$max_concurrency"' in benchmark_lib.read_text(encoding="utf-8")
+    assert "roofline_annotations" not in benchmark_serving.read_text(encoding="utf-8")
+
+
+def test_tracelens_inference_sglang_step_marker_fallback(tmp_path):
+    trace_path = tmp_path / "rank0.trace.json.gz"
+    trace = {
+        "traceEvents": [
+            {"ph": "M", "name": "process_name", "pid": 1, "args": {"name": "rank0"}},
+            {
+                "cat": "user_annotation",
+                "name": "step[DECODE bs=32]",
+                "ts": 100.0,
+                "dur": 10.0,
+            },
+            {
+                "cat": "user_annotation",
+                "name": "step[DECODE bs=64]",
+                "ts": 200.0,
+                "dur": 20.0,
+            },
+            {
+                "cat": "user_annotation",
+                "name": "step[EXTEND bs=4 toks=4096]",
+                "ts": 300.0,
+                "dur": 30.0,
+            },
+            {"cat": "cpu_op", "name": "inside_decode", "ts": 205.0, "dur": 2.0},
+            {"cat": "kernel", "name": "decode_kernel", "ts": 225.0, "dur": 5.0},
+            {"cat": "cpu_op", "name": "outside", "ts": 500.0, "dur": 2.0},
+        ]
+    }
+    with gzip.open(trace_path, "wt", encoding="utf-8") as handle:
+        json.dump(trace, handle)
+
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "sglang",
+            "model": "demo",
+            "envs": {"CONC": 64, "OSL": 1024},
+            "profiler": {"tracelens": {"enabled": True}},
+        }
+    )
+    pipeline = TraceLensInferencePipeline(cfg)
+    split_dir = tmp_path / "split"
+
+    warnings = pipeline._split_sglang_step_markers(trace_path, split_dir)
+
+    assert "wrote 2 trace window" in warnings[-1]
+    rows = list(csv.DictReader((split_dir / "execution_details.csv").open()))
+    assert {row["stage"] for row in rows} == {"decode", "prefill"}
+    assert {
+        row["phase_avg_bs"] for row in rows
+    } == {"64.0", "4.0"}
+    decode_trace = split_dir / "decode_only_step.trace.json.gz"
+    with gzip.open(decode_trace, "rt", encoding="utf-8") as handle:
+        decode_events = json.load(handle)["traceEvents"]
+    assert any(event.get("name") == "inside_decode" for event in decode_events)
+    assert any(event.get("name") == "decode_kernel" for event in decode_events)
+    assert not any(event.get("name") == "outside" for event in decode_events)
 
 
 def test_gap_analysis_config_validates_window():


### PR DESCRIPTION
## Summary

Add TraceLens inference integration for Magpie benchmark runs.

- Add Magpie-managed TraceLens inference preprocess/postprocess flow.
- Default TraceLens analysis mode to `inference`, with legacy `pytorch` still supported.
- Add `analysis_stages` support: `all`, `prefilldecode`, `prefill`, `decode`.
- Write inference analysis outputs under `tracelens/`.
- Use Magpie GPU architecture detection/mapping for TraceLens analysis.
- Add automatic TraceLens-ready Docker image preparation for supported SGLang/vLLM images when TraceLens is enabled.
- Treat `TL_EXTENSION` as a pure pass-through environment variable for TraceLens.
- Update docs, example config, and benchmark support tests.

## Usage

~~~yaml
benchmark:
  framework: sglang
  run_mode: docker
  docker_image: lmsysorg/sglang:v0.5.12-rocm720-mi35x

  envs:
    # TL_EXTENSION: "TraceLens_NDA"

  profiler:
    torch_profiler:
      enabled: true
    tracelens:
      enabled: true
      analysis_mode: inference       # optional, default: inference
      analysis_stages: all           # optional, default: all
      auto_patch_runtime: true       # optional, default: true for Docker runs
      # tracelens_repo_path: /path/to/TraceLens
      # cli_timeout_seconds: 2400    # optional, TraceLens postprocess timeout per command

  timeout_seconds: 7200              # benchmark/client timeout
~~~

`tracelens_repo_path` should point to a public TraceLens source checkout when Magpie needs to build a TraceLens-ready runtime image.

## Test

~~~bash
uv run --extra dev pytest tests/test_benchmark_support.py -q
~~~

Result: `38 passed`