### PR TITLE
[xDiT] Add xDiT diffusion as a scriptable benchmark framework

### DIFF
--- a/Magpie/benchmark_images.yaml
+++ b/Magpie/benchmark_images.yaml
@@ -39,3 +39,8 @@ atom:
   # AMD GPUs
   gfx942: "rocm/atom:latest"
   gfx950: "rocm/atom:latest"
+
+# NOTE: xDiT is intentionally NOT listed here. It is a server-less (scriptable)
+# diffusion workload that runs natively via the `xdit` CLI (no Docker image), so
+# this file stays a pure Docker-image mapping. BenchmarkConfig enforces
+# run_mode=local for framework=xdit instead.

--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -336,13 +336,25 @@ class BenchmarkMode:
                 result_file,
                 framework=self.config.framework,
                 model=self.config.model,
+                is_scriptable=self.config.is_scriptable,
             )
             # Merge parsed results
             result.throughput = parsed.throughput
             result.latency = parsed.latency
             result.raw_result = parsed.raw_result
+            # Scriptable (server-less) extras — e.g. xDiT diffusion quality gate.
+            result.workload_kind = parsed.workload_kind
+            result.throughput_unit = parsed.throughput_unit
+            result.quality_gate = parsed.quality_gate
+            result.latency_s = parsed.latency_s
             if parsed.errors:
                 result.errors.extend(parsed.errors)
+            # Propagate a parse-time gate failure: parse_inferencex_result sets
+            # success=False when the (scriptable) quality gate is missing/not
+            # passed, but the process exit code already set result.success=True.
+            # Without this the gate enforcement would be silently dropped.
+            if not parsed.success:
+                result.success = False
         else:
             result.success = False
             mode_label = "locally" if self.config.is_local else "inside container"

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -18,6 +18,7 @@ class BenchmarkFramework(Enum):
     VLLM = "vllm"
     SGLANG = "sglang"
     ATOM = "atom"
+    XDIT = "xdit"
 
 
 class BenchmarkRunMode(Enum):
@@ -26,6 +27,14 @@ class BenchmarkRunMode(Enum):
     DOCKER = "docker"
     LOCAL = "local"
     RAY = "ray"
+
+
+# Server-less (scriptable) frameworks: a single-command bench script reports
+# throughput plus an image-quality gate (LPIPS/SSIM/MSE) instead of running an
+# OpenAI server + GSM8K eval. For these the quality gate is the only
+# correctness signal, so a missing/un-passed gate must fail the benchmark
+# (see result.py / benchmarker.py) rather than silently pass.
+SCRIPTABLE_FRAMEWORKS = frozenset({"xdit"})
 
 
 class TraceLensExportFormat(Enum):
@@ -710,10 +719,13 @@ class BenchmarkConfig:
     def __post_init__(self):
         """Validate and set defaults."""
         # Normalize framework name
+        # ``xdit`` is a server-less (scriptable) diffusion framework: it runs a
+        # single-command bench script (no OpenAI server) and reports img/s plus
+        # an image-quality gate.
         self.framework = self.framework.lower()
-        if self.framework not in ["vllm", "sglang", "atom"]:
+        if self.framework not in ["vllm", "sglang", "atom", "xdit"]:
             raise ValueError(
-                f"Unsupported framework: {self.framework}. Use 'vllm', 'sglang', or 'atom'."
+                f"Unsupported framework: {self.framework}. Use 'vllm', 'sglang', 'atom', or 'xdit'."
             )
 
         # Validate run_mode
@@ -721,6 +733,15 @@ class BenchmarkConfig:
         if self.run_mode not in ("docker", "local", "ray"):
             raise ValueError(
                 f"Unsupported run_mode: {self.run_mode}. Use 'docker', 'local', or 'ray'."
+            )
+
+        # ``xdit`` is server-less (scriptable) with no Docker image, so it must
+        # run locally. Reject docker/ray here so benchmark_images.yaml stays a
+        # pure Docker-image mapping and the scriptable contract is explicit.
+        if self.framework == "xdit" and self.run_mode != "local":
+            raise ValueError(
+                "Framework 'xdit' is server-less (scriptable) and requires "
+                f"run_mode='local', got run_mode='{self.run_mode}'."
             )
 
         # Set default envs if not provided
@@ -817,6 +838,15 @@ class BenchmarkConfig:
     def is_local(self) -> bool:
         """Check if running in local mode (no Docker)."""
         return self.run_mode == "local"
+
+    @property
+    def is_scriptable(self) -> bool:
+        """Check if the framework is server-less (scriptable), e.g. xDiT.
+
+        Scriptable runs report an image-quality gate in place of a GSM8K eval,
+        so a missing/un-passed gate must fail the benchmark.
+        """
+        return self.framework in SCRIPTABLE_FRAMEWORKS
 
     @property
     def is_ray(self) -> bool:

