### PR TITLE
[feature]: Add diffusion model support

### DIFF
--- a/Magpie/benchmark_images.yaml
+++ b/Magpie/benchmark_images.yaml
@@ -39,3 +39,11 @@ atom:
   # AMD GPUs
   gfx942: "rocm/atom:latest"
   gfx950: "rocm/atom:latest"
+
+# xDiT is an offline diffusion CLI run via run_cmd in local mode (no
+# InferenceX, no Magpie-launched server). Magpie does not pull these images
+# for the offline path; they are listed for reference / optional docker use.
+xdit:
+  # AMD GPUs
+  gfx942: "rocm/pytorch-xdit:v26.5"
+  gfx950: "rocm/pytorch-xdit:v26.5"

--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -12,6 +12,7 @@ Orchestrates benchmark execution using InferenceX as backend.
 import json
 import logging
 import os
+import shlex
 import signal
 import shutil
 import subprocess
@@ -102,7 +103,12 @@ class BenchmarkMode:
         # Ray mode: delegate to remote cluster and return when complete
         if self.config.is_ray:
             return self._execute_ray_benchmark()
-        
+
+        # Offline frameworks: run a verbatim CLI command, no server, no
+        # InferenceX. Entirely separate code path from the LLM serving flow.
+        if self.config.is_offline:
+            return self._run_offline_benchmark(start_time)
+
         # 0. Ensure InferenceX is available (auto-clone if needed)
         try:
             self.config.inferencex_path = ensure_inferencex_available(
@@ -326,6 +332,219 @@ class BenchmarkMode:
         
         return result
     
+    # ------------------------------------------------------------------
+    # Offline path — no server, no InferenceX, no benchmark_lib.sh
+    # ------------------------------------------------------------------
+    def _build_offline_command(self, workspace: Path) -> List[str]:
+        """Tokenize ``run_cmd`` and pin output/profile flags to the workspace.
+
+        The caller supplies the verbatim xDiT command. We always force
+        ``--output_directory`` to the workspace so we can find ``timings.json``
+        / the profile trace, and we add ``--profile`` when torch profiling is
+        enabled (stripping any user-supplied values for these so the
+        benchmarker's contract wins). Everything else is passed through
+        untouched.
+        """
+        tokens = shlex.split(self.config.run_cmd or "")
+        if not tokens:
+            raise ValueError("offline run_cmd is empty")
+
+        want_profile = bool(self.config.profiler.torch_profiler.enabled)
+
+        # Drop any user-supplied --output_directory / --profile (both
+        # "--flag value" and "--flag=value" forms) — Magpie owns these.
+        strip_with_value = {"--output_directory", "--output-directory"}
+        strip_flags = {"--profile"}
+        cleaned: List[str] = []
+        i = 0
+        while i < len(tokens):
+            tok = tokens[i]
+            key = tok.split("=", 1)[0]
+            if key in strip_with_value:
+                if "=" not in tok:
+                    i += 2  # skip flag + its value
+                    continue
+                i += 1
+                continue
+            if key in strip_flags:
+                i += 1
+                continue
+            cleaned.append(tok)
+            i += 1
+
+        # Append explore/variant flags supplied via EXTRA_XDIT_ARGS (e.g.
+        # --use_fbcache, --use_torch_compile). The verbatim run_cmd stays the
+        # baseline; per-variant flags are layered on via this env var.
+        extra_xdit_args = str((self.config.envs or {}).get("EXTRA_XDIT_ARGS", "")).strip()
+        if extra_xdit_args:
+            cleaned += shlex.split(extra_xdit_args)
+
+        cleaned += ["--output_directory", str(workspace)]
+        if want_profile:
+            cleaned.append("--profile")
+        return cleaned
+
+    def _run_offline_benchmark(self, start_time: float) -> BenchmarkResult:
+        """Run an offline diffusion CLI benchmark and parse timings.
+
+        No InferenceX, no server launch, no docker. Runs ``run_cmd`` with the
+        output directory pinned to the workspace, then parses ``timings.json``
+        and (if profiling) xDiT's ``profile_trace_rank_*.json.gz`` traces.
+        """
+        # Optionally pick idle GPU(s); honors the same gpu_selection knobs.
+        try:
+            self._apply_gpu_selection()
+        except RuntimeError as e:
+            result = BenchmarkResult()
+            result.success = False
+            result.errors.append(str(e))
+            return result
+
+        workspace = self.workspace_mgr.create(self.config.to_dict())
+
+        try:
+            cmd = self._build_offline_command(workspace)
+        except ValueError as e:
+            result = BenchmarkResult()
+            result.success = False
+            result.errors.append(f"Invalid offline run_cmd: {e}")
+            return result
+
+        # Build env: inherit current env + any config.envs (e.g. VISIBLE_DEVICES
+        # injected by gpu selection, HF_HOME, attention-backend toggles).
+        env = dict(os.environ)
+        for k, v in (self.config.envs or {}).items():
+            env[str(k)] = str(v)
+
+        gpu_monitor = None
+        gpu_monitor_stats = None
+        if self.config.profiler.gpu_monitor.enabled:
+            monitor_cfg = self.config.profiler.gpu_monitor
+            device_id = monitor_cfg.device_id
+            if device_id is None:
+                visible = (
+                    env.get("HIP_VISIBLE_DEVICES")
+                    or env.get("CUDA_VISIBLE_DEVICES")
+                    or env.get("ROCR_VISIBLE_DEVICES")
+                )
+                device_id = int(visible.split(",")[0]) if visible else 0
+            gpu_monitor = GPUMonitor(
+                device_id=device_id, interval_sec=monitor_cfg.interval_sec
+            )
+            if not gpu_monitor.start():
+                gpu_monitor = None
+
+        logger.info("Running offline benchmark (no server): %s", " ".join(cmd))
+        result, stdout, stderr = self._execute_local_benchmark(cmd, env, workspace)
+
+        if gpu_monitor is not None:
+            gpu_monitor_stats = gpu_monitor.stop()
+
+        result.workspace_dir = str(workspace)
+        result.execution_time = time.time() - start_time
+        result.framework = self.config.framework
+        result.model = self.config.model
+        result.profiling_enabled = self.config.profiler.torch_profiler.enabled
+        if gpu_monitor_stats is not None:
+            result.gpu_monitor = gpu_monitor_stats.to_dict()
+
+        profiling = self.config.profiler.torch_profiler.enabled
+
+        # xDiT writes profile_trace_rank_<N>.json.gz into the workspace root;
+        # rename into torch_trace/*.trace.json.gz so trace consumers (TraceLens
+        # and downstream trace discovery) see the same layout/glob as the LLM
+        # frameworks. The filename scheme is xDiT-specific; result shaping below
+        # is shared with any other diffusion engine.
+        if profiling:
+            trace_dir = workspace / "torch_trace"
+            trace_dir.mkdir(exist_ok=True)
+            for src in sorted(workspace.glob("profile_trace_rank_*.json.gz")):
+                rank = src.name[: -len(".json.gz")].replace(
+                    "profile_trace_rank_", ""
+                )
+                shutil.move(str(src), str(trace_dir / f"rank_{rank}.trace.json.gz"))
+
+        self._finalize_diffusion_result(
+            result, workspace, stderr, profiling=profiling
+        )
+
+        self.workspace_mgr.save_report(result.to_dict())
+        self.workspace_mgr.save_summary(result.get_summary())
+        logger.info(f"Offline benchmark completed in {result.execution_time:.2f}s")
+        return result
+
+    def _finalize_diffusion_result(
+        self,
+        result: BenchmarkResult,
+        workspace: Path,
+        stderr: str,
+        *,
+        profiling: bool,
+    ) -> None:
+        """Shape a diffusion benchmark result from workspace artifacts.
+
+        Reads ``timings.json`` for per-image latency / throughput and consumes
+        any normalized ``torch_trace/*.trace.json.gz`` profile traces, mutating
+        ``result`` in place. Trace files are assumed already normalized to that
+        layout by the caller (the filename scheme is engine-specific).
+
+        Two output contracts depend on the pass:
+          - normal run -> timings.json (per-iteration seconds), no trace
+          - profiling  -> trace files, no timings.json (the profile pass
+            returns an empty timings list by design)
+        So under profiling, success hinges on the trace, not timings.json.
+        """
+        # Parse timings.json -> diffusion metrics (the non-profile contract).
+        timings_file = workspace / "timings.json"
+        if timings_file.exists():
+            parsed = ResultParser.parse_diffusion_result(
+                timings_file,
+                framework=self.config.framework,
+                model=self.config.model,
+                run_cmd=self.config.run_cmd or "",
+            )
+            result.throughput = parsed.throughput
+            result.latency = parsed.latency
+            result.raw_result = parsed.raw_result
+            if parsed.errors:
+                result.errors.extend(parsed.errors)
+        elif not profiling:
+            result.success = False
+            result.errors.append(
+                "timings.json not found - benchmark may have failed"
+            )
+            if stderr:
+                result.errors.append(f"stderr (last 500 chars): {stderr[-500:]}")
+
+        # Consume normalized profile traces (torch_trace/*.trace.json.gz).
+        if profiling:
+            trace_dir = workspace / "torch_trace"
+            normalized = sorted(trace_dir.glob("*.trace.json.gz"))
+            if not normalized:
+                # Profiling pass with no trace == failure.
+                result.success = False
+                result.errors.append(
+                    "No profile trace files found - profiling run may have failed"
+                )
+                if stderr:
+                    result.errors.append(f"stderr (last 500 chars): {stderr[-500:]}")
+            else:
+                kernels = ResultParser.parse_torch_trace(trace_dir)
+                result.kernel_summary = kernels
+                result.top_bottlenecks = [k.name for k in kernels[:10]]
+                if self.config.profiler.tracelens.enabled:
+                    result.tracelens_analysis = self._run_tracelens_analysis(
+                        trace_dir, workspace
+                    )
+                if self.config.gap_analysis.enabled:
+                    result.gap_analysis = self._run_gap_analysis(trace_dir, workspace)
+
+        # Validate latency metrics only for the non-profile contract (profiling
+        # runs legitimately have no throughput/latency, just a trace).
+        if not profiling and result.success and not self._validate_results(result):
+            result.success = False
+            result.errors.append("Benchmark produced no valid latency metrics")
+
     def _apply_gpu_selection(self) -> None:
         """Resolve idle GPU(s) and inject the selection into config.envs.
 

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -18,6 +18,40 @@ class BenchmarkFramework(Enum):
     VLLM = "vllm"
     SGLANG = "sglang"
     ATOM = "atom"
+    XDIT = "xdit"
+
+
+@dataclass(frozen=True)
+class FrameworkSpec:
+    """Three orthogonal facts about a framework, kept separate on purpose.
+
+    These axes are independent — gating on one as a proxy for another breaks as
+    soon as a framework mixes them differently, so call sites read whichever
+    axis names their decision:
+
+    serving:  "online"  -> exposes an inference server
+              "offline" -> no server; a self-contained batch job
+    launch:   "script"  -> Magpie builds the command via InferenceX
+              "command" -> a verbatim ``run_cmd`` is run as-is
+    modality: "text"     -> LLM decode loop, tok/s result shape
+              "diffusion"-> image/video generation, images-per-sec result shape
+    """
+
+    serving: str = "online"
+    launch: str = "script"
+    modality: str = "text"
+
+
+_FRAMEWORK_SPECS: Dict[str, FrameworkSpec] = {
+    "vllm": FrameworkSpec(serving="online", launch="script", modality="text"),
+    "sglang": FrameworkSpec(serving="online", launch="script", modality="text"),
+    "atom": FrameworkSpec(serving="online", launch="script", modality="text"),
+    "xdit": FrameworkSpec(serving="offline", launch="command", modality="diffusion"),
+}
+
+_DEFAULT_FRAMEWORK_SPEC = FrameworkSpec()
+
+SUPPORTED_FRAMEWORKS = tuple(_FRAMEWORK_SPECS)
 
 
 class BenchmarkRunMode(Enum):
@@ -583,6 +617,12 @@ class BenchmarkConfig:
     # InferenceX specific
     runner_type: Optional[str] = None
     benchmark_script: Optional[str] = None
+
+    # Offline frameworks: verbatim command to run as the benchmark.
+    # Magpie appends --output_directory=<workspace> (and --profile for the
+    # profiling pass) and parses timings.json from that workspace. No server,
+    # no InferenceX.
+    run_cmd: Optional[str] = None
     
     # GPU auto-selection (skip cards with running processes / low free VRAM)
     gpu_selection: GpuSelectionConfig = field(default_factory=GpuSelectionConfig)
@@ -597,20 +637,32 @@ class BenchmarkConfig:
         """Validate and set defaults."""
         # Normalize framework name
         self.framework = self.framework.lower()
-        if self.framework not in ["vllm", "sglang", "atom"]:
+        if self.framework not in SUPPORTED_FRAMEWORKS:
             raise ValueError(
-                f"Unsupported framework: {self.framework}. Use 'vllm', 'sglang', or 'atom'."
+                f"Unsupported framework: {self.framework}. "
+                f"Use one of: {', '.join(SUPPORTED_FRAMEWORKS)}."
             )
 
-        # Validate run_mode
+        # Normalize run_mode early; command-launched frameworks default
+        # docker -> local.
         self.run_mode = self.run_mode.lower()
+
+        if self.is_command_launched:
+            if not self.run_cmd:
+                raise ValueError(
+                    f"Framework '{self.framework}' is command-launched and "
+                    "requires 'run_cmd' (the verbatim command to benchmark)."
+                )
+            if self.run_mode == "docker":
+                self.run_mode = "local"
+
+        # Validate run_mode
         if self.run_mode not in ("docker", "local", "ray"):
             raise ValueError(
                 f"Unsupported run_mode: {self.run_mode}. Use 'docker', 'local', or 'ray'."
             )
 
-        # Set default envs if not provided
-        if not self.envs:
+        if not self.envs and not self.is_diffusion:
             self.envs = {
                 "TP": 1,
                 "CONC": 32,
@@ -700,6 +752,26 @@ class BenchmarkConfig:
         return f"generic_{self.precision}_{runner}.sh"
 
     @property
+    def spec(self) -> FrameworkSpec:
+        """Capabilities for this framework (LLM default if unlisted)."""
+        return _FRAMEWORK_SPECS.get(self.framework, _DEFAULT_FRAMEWORK_SPEC)
+
+    @property
+    def is_offline(self) -> bool:
+        """Framework exposes no inference server."""
+        return self.spec.serving == "offline"
+
+    @property
+    def is_command_launched(self) -> bool:
+        """Run a verbatim ``run_cmd`` instead of an InferenceX-built script."""
+        return self.spec.launch == "command"
+
+    @property
+    def is_diffusion(self) -> bool:
+        """Media-generation framework: images-per-sec result shape, no LLM envs."""
+        return self.spec.modality == "diffusion"
+
+    @property
     def is_local(self) -> bool:
         """Check if running in local mode (no Docker)."""
         return self.run_mode == "local"
@@ -731,6 +803,7 @@ class BenchmarkConfig:
             "hf_cache_path": self.hf_cache_path,
             "runner_type": self.runner_type,
             "benchmark_script": self.benchmark_script,
+            "run_cmd": self.run_cmd,
             "gpu_selection": self.gpu_selection.to_dict(),
         }
         if self.ray_config is not None:
@@ -792,6 +865,7 @@ class BenchmarkConfig:
             hf_cache_path=data.get("hf_cache_path"),
             runner_type=data.get("runner_type"),
             benchmark_script=data.get("benchmark_script"),
+            run_cmd=data.get("run_cmd"),
             gpu_selection=GpuSelectionConfig.from_dict(data.get("gpu_selection") or {}),
             ray_config=ray_config,
             server_lifecycle=server_lifecycle,

--- a/Magpie/modes/benchmark/result.py
+++ b/Magpie/modes/benchmark/result.py
@@ -12,6 +12,7 @@ Parses and structures benchmark results from InferenceX output.
 import gzip
 import json
 import logging
+import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -175,6 +176,9 @@ class BenchmarkResult:
             "execution_time": self.execution_time,
             "profiling_enabled": self.profiling_enabled,
             "errors": self.errors,
+            # Backend-native detail (e.g. diffusion latency_per_image_s /
+            # images_per_sec / steps_per_sec for the offline xdit path).
+            "raw_result": self.raw_result,
         }
     
     def get_summary(self) -> str:
@@ -365,6 +369,145 @@ class ResultParser:
         
         return result
     
+    @staticmethod
+    def _arg_value_from_cmd(cmd: str, *names: str) -> Optional[str]:
+        """Return the value of the first matching CLI flag in ``cmd``.
+
+        Handles both ``--flag value`` and ``--flag=value`` forms and the
+        dash/underscore aliasing xDiT allows (e.g. --batch-size == --batch_size).
+        """
+        try:
+            tokens = shlex.split(cmd or "")
+        except ValueError:
+            return None
+        wanted = set()
+        for n in names:
+            wanted.add(n)
+            wanted.add(n.replace("_", "-"))
+            wanted.add(n.replace("-", "_"))
+        i = 0
+        while i < len(tokens):
+            tok = tokens[i]
+            key = tok.split("=", 1)[0]
+            if key in wanted:
+                if "=" in tok:
+                    return tok.split("=", 1)[1]
+                if i + 1 < len(tokens):
+                    return tokens[i + 1]
+                return None
+            i += 1
+        return None
+
+    @staticmethod
+    def parse_diffusion_result(
+        timings_file: Path,
+        framework: str = "",
+        model: str = "",
+        run_cmd: str = "",
+    ) -> BenchmarkResult:
+        """Parse an offline diffusion run (xDiT ``timings.json``).
+
+        ``timings.json`` is a JSON list of per-iteration wall times in seconds
+        (xDiT already drops the first iteration when there is more than one).
+        We derive:
+          - latency_per_image (s) = mean(timings) / batch_size
+          - images_per_sec        = batch_size / mean(timings)
+          - steps_per_sec         = num_inference_steps / mean(timings)
+
+        Diffusion-native metrics live in ``raw_result``. For compatibility with
+        the existing throughput/latency validators and downstream consumers, we
+        also map: latency.e2el_mean = mean iteration time in ms, and
+        throughput.request_throughput = images_per_sec.
+        """
+        result = BenchmarkResult(framework=framework, model=model)
+
+        if not timings_file.exists():
+            result.errors.append(f"Timings file not found: {timings_file}")
+            return result
+
+        try:
+            with open(timings_file, "r") as f:
+                timings = json.load(f)
+        except json.JSONDecodeError as e:
+            result.errors.append(f"Failed to parse timings.json: {e}")
+            return result
+        except Exception as e:
+            result.errors.append(f"Failed to read timings.json: {e}")
+            return result
+
+        timings = [float(t) for t in (timings or []) if isinstance(t, (int, float))]
+        if not timings:
+            result.errors.append("timings.json contained no numeric timings")
+            return result
+
+        batch_size = 1
+        bs_raw = ResultParser._arg_value_from_cmd(run_cmd, "--batch_size")
+        if bs_raw:
+            try:
+                batch_size = max(1, int(bs_raw))
+            except ValueError:
+                pass
+
+        steps = None
+        steps_raw = ResultParser._arg_value_from_cmd(run_cmd, "--num_inference_steps")
+        if steps_raw:
+            try:
+                steps = int(steps_raw)
+            except ValueError:
+                pass
+
+        n = len(timings)
+        mean_s = sum(timings) / n
+        sorted_t = sorted(timings)
+        median_s = sorted_t[n // 2] if n % 2 else (sorted_t[n // 2 - 1] + sorted_t[n // 2]) / 2
+        p99_s = sorted_t[min(n - 1, int(round(0.99 * (n - 1))))]
+        var = sum((t - mean_s) ** 2 for t in timings) / n
+        std_s = var ** 0.5
+
+        latency_per_image_s = mean_s / batch_size if batch_size else mean_s
+        images_per_sec = (batch_size / mean_s) if mean_s > 0 else 0.0
+        steps_per_sec = (steps / mean_s) if (steps and mean_s > 0) else 0.0
+
+        result.raw_result = {
+            "timings_s": timings,
+            "iterations": n,
+            "batch_size": batch_size,
+            "num_inference_steps": steps,
+            "mean_iteration_s": mean_s,
+            "median_iteration_s": median_s,
+            "p99_iteration_s": p99_s,
+            "std_iteration_s": std_s,
+            "latency_per_image_s": latency_per_image_s,
+            "images_per_sec": images_per_sec,
+            "steps_per_sec": steps_per_sec,
+        }
+
+        # Map onto the generic schema so existing validators/consumers work.
+        # output_throughput carries images/sec (the higher-is-better metric the
+        # gain/objective machinery ranks on — the reciprocal of per-image
+        # latency); request_throughput mirrors it; e2el latency carries the
+        # per-iteration wall time in ms.
+        result.throughput = ThroughputMetrics(
+            request_throughput=images_per_sec,
+            output_throughput=images_per_sec,
+            completed_requests=n * batch_size,
+            duration_seconds=sum(timings),
+        )
+        result.latency = LatencyMetrics(
+            e2el_mean=mean_s * 1000.0,
+            e2el_median=median_s * 1000.0,
+            e2el_p99=p99_s * 1000.0,
+            e2el_std=std_s * 1000.0,
+        )
+        result.success = True
+        logger.info(
+            "Parsed diffusion result: %.3fs/img, %.3f img/s over %d iters",
+            latency_per_image_s,
+            images_per_sec,
+            n,
+        )
+        return result
+
     @staticmethod
     def parse_torch_trace(trace_dir: Path) -> List[KernelMetrics]:
         """

--- a/tests/test_xdit_offline.py
+++ b/tests/test_xdit_offline.py
@@ -1,0 +1,420 @@
+"""Unit tests for the offline diffusion (xDiT) benchmark path.
+
+Covers the InferenceX-free offline runner added for xDiT:
+  - BenchmarkConfig offline validation / defaults / round-trip
+  - ResultParser.parse_diffusion_result (timings.json -> diffusion metrics)
+  - BenchmarkMode._build_offline_command (output_directory/profile injection)
+  - benchmark_images.yaml xdit entry
+"""
+
+import json
+
+import pytest
+import yaml
+
+from Magpie.modes.benchmark.benchmarker import BenchmarkMode
+from Magpie.modes.benchmark.config import (
+    SUPPORTED_FRAMEWORKS,
+    BenchmarkConfig,
+    BenchmarkFramework,
+    ProfilerConfig,
+    TorchProfilerConfig,
+)
+from Magpie.modes.benchmark.result import ResultParser
+
+
+# --------------------------------------------------------------------------- #
+# BenchmarkConfig — offline framework handling
+# --------------------------------------------------------------------------- #
+class TestOfflineBenchmarkConfig:
+    def test_xdit_is_registered_framework(self):
+        assert BenchmarkFramework.XDIT.value == "xdit"
+        assert "xdit" in SUPPORTED_FRAMEWORKS
+
+    def test_xdit_requires_run_cmd(self):
+        with pytest.raises(ValueError, match="run_cmd"):
+            BenchmarkConfig(framework="xdit", model="flux")
+
+    def test_xdit_minimal_valid_config(self):
+        cfg = BenchmarkConfig(
+            framework="xdit", model="flux", run_cmd="xdit --model flux"
+        )
+        assert cfg.is_offline is True
+        assert cfg.is_command_launched is True
+        assert cfg.is_diffusion is True
+        assert cfg.framework == "xdit"
+        assert cfg.run_cmd == "xdit --model flux"
+
+    def test_llm_framework_axes_are_defaults(self):
+        cfg = BenchmarkConfig(framework="sglang", model="demo")
+        assert cfg.is_offline is False
+        assert cfg.is_command_launched is False
+        assert cfg.is_diffusion is False
+
+    def test_xdit_docker_run_mode_downgraded_to_local(self):
+        cfg = BenchmarkConfig(
+            framework="xdit",
+            model="flux",
+            run_cmd="xdit --model flux",
+            run_mode="docker",
+        )
+        assert cfg.run_mode == "local"
+
+    def test_xdit_does_not_inject_llm_env_defaults(self):
+        cfg = BenchmarkConfig(
+            framework="xdit", model="flux", run_cmd="xdit --model flux"
+        )
+        # No TP/CONC/ISL/OSL — those are LLM serving knobs.
+        assert cfg.envs == {}
+
+    def test_online_framework_still_gets_llm_env_defaults(self):
+        cfg = BenchmarkConfig(framework="sglang", model="demo")
+        assert cfg.is_offline is False
+        assert cfg.envs["TP"] == 1
+        assert cfg.envs["CONC"] == 32
+
+    def test_xdit_name_is_case_insensitive(self):
+        cfg = BenchmarkConfig(
+            framework="XDIT", model="flux", run_cmd="xdit --model flux"
+        )
+        assert cfg.framework == "xdit"
+
+    def test_unknown_framework_still_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported framework"):
+            BenchmarkConfig(framework="nope", model="demo")
+
+    def test_to_dict_and_from_dict_roundtrip_run_cmd(self):
+        cfg = BenchmarkConfig(
+            framework="xdit",
+            model="flux",
+            run_cmd="xdit --model flux --ulysses_degree 2",
+        )
+        d = cfg.to_dict()
+        assert d["run_cmd"] == "xdit --model flux --ulysses_degree 2"
+        restored = BenchmarkConfig.from_dict(d)
+        assert restored.run_cmd == cfg.run_cmd
+        assert restored.is_offline is True
+
+    def test_from_dict_offline_without_run_cmd_raises(self):
+        with pytest.raises(ValueError, match="run_cmd"):
+            BenchmarkConfig.from_dict({"framework": "xdit", "model": "flux"})
+
+
+# --------------------------------------------------------------------------- #
+# ResultParser.parse_diffusion_result
+# --------------------------------------------------------------------------- #
+class TestParseDiffusionResult:
+    def _write_timings(self, tmp_path, timings):
+        f = tmp_path / "timings.json"
+        f.write_text(json.dumps(timings), encoding="utf-8")
+        return f
+
+    def test_missing_file_returns_failure(self, tmp_path):
+        result = ResultParser.parse_diffusion_result(tmp_path / "missing.json")
+        assert result.success is False
+        assert result.errors
+
+    def test_empty_timings_returns_failure(self, tmp_path):
+        f = self._write_timings(tmp_path, [])
+        result = ResultParser.parse_diffusion_result(f)
+        assert result.success is False
+        assert result.errors
+
+    def test_malformed_json_returns_failure(self, tmp_path):
+        f = tmp_path / "timings.json"
+        f.write_text("{not json", encoding="utf-8")
+        result = ResultParser.parse_diffusion_result(f)
+        assert result.success is False
+        assert result.errors
+
+    def test_single_timing_no_batch(self, tmp_path):
+        f = self._write_timings(tmp_path, [2.0])
+        result = ResultParser.parse_diffusion_result(
+            f, framework="xdit", model="flux", run_cmd="xdit --model flux"
+        )
+        assert result.success is True
+        # latency/image = mean = 2.0s; images/sec = 1/2 = 0.5
+        assert result.raw_result["latency_per_image_s"] == pytest.approx(2.0)
+        assert result.raw_result["images_per_sec"] == pytest.approx(0.5)
+        assert result.raw_result["batch_size"] == 1
+
+    def test_batch_size_parsed_from_run_cmd(self, tmp_path):
+        f = self._write_timings(tmp_path, [2.0])
+        result = ResultParser.parse_diffusion_result(
+            f, run_cmd="xdit --model flux --batch_size 4"
+        )
+        assert result.raw_result["batch_size"] == 4
+        # latency/image = mean/batch = 2.0/4 = 0.5; images/sec = 4/2 = 2.0
+        assert result.raw_result["latency_per_image_s"] == pytest.approx(0.5)
+        assert result.raw_result["images_per_sec"] == pytest.approx(2.0)
+
+    def test_batch_size_dash_alias(self, tmp_path):
+        f = self._write_timings(tmp_path, [1.0])
+        result = ResultParser.parse_diffusion_result(
+            f, run_cmd="xdit --batch-size 2 --model flux"
+        )
+        assert result.raw_result["batch_size"] == 2
+
+    def test_steps_per_sec_from_num_inference_steps(self, tmp_path):
+        f = self._write_timings(tmp_path, [2.0])
+        result = ResultParser.parse_diffusion_result(
+            f, run_cmd="xdit --model flux --num_inference_steps 50"
+        )
+        # steps/sec = 50 / mean(2.0) = 25
+        assert result.raw_result["steps_per_sec"] == pytest.approx(25.0)
+        assert result.raw_result["num_inference_steps"] == 50
+
+    def test_steps_per_sec_zero_when_steps_absent(self, tmp_path):
+        f = self._write_timings(tmp_path, [2.0])
+        result = ResultParser.parse_diffusion_result(f, run_cmd="xdit --model flux")
+        assert result.raw_result["steps_per_sec"] == 0.0
+        assert result.raw_result["num_inference_steps"] is None
+
+    def test_images_per_sec_mapped_onto_output_throughput(self, tmp_path):
+        """The gain/objective machinery ranks on output_throughput; for xDiT
+        that must carry images/sec (higher = better)."""
+        f = self._write_timings(tmp_path, [2.0])
+        result = ResultParser.parse_diffusion_result(
+            f, run_cmd="xdit --model flux --batch_size 2"
+        )
+        assert result.throughput.output_throughput == pytest.approx(1.0)
+        assert result.throughput.request_throughput == pytest.approx(1.0)
+
+    def test_latency_mapped_onto_e2el_ms(self, tmp_path):
+        f = self._write_timings(tmp_path, [1.0, 1.0])
+        result = ResultParser.parse_diffusion_result(f, run_cmd="xdit --model flux")
+        # mean iteration = 1.0s -> 1000 ms on e2el_mean
+        assert result.latency.e2el_mean == pytest.approx(1000.0)
+
+    def test_does_not_double_drop_first_iteration(self, tmp_path):
+        """xDiT already drops the first iteration in timings.json; the parser
+        must average ALL entries it receives (no second drop)."""
+        f = self._write_timings(tmp_path, [1.0, 3.0])
+        result = ResultParser.parse_diffusion_result(f, run_cmd="xdit --model flux")
+        assert result.raw_result["iterations"] == 2
+        assert result.raw_result["mean_iteration_s"] == pytest.approx(2.0)
+
+    def test_non_numeric_entries_filtered(self, tmp_path):
+        f = self._write_timings(tmp_path, [1.0, "bad", 3.0, None])
+        result = ResultParser.parse_diffusion_result(f, run_cmd="xdit --model flux")
+        assert result.success is True
+        assert result.raw_result["iterations"] == 2
+
+    def test_invalid_batch_size_falls_back_to_one(self, tmp_path):
+        f = self._write_timings(tmp_path, [2.0])
+        result = ResultParser.parse_diffusion_result(
+            f, run_cmd="xdit --batch_size notanint --model flux"
+        )
+        assert result.raw_result["batch_size"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# BenchmarkMode._build_offline_command
+# --------------------------------------------------------------------------- #
+class TestBuildOfflineCommand:
+    def _mode(self, run_cmd, profile=False):
+        cfg = BenchmarkConfig(
+            framework="xdit",
+            model="flux",
+            run_cmd=run_cmd,
+            run_mode="local",
+            profiler=ProfilerConfig(
+                torch_profiler=TorchProfilerConfig(enabled=profile)
+            ),
+        )
+        return BenchmarkMode(config=cfg, output_dir="/tmp")
+
+    def test_injects_output_directory(self, tmp_path):
+        mode = self._mode("xdit --model flux --ulysses_degree 2")
+        cmd = mode._build_offline_command(tmp_path)
+        assert cmd[-2:] == ["--output_directory", str(tmp_path)]
+        assert "xdit" in cmd and "--ulysses_degree" in cmd
+
+    def test_strips_user_output_directory_space_form(self, tmp_path):
+        mode = self._mode("xdit --model flux --output_directory /user/dir")
+        cmd = mode._build_offline_command(tmp_path)
+        assert "/user/dir" not in cmd
+        assert cmd.count("--output_directory") == 1
+        assert cmd[-1] == str(tmp_path)
+
+    def test_strips_user_output_directory_equals_form(self, tmp_path):
+        mode = self._mode("xdit --model flux --output_directory=/user/dir")
+        cmd = mode._build_offline_command(tmp_path)
+        assert "/user/dir" not in cmd
+        assert "--output_directory=/user/dir" not in cmd
+        assert cmd.count("--output_directory") == 1
+
+    def test_strips_user_output_directory_dash_alias(self, tmp_path):
+        mode = self._mode("xdit --model flux --output-directory /user/dir")
+        cmd = mode._build_offline_command(tmp_path)
+        assert "/user/dir" not in cmd
+
+    def test_profile_off_omits_profile_flag(self, tmp_path):
+        mode = self._mode("xdit --model flux", profile=False)
+        cmd = mode._build_offline_command(tmp_path)
+        assert "--profile" not in cmd
+
+    def test_profile_on_adds_profile_flag(self, tmp_path):
+        mode = self._mode("xdit --model flux", profile=True)
+        cmd = mode._build_offline_command(tmp_path)
+        assert "--profile" in cmd
+
+    def test_profile_on_strips_user_profile_then_readds(self, tmp_path):
+        mode = self._mode("xdit --model flux --profile", profile=True)
+        cmd = mode._build_offline_command(tmp_path)
+        assert cmd.count("--profile") == 1
+
+    def test_profile_off_strips_user_profile(self, tmp_path):
+        mode = self._mode("xdit --model flux --profile", profile=False)
+        cmd = mode._build_offline_command(tmp_path)
+        assert "--profile" not in cmd
+
+    def test_preserves_quoted_prompt(self, tmp_path):
+        mode = self._mode('xdit --model flux --prompt "a cat sitting"')
+        cmd = mode._build_offline_command(tmp_path)
+        assert "a cat sitting" in cmd
+
+    def test_empty_run_cmd_raises(self, tmp_path):
+        mode = self._mode("xdit --model flux")
+        mode.config.run_cmd = "   "
+        with pytest.raises(ValueError, match="empty"):
+            mode._build_offline_command(tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# Full offline run() — InferenceX-free path (subprocess mocked)
+# --------------------------------------------------------------------------- #
+class TestOfflineRunEndToEnd:
+    def _make_mode(self, tmp_path, run_cmd, profile=False):
+        from Magpie.modes.benchmark.config import GpuSelectionConfig
+
+        cfg = BenchmarkConfig(
+            framework="xdit",
+            model="flux",
+            run_cmd=run_cmd,
+            run_mode="local",
+            profiler=ProfilerConfig(
+                torch_profiler=TorchProfilerConfig(enabled=profile)
+            ),
+            gpu_selection=GpuSelectionConfig(auto=False),
+        )
+        return BenchmarkMode(config=cfg, output_dir=str(tmp_path / "results"))
+
+    def _patch_subprocess_to_emit_timings(self, monkeypatch, timings, capture):
+        """Patch subprocess.run so the 'benchmark' writes timings.json into the
+        workspace passed via --output_directory, then reports success."""
+        import subprocess
+
+        def fake_run(cmd, *args, **kwargs):
+            capture["cmd"] = cmd
+            # Resolve --output_directory from the command.
+            out_dir = None
+            for i, tok in enumerate(cmd):
+                if tok == "--output_directory" and i + 1 < len(cmd):
+                    out_dir = cmd[i + 1]
+            assert out_dir is not None, "output_directory not injected"
+            from pathlib import Path
+
+            (Path(out_dir) / "timings.json").write_text(
+                json.dumps(timings), encoding="utf-8"
+            )
+
+            class _CP:
+                returncode = 0
+                stdout = "ok"
+                stderr = ""
+
+            return _CP()
+
+        monkeypatch.setattr(
+            "Magpie.modes.benchmark.benchmarker.subprocess.run", fake_run
+        )
+
+    def test_offline_run_never_touches_inferencex(self, tmp_path, monkeypatch):
+        """The whole point: offline run must NOT call ensure_inferencex_available."""
+        called = {"inferencex": False}
+
+        def boom(*a, **k):
+            called["inferencex"] = True
+            raise AssertionError("ensure_inferencex_available must not be called")
+
+        monkeypatch.setattr(
+            "Magpie.modes.benchmark.benchmarker.ensure_inferencex_available",
+            boom,
+        )
+        capture = {}
+        self._patch_subprocess_to_emit_timings(monkeypatch, [1.0, 1.0], capture)
+
+        mode = self._make_mode(tmp_path, "xdit --model flux --batch_size 1")
+        result = mode.run()
+
+        assert called["inferencex"] is False
+        assert result.success is True
+
+    def test_offline_run_parses_timings_into_result(self, tmp_path, monkeypatch):
+        capture = {}
+        self._patch_subprocess_to_emit_timings(
+            monkeypatch, [2.0, 2.0], capture
+        )
+        mode = self._make_mode(
+            tmp_path, "xdit --model flux --batch_size 1 --num_inference_steps 10"
+        )
+        result = mode.run()
+
+        assert result.success is True
+        assert result.framework == "xdit"
+        assert result.throughput.output_throughput == pytest.approx(0.5)
+        assert result.raw_result["latency_per_image_s"] == pytest.approx(2.0)
+        assert result.raw_result["steps_per_sec"] == pytest.approx(5.0)
+
+    def test_offline_run_missing_timings_marks_failure(
+        self, tmp_path, monkeypatch
+    ):
+        import subprocess
+
+        def fake_run(cmd, *args, **kwargs):
+            class _CP:
+                returncode = 0
+                stdout = ""
+                stderr = "boom"
+
+            return _CP()
+
+        monkeypatch.setattr(
+            "Magpie.modes.benchmark.benchmarker.subprocess.run", fake_run
+        )
+        mode = self._make_mode(tmp_path, "xdit --model flux")
+        result = mode.run()
+
+        assert result.success is False
+        assert any("timings.json" in e for e in result.errors)
+
+    def test_offline_run_writes_report(self, tmp_path, monkeypatch):
+        capture = {}
+        self._patch_subprocess_to_emit_timings(monkeypatch, [1.0], capture)
+        mode = self._make_mode(tmp_path, "xdit --model flux")
+        result = mode.run()
+        assert result.success is True
+        # Report written into the workspace.
+        from pathlib import Path
+
+        report = Path(result.workspace_dir) / "benchmark_report.json"
+        assert report.exists()
+
+
+# --------------------------------------------------------------------------- #
+# benchmark_images.yaml — xdit entry exists
+# --------------------------------------------------------------------------- #
+class TestBenchmarkImagesYaml:
+    def test_xdit_entry_present(self):
+        from pathlib import Path
+
+        images_path = (
+            Path(__file__).resolve().parent.parent
+            / "Magpie"
+            / "benchmark_images.yaml"
+        )
+        data = yaml.safe_load(images_path.read_text(encoding="utf-8"))
+        assert "xdit" in data
+        assert "gfx942" in data["xdit"]
+        assert "gfx950" in data["xdit"]


### PR DESCRIPTION
Hello!

I'll start by saying this is a draft PR - I haven't fully finalized and tested it, but I wanted to open it to maybe garner some discussion whether this would be something that could be eventually merged or if I should change my approach entirely.

### What?
Adds a new offline benchmark path for diffusion engines (just xDiT for now). Unlike the existing LLM frameworks that launch an inference server via InferenceX and measure token throughput, diffusion models measure latency and do not necessarily launch a server at all. Diffusion models also do not benefit at all from parameter sweeping, so a mostly verbatim CLI command is given.

Currently this is just for xDiT and the code here is still somewhat "diffusion = xDiT", but I plan to generalize it more when I add support for other diffusion frameworks (SGL-D and vLLM-Omni). 

### Changes
This PR adds a new framework capability spec, where each supported framework define their own capabilities, i.e. whether to launch a server, if it's text or image/video output etc. Based on these capabilities, different code paths are used.

Secondary change this PR adds is the offline execution path. As xDiT is fully offline, i.e. it does not spawn a server, it has to run differently. With these changes, we can benchmark and profile xDiT while still adhering to the original data structure.

---

Like I said in the beginning, this is not finalized and I just want to know if this fits the maintainers' vision. I'm open to all and any changes required :)