### PR TITLE
Make IntelliKit dependencies optional extras

### DIFF
--- a/Magpie/eval/correctness.py
+++ b/Magpie/eval/correctness.py
@@ -435,11 +435,9 @@ class Correctness:
                 success=False,
                 errors=(
                     "'accordo' CLI not found on PATH. Install IntelliKit Accordo "
-                    '(pip install "git+https://github.com/AMDResearch/intellikit.git@'
-                    '1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=accordo" '
-                    "or git clone https://github.com/AMDResearch/intellikit.git && "
-                    "cd intellikit && git checkout "
-                    "1511ed984c01f2254df3ca567153c5e7cb2ac9d9 && pip install -e accordo)."
+                    '(pip install -e ".[accordo]" from a Magpie checkout, or '
+                    'pip install "magpie-eval[accordo] @ '
+                    'git+https://github.com/AMD-AGI/Magpie.git@<tag-or-sha>").'
                 ),
             )
 

--- a/Magpie/eval/performance.py
+++ b/Magpie/eval/performance.py
@@ -930,8 +930,9 @@ class Performance:
                 success=False,
                 errors=(
                     "metrix not found. Install IntelliKit Metrix "
-                    '(pip install "git+https://github.com/AMDResearch/intellikit.git@'
-                    '1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=metrix").'
+                    '(pip install -e ".[metrix]" from a Magpie checkout, or '
+                    'pip install "magpie-eval[metrix] @ '
+                    'git+https://github.com/AMD-AGI/Magpie.git@<tag-or-sha>").'
                 ),
             )
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A lightweight, general-purpose framework for evaluating GPU kernel correctness a
 # Basic installation
 pip install git+https://github.com/AMD-AGI/Magpie.git
 
+# Full installation: MCP + IntelliKit integrations
+pip install "magpie-eval[all] @ git+https://github.com/AMD-AGI/Magpie.git"
 ```
 
 ### From Source (Development)
@@ -39,7 +41,10 @@ cd Magpie
 # Editable install (recommended for development)
 pip install -e .
 
-# Or use make
+# Full editable install: MCP + IntelliKit integrations
+pip install -e ".[all]"
+
+# Or use make for a managed dependency virtualenv
 make install
 ```
 

--- a/docs/how-to/ray.md
+++ b/docs/how-to/ray.md
@@ -27,7 +27,7 @@ Ray integration does not require the Ray Dashboard or Jobs API—only connectivi
 |-------------|--------|
 | Python `ray` package on the driver | `pip install ray`; same major version as the cluster is recommended. |
 | GPU worker nodes registered with Ray | Nodes expose `GPU` resources in `ray.nodes()`. |
-| Magpie importable on workers | Default `RayConfig.install_magpie` is `true`: workers can install Magpie + `requirements.txt` via Ray `runtime_env["pip"]`. Pre-install Magpie in the image and set `install_magpie: false` to skip. |
+| Magpie importable on workers | Default `RayConfig.install_magpie` is `true`: workers can install Magpie + `requirements.txt` via Ray `runtime_env["pip"]`. Optional extras such as `.[intellikit]` are not installed this way; add those packages to `pip_packages` or pre-install them in the image. Set `install_magpie: false` to skip runtime installation. |
 | Shared filesystem (strongly recommended) | Same mount path on driver and workers for model cache, InferenceX, and benchmark results. |
 | Kernel / project paths (analyze and compare) | Paths in YAML (for example, `${CK_HOME}/…`) must exist on the worker (or on shared FS visible there). |
 
@@ -207,7 +207,7 @@ Defined in `Magpie/modes/benchmark/config.py` (`@dataclass RayConfig`).
 | `multi_node`, `total_num_gpus`, `num_nodes`, `gpus_per_node` | Used when building `runtime_env` (`RAY_ADDRESS`, `MAGPIE_TOTAL_GPUS`) for multi-node scenarios |
 | `pip_packages` | Extra pip specs in `runtime_env` |
 | `env_vars` | Extra env for remote task |
-| `install_magpie` | If true, adds Magpie project + `requirements.txt` lines to `runtime_env["pip"]` |
+| `install_magpie` | If true, adds Magpie project + `requirements.txt` lines to `runtime_env["pip"]`; optional extras must be supplied through `pip_packages` or a prebuilt worker image |
 | `magpie_install_path` | Override root used for editable Magpie install |
 
 Derived helpers: `results_dir`, `hf_cache_dir`, `inferencex_dir`.

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -30,11 +30,21 @@ For the full list of verified hardware and software versions, see the
 
 ## Install from GitHub (recommended)
 
-This installs the latest published Magpie package and its core dependencies:
+This installs Magpie from GitHub with its core dependencies:
 
 ```bash
 pip install git+https://github.com/AMD-AGI/Magpie.git
 ```