--- a/Magpie/modes/benchmark/result.py
+++ b/Magpie/modes/benchmark/result.py
@@ -157,10 +157,20 @@ class BenchmarkResult:
     
     # Raw data
     raw_result: Optional[Dict[str, Any]] = None
+
+    # Scriptable (server-less) extras — e.g. xDiT diffusion. ``workload_kind``
+    # distinguishes serving vs scriptable runs; ``quality_gate`` carries the
+    # image-quality result (LPIPS/SSIM/MSE) in place of a GSM8K eval;
+    # ``throughput_unit`` is "img/s" for diffusion; ``latency_s`` is the E2E
+    # per-image latency the throughput was derived from.
+    workload_kind: str = ""
+    throughput_unit: str = ""
+    quality_gate: Optional[Dict[str, Any]] = None
+    latency_s: Optional[float] = None
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
-        return {
+        d = {
             "success": self.success,
             "framework": self.framework,
             "model": self.model,
@@ -176,6 +186,17 @@ class BenchmarkResult:
             "profiling_enabled": self.profiling_enabled,
             "errors": self.errors,
         }
+        # Scriptable (server-less) extras — e.g. xDiT diffusion. Only emit when
+        # populated so the report schema is unchanged for vLLM/SGLang/Atom.
+        if self.workload_kind:
+            d["workload_kind"] = self.workload_kind
+        if self.throughput_unit:
+            d["throughput_unit"] = self.throughput_unit
+        if self.quality_gate is not None:
+            d["quality_gate"] = self.quality_gate
+        if self.latency_s is not None:
+            d["latency_s"] = self.latency_s
+        return d
     
     def get_summary(self) -> str:
         """Generate human-readable summary."""
@@ -296,6 +317,7 @@ class ResultParser:
         result_file: Path,
         framework: str = "",
         model: str = "",
+        is_scriptable: bool = False,
     ) -> BenchmarkResult:
         """
         Parse InferenceX result JSON file.
@@ -304,6 +326,10 @@ class ResultParser:
             result_file: Path to inferencex_result.json
             framework: Framework name
             model: Model name
+            is_scriptable: Whether this is a server-less (scriptable) workload
+                (e.g. xDiT diffusion). For scriptable runs the image-quality
+                gate is the only correctness signal, so a missing/un-passed
+                gate fails the benchmark instead of silently passing.
         
         Returns:
             Parsed BenchmarkResult
@@ -352,6 +378,44 @@ class ResultParser:
                 e2el_std=data.get("std_e2el_ms", 0.0),
             )
             
+            # Scriptable (server-less) extras — carried verbatim from the bench
+            # script's result JSON (e.g. xDiT diffusion image-quality gate).
+            result.workload_kind = data.get("workload_kind", "")
+            result.throughput_unit = data.get("throughput_unit", "")
+            result.quality_gate = data.get("quality_gate")
+            result.latency_s = data.get("latency_s")
+
+            # Enforce the scriptable image-quality gate so tuning/leaderboard
+            # runs never accept a faster config that regressed image quality.
+            #
+            # Serving (vLLM/SGLang/Atom): only a populated gate with
+            # passed=False fails (a missing gate is legitimate — no eval ran).
+            #
+            # Scriptable (xDiT diffusion): the gate is the ONLY correctness
+            # signal, so it is required — a missing/non-dict gate, or one whose
+            # ``passed`` is not exactly True, fails the benchmark (fail-closed)
+            # rather than silently passing.
+            if is_scriptable:
+                gate = result.quality_gate
+                if not isinstance(gate, dict):
+                    result.success = False
+                    result.errors.append(
+                        "Quality gate missing for scriptable workload: "
+                        "the image-quality gate is required but was not "
+                        f"reported (got {gate!r})"
+                    )
+                elif gate.get("passed") is not True:
+                    result.success = False
+                    result.errors.append(
+                        f"Quality gate not passed: {gate}"
+                    )
+            elif isinstance(result.quality_gate, dict) and \
+                    result.quality_gate.get("passed") is False:
+                result.success = False
+                result.errors.append(
+                    f"Quality gate failed: {result.quality_gate}"
+                )
+
             # Extract model info if not provided
             if not result.model and "model_id" in data:
                 result.model = data["model_id"]

--- a/Magpie/scripts/benchmark/xdit_bench_common.sh
+++ b/Magpie/scripts/benchmark/xdit_bench_common.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+#
+# Magpie generic benchmark body for xDiT (diffusion, server-less).
+#
+# Sourced by the runner-specific entrypoints xdit_mi355x.sh / xdit_mi300x.sh.
+# Unlike the serving scripts (sglang/vllm), xDiT runs a SINGLE command: there
+# is no OpenAI server and no benchmark_serving.py client. It runs the xDiT CLI
+# once, parses E2E per-image latency, runs an image-quality gate (LPIPS / SSIM
+# / MSE vs a fixed BF16 reference), and writes an InferenceX-shaped result JSON
+# that Magpie's ResultParser consumes.
+#
+# Magpie contract (env in):
+#   RESULT_DIR        output dir (Magpie sets to the workspace)
+#   RESULT_FILENAME   result basename (Magpie sets to "inferencex_result")
+#   RUNNER_TYPE       gpu runner (mi355x / mi300x) — set by the entrypoint
+#   MODEL             model path (xdit --model uses its basename)
+#   PRECISION         locked bf16
+#   TP                Ulysses sequence-parallel degree (= GPU count)
+#   ROCR_VISIBLE_DEVICES  GPU pin from Magpie/Hyperloom (mapped to HIP)
+#   EXTRA_XDIT_ARGS   extra xdit CLI flags injected by the grid runner
+#   PROFILE           "1" enables best-effort torch profiler (see below)
+#
+# Tunable env (BF16-safe knobs the optimizer may set):
+#   XDIT_ATTENTION_BACKEND (aiter) XDIT_USE_TORCH_COMPILE (1)
+#   XDIT_HEIGHT (1024) XDIT_WIDTH (1024) XDIT_NUM_STEPS (28)
+#   XDIT_NUM_ITERATIONS (25) XDIT_WARMUP_CALLS (5) XDIT_GUIDANCE_SCALE (4.0)
+#   XDIT_ULYSSES_DEGREE (defaults to $TP)
+#
+# Quality gate env:
+#   XDIT_QUALITY_REF / XDIT_QUALITY_LPIPS_MAX / XDIT_QUALITY_SSIM_MIN /
+#   XDIT_QUALITY_MSE_MAX  (empty ref => gate skipped, passed=true)
+#
+# LOCKED (precision = BF16; a precision change is a different model):
+#   XDIT_USE_FP4_GEMMS / XDIT_USE_FP8_GEMMS forced OFF (overrides ignored).
+#
+set -euo pipefail
+
+# ── ROCm toolchain: aiter JIT needs hipcc ────────────────────────────
+if ! command -v hipcc &>/dev/null && [ -x /opt/rocm/bin/hipcc ]; then
+    export PATH="/opt/rocm/bin:${PATH}"
+fi
+
+# ── Precision lock: BF16 ─────────────────────────────────────────────
+if [ "${XDIT_USE_FP4_GEMMS:-0}" != "0" ]; then
+    echo "[xdit][lock] XDIT_USE_FP4_GEMMS=${XDIT_USE_FP4_GEMMS} IGNORED — precision locked to BF16."
+fi
+if [ "${XDIT_USE_FP8_GEMMS:-0}" != "0" ]; then
+    echo "[xdit][lock] XDIT_USE_FP8_GEMMS=${XDIT_USE_FP8_GEMMS} IGNORED — precision locked to BF16."
+fi
+
+# ── GPU visibility (rocm index space -> HIP) ─────────────────────────
+# ROCR_VISIBLE_DEVICES already re-indexes visible GPUs to 0..N-1, so HIP must
+# use the logical range, not the original physical ids. Only derive it when the
+# caller has not already pinned HIP_VISIBLE_DEVICES (matches vLLM/Atom scripts).
+unset CUDA_VISIBLE_DEVICES 2>/dev/null || true
+if [ -n "${ROCR_VISIBLE_DEVICES:-}" ] && [ -z "${HIP_VISIBLE_DEVICES:-}" ]; then
+    n=$(echo "${ROCR_VISIBLE_DEVICES}" | awk -F, '{print NF}')
+    export HIP_VISIBLE_DEVICES=$(seq -s, 0 $((n - 1)))
+fi
+export HSA_NO_SCRATCH_RECLAIM=1
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-16}"
+
+# ── Resolve config ───────────────────────────────────────────────────
+RESULT_DIR="${RESULT_DIR:?RESULT_DIR must be set by Magpie}"
+RESULT_FILENAME="${RESULT_FILENAME:-inferencex_result}"
+OUTPUT_FILE="${RESULT_DIR}/${RESULT_FILENAME}.json"
+mkdir -p "${RESULT_DIR}"
+
+MODEL_PATH="${MODEL:?MODEL must be set}"
+# xDiT CLI --model accepts a model name (basename) or full path depending on
+# the build. Default to basename (arbor parity); set XDIT_MODEL_ARG=path to
+# pass the full local path instead.
+case "${XDIT_MODEL_ARG:-name}" in
+    path) XDIT_MODEL_NAME="${MODEL_PATH}" ;;
+    *)    XDIT_MODEL_NAME="${XDIT_MODEL_NAME:-$(basename "${MODEL_PATH}")}" ;;
+esac
+
+ATTENTION_BACKEND="${XDIT_ATTENTION_BACKEND:-aiter}"
+ULYSSES="${XDIT_ULYSSES_DEGREE:-${TP:-8}}"
+SEED="${XDIT_SEED:-42}"
+MAX_SEQ_LEN="${XDIT_MAX_SEQ_LEN:-512}"
+HEIGHT="${XDIT_HEIGHT:-1024}"
+WIDTH="${XDIT_WIDTH:-1024}"
+NUM_STEPS="${XDIT_NUM_STEPS:-28}"
+NUM_ITERATIONS="${XDIT_NUM_ITERATIONS:-25}"
+WARMUP="${XDIT_WARMUP_CALLS:-5}"
+GUIDANCE="${XDIT_GUIDANCE_SCALE:-4.0}"
+
+QUALITY_REF="${XDIT_QUALITY_REF:-}"
+QUALITY_LPIPS_MAX="${XDIT_QUALITY_LPIPS_MAX:-0.05}"
+QUALITY_SSIM_MIN="${XDIT_QUALITY_SSIM_MIN:-0.95}"
+QUALITY_MSE_MAX="${XDIT_QUALITY_MSE_MAX:-0.002}"
+
+# torch.compile flag (BF16-safe; the big proven win)
+EXTRA_FLAGS=()
+if [ "${XDIT_USE_TORCH_COMPILE:-1}" = "1" ]; then
+    EXTRA_FLAGS+=(--use_torch_compile)
+fi
+
+# Best-effort torch profiler: xDiT uses --profile + --output_directory (not
+# --torch_profiler_dir). Traces land as profile_trace_rank_*.json.gz; a
+# post-run rename bridges them to the *.trace.json.gz glob Hyperloom expects.
+PROFILER_DIR="${VLLM_TORCH_PROFILER_DIR:-${SGLANG_TORCH_PROFILER_DIR:-${RESULT_DIR}/torch_trace}}"
+XDIT_PROFILE_ENABLED=0
+if [ "${PROFILE:-0}" = "1" ] && [ "${XDIT_SUPPORTS_PROFILER:-0}" = "1" ]; then
+    mkdir -p "${PROFILER_DIR}"
+    EXTRA_FLAGS+=(--profile --profile_wait 0 --profile_warmup "${XDIT_PROFILE_WARMUP:-2}" --profile_active "${XDIT_PROFILE_ACTIVE:-1}")
+    XDIT_PROFILE_ENABLED=1
+fi
+
+case "${ATTENTION_BACKEND}" in
+    aiter_fp8|aiter_sage|aiter_sage_v2|aiter_sparse_sage|aiter_sparse_sage_v2)
+        echo "[xdit][warn] ${ATTENTION_BACKEND} is QUANTIZED attention — known regression on FLUX (small seqlen). Prefer 'aiter'."
+        ;;
+esac
+
+XDIT_INPUT_IMAGE="${XDIT_INPUT_IMAGE:-/app/data/flux_cat.png}"
+XDIT_PROMPT="${XDIT_PROMPT:-Add a cool hat to the cat}"
+
+# ── Preflight checks ─────────────────────────────────────────────────
+if ! command -v xdit &>/dev/null; then
+    echo "[xdit][fatal] 'xdit' binary not found in PATH. Ensure the xDiT package is installed in the current environment." >&2
+    exit 1
+fi
+if [ ! -f "${XDIT_INPUT_IMAGE}" ]; then
+    echo "[xdit][warn] input image not found: ${XDIT_INPUT_IMAGE} — xDiT may fail or use its default." >&2
+fi
+
+echo "=== Magpie xDiT bench (BF16, runner=${RUNNER_TYPE:-unknown}) ==="
+echo "  model=${MODEL_PATH} attn=${ATTENTION_BACKEND} res=${HEIGHT}x${WIDTH} ulysses=${ULYSSES}"
+echo "  steps=${NUM_STEPS} iters=${NUM_ITERATIONS} warmup=${WARMUP} compile=${XDIT_USE_TORCH_COMPILE:-1}"
+echo "  quality_ref=${QUALITY_REF:-<none>} thresholds: LPIPS<${QUALITY_LPIPS_MAX} SSIM>${QUALITY_SSIM_MIN} MSE<${QUALITY_MSE_MAX}"
+echo "  extra_xdit_args=${EXTRA_XDIT_ARGS:-<none>}"
+
+XDIT_RUN_DIR="$(mktemp -d "${RESULT_DIR}/xdit_run.XXXXXX")"
+XDIT_LOG="${XDIT_RUN_DIR}/xdit_stdout.log"
+
+START_NS=$(date +%s%N)
+
+# shellcheck disable=SC2086  # EXTRA_XDIT_ARGS is intentionally word-split.
+xdit \
+    --model "${XDIT_MODEL_NAME}" \
+    --seed "${SEED}" \
+    --prompt "${XDIT_PROMPT}" \
+    --height "${HEIGHT}" \
+    --width "${WIDTH}" \
+    --num_inference_steps "${NUM_STEPS}" \
+    --max_sequence_length "${MAX_SEQ_LEN}" \
+    --warmup_calls "${WARMUP}" \
+    --ulysses_degree "${ULYSSES}" \
+    --guidance_scale "${GUIDANCE}" \
+    --num_iterations "${NUM_ITERATIONS}" \
+    --attention_backend "${ATTENTION_BACKEND}" \
+    --input_images "${XDIT_INPUT_IMAGE}" \
+    --output_directory "${XDIT_RUN_DIR}" \
+    ${EXTRA_FLAGS[@]+"${EXTRA_FLAGS[@]}"} \
+    ${EXTRA_XDIT_ARGS:-} \
+    2>&1 | tee "${XDIT_LOG}"
+
+END_NS=$(date +%s%N)
+WALL_MS=$(( (END_NS - START_NS) / 1000000 ))
+
+# Bridge xDiT profiler traces to Hyperloom's expected *.trace.json.gz naming.
+if [ "${XDIT_PROFILE_ENABLED}" = "1" ]; then
+    for src in "${XDIT_RUN_DIR}"/profile_trace_rank_*.json.gz; do
+        [ -f "$src" ] || continue
+        rank=$(echo "$src" | grep -oP 'rank_\K\d+')
+        dst="${PROFILER_DIR}/rank_${rank}.trace.json.gz"
+        cp "$src" "$dst"
+        echo "[xdit][profile] copied $src -> $dst"
+    done
+fi
+
+python3 - "${XDIT_LOG}" "${OUTPUT_FILE}" "${WALL_MS}" "${NUM_ITERATIONS}" "${XDIT_RUN_DIR}" \
+          "${QUALITY_REF}" "${QUALITY_LPIPS_MAX}" "${QUALITY_SSIM_MIN}" "${QUALITY_MSE_MAX}" \
+          "${MODEL_PATH}" "${ATTENTION_BACKEND}" <<'PYEOF'
+import glob
+import json
+import os
+import re
+import sys
+
+log_path, output_path, wall_ms_str, num_iter_str, run_dir = sys.argv[1:6]
+quality_ref_path, lpips_max_str, ssim_min_str, mse_max_str = sys.argv[6:10]
+model_path, attention_backend = sys.argv[10:12]
+
+wall_ms = int(wall_ms_str)
+num_iterations = int(num_iter_str)
+lpips_max = float(lpips_max_str)
+ssim_min = float(ssim_min_str)
+mse_max = float(mse_max_str)
+
+try:
+    log_text = open(log_path, encoding="utf-8", errors="replace").read()
+except OSError:
+    log_text = ""
+
+# ── Parse E2E per-image latency ──────────────────────────────────────
+e2e_latency_s = None
+for pattern in [
+    r"Average time over \d+ runs:\s*([\d.]+)s",
+    r"Iteration \d+ completed in ([\d.]+)s",
+    r"100%\|[^|]*\|\s*\d+/\d+\s*\[[\d:]+<[\d:]+,\s*([\d.]+)s/it\]",
+    r"([\d.]+)s/it\]",
+    r"(?:average|mean|avg)\s+(?:e2e|end.to.end|latency|time)\s*[:\s=]+\s*([\d.]+)\s*(?:s|sec)",
+    r"(?:e2e|latency|inference)\s*[:\s=]+\s*([\d.]+)\s*s",
+]:
+    matches = re.findall(pattern, log_text, re.IGNORECASE)
+    if matches:
+        e2e_latency_s = float(matches[-1])
+        break
+
+if e2e_latency_s is None:
+    e2e_latency_s = (wall_ms / 1000.0) / max(num_iterations, 1)
+    print(f"[xdit] no parsed timing; wall-clock fallback {e2e_latency_s:.3f}s/image")
+else:
+    print(f"[xdit] parsed E2E latency {e2e_latency_s:.3f}s/image")
+
+output_throughput = 1.0 / e2e_latency_s if e2e_latency_s > 0 else 0.0
+
+generated = sorted(
+    glob.glob(os.path.join(run_dir, "*.png")) + glob.glob(os.path.join(run_dir, "*.jpg"))
+)
+completed = len(generated) if generated else num_iterations
+
+# ── Image-quality gate (vs fixed BF16 reference) ─────────────────────
+quality_gate = None
+ref_write_path = os.environ.get("XDIT_QUALITY_REF_WRITE", "").strip()
+
+
+def _try_load_image_libs():
+    """Return (numpy, PIL.Image) or (None, None) if unavailable."""
+    try:
+        import numpy as _np
+        from PIL import Image as _Img
+        return _np, _Img
+    except Exception as exc:
+        print(f"[xdit][warn] image libs unavailable ({exc}); quality gate skipped",
+              file=sys.stderr)
+        return None, None
+
+
+if quality_ref_path and os.path.isfile(quality_ref_path) and generated:
+    np, Image = _try_load_image_libs()
+    if np is None:
+        quality_gate = {"passed": True, "skipped": True, "reason": "image_libs_unavailable"}
+    else:
+        ref = np.array(Image.open(quality_ref_path).convert("RGB")).astype("float32") / 255.0
+        gen_path = generated[-1]
+        gen_img = Image.open(gen_path).convert("RGB")
+        if (gen_img.height, gen_img.width) != (ref.shape[0], ref.shape[1]):
+            gen_img = gen_img.resize((ref.shape[1], ref.shape[0]), Image.LANCZOS)
+        gen = np.array(gen_img).astype("float32") / 255.0
+
+        mse_val = float(np.mean((ref - gen) ** 2))
+        try:
+            from skimage.metrics import structural_similarity
+            ssim_val = float(structural_similarity(ref, gen, channel_axis=2, data_range=1.0))
+        except Exception as exc:
+            print(f"[xdit] SSIM failed ({exc}); fallback 1.0")
+            ssim_val = 1.0
+        lpips_val = 0.0
+        try:
+            import lpips
+            import torch
+            loss_fn = lpips.LPIPS(net="alex", verbose=False)
+            ref_t = torch.from_numpy(ref).permute(2, 0, 1).unsqueeze(0) * 2 - 1
+            gen_t = torch.from_numpy(gen).permute(2, 0, 1).unsqueeze(0) * 2 - 1
+            with torch.no_grad():
+                lpips_val = float(loss_fn(ref_t, gen_t).item())
+        except Exception as exc:
+            print(f"[xdit] LPIPS failed ({exc}); fallback 0.0")
+            lpips_val = 0.0
+
+        passed = (mse_val <= mse_max) and (ssim_val >= ssim_min) and (lpips_val <= lpips_max)
+        quality_gate = {
+            "passed": bool(passed),
+            "lpips": round(lpips_val, 6),
+            "ssim": round(ssim_val, 6),
+            "mse": round(mse_val, 6),
+            "lpips_max": lpips_max,
+            "ssim_min": ssim_min,
+            "mse_max": mse_max,
+            "reference": quality_ref_path,
+        }
+        print(
+            f"[xdit] quality {'PASS' if passed else 'FAIL'} "
+            f"lpips={lpips_val:.4f} ssim={ssim_val:.4f} mse={mse_val:.6f}"
+        )
+elif generated and ref_write_path:
+    np, Image = _try_load_image_libs()
+    if np is not None:
+        try:
+            os.makedirs(os.path.dirname(ref_write_path) or ".", exist_ok=True)
+            Image.open(generated[-1]).convert("RGB").save(ref_write_path)
+            print(f"[xdit] established quality reference -> {ref_write_path}", file=sys.stderr)
+        except Exception as exc:
+            print(f"[xdit][warn] could not write reference ({exc})", file=sys.stderr)
+    quality_gate = {"passed": True, "skipped": True, "reason": "reference_established"}
+else:
+    print(
+        "[xdit][warn] XDIT_QUALITY_REF is empty — image-quality gate SKIPPED. "
+        "Throughput tuning has NO quality guard. Set XDIT_QUALITY_REF to a BF16 "
+        "reference image or XDIT_QUALITY_REF_WRITE to auto-capture one.",
+        file=sys.stderr,
+    )
+    quality_gate = {"passed": True, "skipped": True, "reason": "no_reference_or_image"}
+
+result = {
+    "framework": "xdit",
+    "model": model_path,
+    "workload_kind": "scriptable",
+    "throughput_unit": "img/s",
+    "output_throughput": round(output_throughput, 6),
+    "request_throughput": round(output_throughput, 6),
+    "completed": completed,
+    "num_prompts": num_iterations,
+    "duration": round(wall_ms / 1000.0, 3),
+    "latency_s": round(e2e_latency_s, 4),
+    "mean_e2el_ms": round(e2e_latency_s * 1000.0, 3),
+    "attention_backend": attention_backend,
+    "precision_locked": "bf16",
+    "quality_gate": quality_gate,
+}
+
+with open(output_path, "w", encoding="utf-8") as fh:
+    json.dump(result, fh, indent=2)
+
+print(
+    f"[xdit] throughput={output_throughput:.4f} img/s latency={e2e_latency_s:.3f}s "
+    f"completed={completed} -> {output_path}"
+)
+PYEOF
+
+echo "=== Magpie xDiT bench complete ==="

--- a/Magpie/scripts/benchmark/xdit_mi300x.sh
+++ b/Magpie/scripts/benchmark/xdit_mi300x.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+#
+# Magpie generic xDiT benchmark entrypoint for MI300X (gfx942).
+# Resolved by benchmarker._get_benchmark_script as the Priority-3 generic
+# script "xdit_<runner>.sh". Delegates to the shared body.
+#
+set -euo pipefail
+
+export RUNNER_TYPE="${RUNNER_TYPE:-mi300x}"
+export XDIT_ATTENTION_BACKEND="${XDIT_ATTENTION_BACKEND:-aiter}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/xdit_bench_common.sh"

--- a/Magpie/scripts/benchmark/xdit_mi355x.sh
+++ b/Magpie/scripts/benchmark/xdit_mi355x.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+###############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+#
+# Magpie generic xDiT benchmark entrypoint for MI355X (gfx950).
+# Resolved by benchmarker._get_benchmark_script as the Priority-3 generic
+# script "xdit_<runner>.sh". Delegates to the shared body.
+#
+set -euo pipefail
+
+export RUNNER_TYPE="${RUNNER_TYPE:-mi355x}"
+# aiter is the BF16-correct attention backend on gfx950.
+export XDIT_ATTENTION_BACKEND="${XDIT_ATTENTION_BACKEND:-aiter}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/xdit_bench_common.sh"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ where = ["."]
 include = ["Magpie*"]
 
 [tool.setuptools.package-data]
-Magpie = ["*.yaml", "*.yaml.example", "*.json"]
+Magpie = ["*.yaml", "*.yaml.example", "*.json", "scripts/benchmark/*.sh"]
 
 [tool.black]
 line-length = 88

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -1047,3 +1047,172 @@ def test_benchmark_result_summary_includes_sections():
     assert "Benchmark Result: VLLM" in summary
     assert "Status: SUCCESS" in summary
     assert "Errors:" in summary
+
+
+def test_benchmark_config_accepts_xdit_scriptable_framework():
+    cfg = BenchmarkConfig(framework="XDIT", model="/models/FLUX.2-dev", run_mode="local")
+    assert cfg.framework == "xdit"
+    assert cfg.is_scriptable is True
+
+
+def test_benchmark_config_serving_frameworks_not_scriptable():
+    for fw in ("vllm", "sglang", "atom"):
+        cfg = BenchmarkConfig(framework=fw, model="demo")
+        assert cfg.is_scriptable is False
+
+
+def test_benchmark_config_rejects_unknown_framework():
+    with pytest.raises(ValueError):
+        BenchmarkConfig(framework="rust-burn", model="demo")
+
+
+def test_benchmark_config_xdit_requires_local_run_mode():
+    # xDiT is server-less (scriptable) and has no Docker image, so docker/ray
+    # must be rejected at config time.
+    for bad_mode in ("docker", "ray"):
+        with pytest.raises(ValueError):
+            BenchmarkConfig(framework="xdit", model="/models/FLUX.2-dev", run_mode=bad_mode)
+
+
+def test_result_parser_fails_on_quality_gate_regression(tmp_path):
+    # A scriptable quality gate with passed=False must fail the benchmark so a
+    # faster-but-degraded config is never accepted.
+    result_path = tmp_path / "inferencex_result.json"
+    result_path.write_text(
+        json.dumps(
+            {
+                "framework": "xdit",
+                "workload_kind": "scriptable",
+                "throughput_unit": "img/s",
+                "output_throughput": 0.42,
+                "latency_s": 2.38,
+                "quality_gate": {"passed": False, "ssim": 0.40, "lpips": 0.55},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = ResultParser.parse_inferencex_result(
+        result_path, framework="xdit", is_scriptable=True
+    )
+
+    assert parsed.success is False
+    assert any("Quality gate not passed" in e for e in parsed.errors)
+
+
+def test_result_parser_fails_on_missing_quality_gate_scriptable(tmp_path):
+    # Scriptable (xDiT) runs report an image-quality gate in place of an eval;
+    # the gate is the only correctness signal, so a missing gate must fail the
+    # benchmark (fail-closed) rather than silently pass.
+    result_path = tmp_path / "inferencex_result.json"
+    result_path.write_text(
+        json.dumps(
+            {
+                "framework": "xdit",
+                "workload_kind": "scriptable",
+                "throughput_unit": "img/s",
+                "output_throughput": 0.42,
+                "latency_s": 2.38,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = ResultParser.parse_inferencex_result(
+        result_path, framework="xdit", is_scriptable=True
+    )
+
+    assert parsed.success is False
+    assert any("Quality gate missing" in e for e in parsed.errors)
+
+
+def test_result_parser_fails_on_passed_absent_scriptable(tmp_path):
+    # A scriptable gate dict that omits the ``passed`` flag is ambiguous and
+    # must not be treated as a pass.
+    result_path = tmp_path / "inferencex_result.json"
+    result_path.write_text(
+        json.dumps(
+            {
+                "framework": "xdit",
+                "workload_kind": "scriptable",
+                "throughput_unit": "img/s",
+                "output_throughput": 0.42,
+                "quality_gate": {"ssim": 0.97, "lpips": 0.01},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = ResultParser.parse_inferencex_result(
+        result_path, framework="xdit", is_scriptable=True
+    )
+
+    assert parsed.success is False
+    assert any("Quality gate not passed" in e for e in parsed.errors)
+
+
+def test_result_parser_serving_allows_missing_gate(tmp_path):
+    # Serving frameworks (vLLM/SGLang/Atom) legitimately have no quality gate
+    # (eval may not have run), so a missing gate must not fail the benchmark.
+    result_path = tmp_path / "inferencex_result.json"
+    result_path.write_text(
+        json.dumps({"output_throughput": 123.0, "completed": 10, "duration": 5.0}),
+        encoding="utf-8",
+    )
+
+    parsed = ResultParser.parse_inferencex_result(
+        result_path, framework="vllm", is_scriptable=False
+    )
+
+    assert parsed.success is True
+    assert not any("Quality gate" in e for e in parsed.errors)
+
+
+def test_result_to_dict_omits_scriptable_fields_for_serving(tmp_path):
+    # vLLM/SGLang/Atom results have no scriptable extras, so to_dict() must not
+    # add workload_kind / throughput_unit / quality_gate / latency_s keys.
+    result_path = tmp_path / "inferencex_result.json"
+    result_path.write_text(
+        json.dumps({"output_throughput": 123.0, "completed": 10, "duration": 5.0}),
+        encoding="utf-8",
+    )
+
+    parsed = ResultParser.parse_inferencex_result(result_path, framework="vllm")
+    d = parsed.to_dict()
+
+    assert parsed.latency_s is None
+    for key in ("workload_kind", "throughput_unit", "quality_gate", "latency_s"):
+        assert key not in d
+
+
+def test_result_parser_carries_scriptable_quality_gate(tmp_path):
+    result_path = tmp_path / "inferencex_result.json"
+    result_path.write_text(
+        json.dumps(
+            {
+                "framework": "xdit",
+                "workload_kind": "scriptable",
+                "throughput_unit": "img/s",
+                "output_throughput": 0.287,
+                "completed": 25,
+                "duration": 90.0,
+                "latency_s": 3.48,
+                "quality_gate": {"passed": True, "ssim": 0.97, "lpips": 0.01},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = ResultParser.parse_inferencex_result(
+        result_path, framework="xdit", is_scriptable=True
+    )
+
+    assert parsed.success is True
+    assert parsed.workload_kind == "scriptable"
+    assert parsed.throughput_unit == "img/s"
+    assert parsed.latency_s == 3.48
+    assert parsed.quality_gate == {"passed": True, "ssim": 0.97, "lpips": 0.01}
+    # to_dict surfaces the extras at top level for Hyperloom to consume.
+    d = parsed.to_dict()
+    assert d["workload_kind"] == "scriptable"
+    assert d["quality_gate"]["passed"] is True


### PR DESCRIPTION
Add server-less (scriptable) xDiT diffusion support to benchmark mode:
- config: accept `xdit` framework; scriptable run_mode handling
- image_selector: recognise xdit, raise clear error on `_scriptable` sentinel so a docker run_mode never tries to pull a non-image
- benchmark_images.yaml: AMD-only xdit entries (gfx942/gfx950 _scriptable)
- benchmarker/result: parse the scriptable result JSON (img/s, quality gate)
- scripts: xdit_bench_common.sh + xdit_mi300x.sh / xdit_mi355x.sh runners (BF16-locked, ROCm hipcc on PATH, env-tunable seed/seqlen/profiler knobs)
- tracelens_inference/runtime: TraceLens runtime image helpers