+
+To install all optional Magpie integrations, including MCP and IntelliKit
+components, request the `all` extra:
+
+```bash
+pip install "magpie-eval[all] @ git+https://github.com/AMD-AGI/Magpie.git"
+```
+
+Some IntelliKit components build native ROCm/HIP code. Use the full install on
+systems with the required ROCm/HIP build toolchain available.
 
 To also install the optional Model Context Protocol (MCP) server dependencies,
 request the `mcp` extra:
@@ -56,6 +66,9 @@ cd Magpie
 # Editable install (recommended for development)
 pip install -e .
 
+# Optional: include all optional integrations
+pip install -e ".[all]"
+
 # Optional: include the MCP server extra
 pip install -e ".[mcp]"
 
@@ -66,7 +79,8 @@ pip install -e ".[dev]"
 ## Install with make (managed virtual environment)
 
 The provided `Makefile` creates a `.venv` virtual environment and installs the
-runtime dependencies from `requirements.txt`.
+runtime dependencies from `requirements.txt`. It does not install optional
+pyproject extras such as `.[intellikit]` or `.[all]`.
 
 ```bash
 git clone https://github.com/AMD-AGI/Magpie.git
@@ -80,6 +94,9 @@ make install-dev
 
 # Activate the environment
 source .venv/bin/activate
+
+# Optional: add all pyproject extras into the managed environment
+pip install -e ".[all]"
 ```
 
 ## Optional dependencies
@@ -93,17 +110,17 @@ default. Install them based on the features you need:
   [rocprofiler-compute install guide](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/install/core-install.html).
 - **NVIDIA profiling**: `ncu` (Nsight Compute). See the
   [Nsight Compute CLI documentation](https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html).
-- **IntelliKit Metrix** (human-readable AMD profiling metrics):
+- **IntelliKit integrations** (human-readable AMD profiling metrics, AMD
+  kernel correctness validation via HSA interception, and related ROCm tools):
 
   ```bash
-  pip install "git+https://github.com/AMDResearch/intellikit.git#subdirectory=metrix"
+  pip install "magpie-eval[intellikit] @ git+https://github.com/AMD-AGI/Magpie.git"
   ```
 
-- **IntelliKit Accordo** (AMD kernel correctness validation via HSA
-  interception):
+  From a source checkout, use:
 
   ```bash
-  pip install "git+https://github.com/AMDResearch/intellikit.git#subdirectory=accordo"
+  pip install -e ".[intellikit]"
   ```
 
 ## Verify the installation

--- a/examples/ck_gemm_add_accordo.yaml
+++ b/examples/ck_gemm_add_accordo.yaml
@@ -4,7 +4,7 @@
 #   git clone https://github.com/ROCm/composable_kernel.git
 #   export CK_HOME=/path/to/composable_kernel
 #   Rebuild with debug info: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ... && make test_gemm_add_xdl -j8
-#   pip install "git+https://github.com/AMDResearch/intellikit.git@1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=accordo"
+#   pip install -e ".[accordo]"  # from the Magpie checkout
 # Note:
 #   CK binaries must be compiled with debug info (-g / RelWithDebInfo) so Accordo
 #   can extract kernel arguments via kernelDB. Release builds will fail with

--- a/examples/ck_grouped_gemm_compare_accordo.yaml
+++ b/examples/ck_grouped_gemm_compare_accordo.yaml
@@ -5,7 +5,7 @@
 #   git clone https://github.com/ROCm/composable_kernel.git
 #   export CK_HOME=/path/to/composable_kernel
 #   Rebuild with debug info: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ... && make -j8
-#   pip install "git+https://github.com/AMDResearch/intellikit.git@1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=accordo"
+#   pip install -e ".[accordo]"  # from the Magpie checkout
 # Note:
 #   CK binaries must be compiled with debug info (-g / RelWithDebInfo) so Accordo
 #   can extract kernel arguments via kernelDB.

--- a/examples/simple_hip_test/analyze_accordo.yaml
+++ b/examples/simple_hip_test/analyze_accordo.yaml
@@ -2,7 +2,7 @@
 # ================================================
 # Prereq:
 #   cd examples/simple_hip_test && hipcc -g -O2 -o vector_add vector_add.hip
-#   pip install "git+https://github.com/AMDResearch/intellikit.git@1511ed984c01f2254df3ca567153c5e7cb2ac9d9#subdirectory=accordo"
+#   pip install -e ".[accordo]"  # from the Magpie checkout
 # Note:
 #   Binaries must be compiled with -g so Accordo can extract kernel arguments.
 #   First run builds the Accordo interception library (~2-3 min one-time cost).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,36 @@ keywords = ["gpu", "kernel", "evaluation", "profiling", "hip", "cuda", "rocm"]
 dependencies = [
     "PyYAML>=6.0",
     "numpy>=1.24.0",
-    # IntelliKit components (pinned to intellikit@3f45cd3). Installed automatically
-    # so plain `pip install .` provides the metrix/accordo/etc. CLIs Magpie shells
-    # out to. NOTE: accordo/nexus/kerncap build native code and require the ROCm/HIP
-    # build toolchain (cmake, hipcc) on the install machine.
+]
+
+[project.optional-dependencies]
+mcp = [
+    "mcp>=1.0.0",
+]
+# IntelliKit components are pinned but optional because Accordo builds native
+# ROCm/HIP code and should not be required for a plain Magpie install.
+metrix = [
+    "metrix @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=metrix",
+]
+accordo = [
+    "accordo @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=accordo",
+]
+nexus = [
+    "nexus @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=nexus",
+]
+linex = [
+    "linex @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=linex",
+]
+kerncap = [
+    "kerncap @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=kerncap",
+]
+rocm-mcp = [
+    "rocm-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=rocm_mcp",
+]
+uprof-mcp = [
+    "uprof-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=uprof_mcp",
+]
+intellikit = [
     "metrix @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=metrix",
     "accordo @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=accordo",
     "nexus @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=nexus",
@@ -42,13 +68,15 @@ dependencies = [
     "rocm-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=rocm_mcp",
     "uprof-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=uprof_mcp",
 ]
-
-[project.optional-dependencies]
-mcp = [
-    "mcp>=1.0.0",
-]
 all = [
     "mcp>=1.0.0",
+    "metrix @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=metrix",
+    "accordo @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=accordo",
+    "nexus @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=nexus",
+    "linex @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=linex",
+    "kerncap @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=kerncap",
+    "rocm-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=rocm_mcp",
+    "uprof-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=uprof_mcp",
 ]
 dev = [
     "pytest>=7.0.0",
@@ -86,4 +114,3 @@ line_length = 88
 python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-# Core dependencies
+# Runtime dependencies used by make install and Ray runtime_env.
+# pip install . reads core dependencies from pyproject.toml instead.
 PyYAML>=6.0
 numpy>=1.24.0
 
-# MCP (Model Context Protocol) Server
+# MCP (Model Context Protocol) Server used by make/Ray installs
 mcp>=1.0.0
 
 # GPU/CUDA support (uncomment based on your setup)
@@ -19,15 +20,10 @@ mcp>=1.0.0
 # Optional: CUDA profiling integration
 # see https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html
 
-# IntelliKit components (pinned to intellikit@3f45cd3). These mirror the hard
-# dependencies declared in pyproject.toml so `pip install -r requirements.txt`
-# matches `pip install .`.
-# NOTE: accordo/nexus/kerncap build native code and require the ROCm/HIP build
-# toolchain (cmake, hipcc) on the install machine.
-metrix @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=metrix
-accordo @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=accordo
-nexus @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=nexus
-linex @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=linex
-kerncap @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=kerncap
-rocm-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=rocm_mcp
-uprof-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=uprof_mcp
+# Optional: IntelliKit integrations.
+# These are exposed as optional pyproject extras because some components build
+# native ROCm/HIP code and should not be required for a plain install.
+# From a Magpie checkout:
+#   pip install -e ".[intellikit]"
+# Or install a pinned release extra:
+#   pip install "magpie-eval[intellikit] @ git+https://github.com/AMD-AGI/Magpie.git@<tag-or-sha>"

--- a/skills/magpie/SKILL.md
+++ b/skills/magpie/SKILL.md
@@ -12,7 +12,7 @@ Magpie is a GPU kernel evaluation and LLM benchmarking framework. Use this skill
 ## Entry point
 
 - **CLI:** `magpie` or `python -m Magpie`. Run from the Magpie repo root (or with `PYTHONPATH` including the Magpie package).
-- **Setup:** From repo root, `pip install -e .` (or `make install`).
+- **Setup:** From repo root, `pip install -e .` for core Magpie. Use `pip install -e ".[all]"` when MCP and IntelliKit integrations are needed.
 
 ## Analyze (single or multi-kernel)
 


### PR DESCRIPTION
###  Summary

- Move pinned IntelliKit packages out of core dependencies into optional extras.
- Add individual IntelliKit extras plus aggregate intellikit and all extras.
- Update install docs, README, Ray guidance, skill setup, and missing-tool messages.

###  Tests

- python -c 'import tomllib; tomllib.load(open("pyproject.toml", "rb"))'
- optional dependency parsing with packaging.requirements.Requirement
- git diff --check