### PR TITLE
Limit all extra to broadly supported dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A lightweight, general-purpose framework for evaluating GPU kernel correctness a
 # Basic installation
 pip install git+https://github.com/AMD-AGI/Magpie.git
 
-# Full installation: MCP + IntelliKit integrations
+# Optional MCP support
 pip install "magpie-eval[all] @ git+https://github.com/AMD-AGI/Magpie.git"
 ```
 
@@ -41,7 +41,7 @@ cd Magpie
 # Editable install (recommended for development)
 pip install -e .
 
-# Full editable install: MCP + IntelliKit integrations
+# Optional MCP support
 pip install -e ".[all]"
 
 # Or use make for a managed dependency virtualenv

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -42,22 +42,23 @@ For a reproducible Magpie 0.1.0 beta install, pin the release tag:
 pip install "magpie-eval @ git+https://github.com/AMD-AGI/Magpie.git@v0.1.0"
 ```
 
-To install all optional Magpie integrations, including MCP and IntelliKit
-components, request the `all` extra:
+To install the broadly supported optional Magpie integrations, request the
+`all` extra. This currently installs MCP support:
 
 ```bash
 pip install "magpie-eval[all] @ git+https://github.com/AMD-AGI/Magpie.git"
 ```
 
-To install all optional integrations from the Magpie 0.1.0 beta release, pin the
+To install the same optional set from the Magpie 0.1.0 beta release, pin the
 same tag:
 
 ```bash
 pip install "magpie-eval[all] @ git+https://github.com/AMD-AGI/Magpie.git@v0.1.0"
 ```
 
-Some IntelliKit components build native ROCm/HIP code. Use the full install on
-systems with the required ROCm/HIP build toolchain available.
+IntelliKit integrations are intentionally not part of `all` because some
+components build native ROCm/HIP code and require additional system packages.
+Install them explicitly on supported systems.
 
 To also install the optional Model Context Protocol (MCP) server dependencies,
 request the `mcp` extra:
@@ -79,7 +80,7 @@ cd Magpie
 # Editable install (recommended for development)
 pip install -e .
 
-# Optional: include all optional integrations
+# Optional: include broadly supported extras
 pip install -e ".[all]"
 
 # Optional: include the MCP server extra
@@ -108,7 +109,7 @@ make install-dev
 # Activate the environment
 source .venv/bin/activate
 
-# Optional: add all pyproject extras into the managed environment
+# Optional: add broadly supported extras into the managed environment
 pip install -e ".[all]"
 ```
 

--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -22,7 +22,7 @@ The following Python packages and operating systems are required or tested with 
 | PyYAML | >= 6.0 | Core dependency. |
 | NumPy | >= 1.24.0 | Core dependency. |
 | MCP (`mcp`) | >= 1.0.0 | Required only for the MCP server. |
-| IntelliKit integrations | `3f45cd314d455b652a1246678511b40547fe521e` | Optional. Install with `.[intellikit]` or `.[all]`. Some components require ROCm/HIP build tools. |
+| IntelliKit integrations | `3f45cd314d455b652a1246678511b40547fe521e` | Optional. Install with `.[intellikit]` or individual extras. Some components require ROCm/HIP build tools. |
 
 ## Profilers and optional tools
 
@@ -31,8 +31,8 @@ The following profiling tools and optional packages extend Magpie's capabilities
 | Tool | Supported / tested versions | Notes |
 | --- | --- | --- |
 | `rocprof-compute` | >= 3.40 | AMD performance profiling. See the [install guide](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/install/core-install.html). |
-| IntelliKit Metrix | `3f45cd314d455b652a1246678511b40547fe521e` | Optional AMD profiling integration. Install with `.[metrix]`, `.[intellikit]`, or `.[all]`. |
-| IntelliKit Accordo | `3f45cd314d455b652a1246678511b40547fe521e` | Optional AMD correctness integration. Install with `.[accordo]`, `.[intellikit]`, or `.[all]`. |
+| IntelliKit Metrix | `3f45cd314d455b652a1246678511b40547fe521e` | Optional AMD profiling integration. Install with `.[metrix]` or `.[intellikit]`. |
+| IntelliKit Accordo | `3f45cd314d455b652a1246678511b40547fe521e` | Optional AMD correctness integration. Install with `.[accordo]` or `.[intellikit]`. |
 
 ## Hardware
 

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -24,9 +24,9 @@ across AMD and NVIDIA hardware.
 - IntelliKit components are pinned to a fixed commit and moved behind optional
   extras instead of being installed by default.
 - The `intellikit` extra installs the pinned IntelliKit integrations:
-  `metrix`, `accordo`, `nexus`, `linex`, `kerncap`, `rocm-mcp`, and
-  `uprof-mcp`.
-- The `all` extra installs MCP plus the IntelliKit integrations.
+  `metrix` and `accordo`.
+- The `all` extra installs broadly supported optional integrations. It
+  currently includes MCP support.
 
 ### Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,39 +44,12 @@ metrix = [
 accordo = [
     "accordo @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=accordo",
 ]
-nexus = [
-    "nexus @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=nexus",
-]
-linex = [
-    "linex @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=linex",
-]
-kerncap = [
-    "kerncap @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=kerncap",
-]
-rocm-mcp = [
-    "rocm-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=rocm_mcp",
-]
-uprof-mcp = [
-    "uprof-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=uprof_mcp",
-]
 intellikit = [
     "metrix @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=metrix",
     "accordo @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=accordo",
-    "nexus @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=nexus",
-    "linex @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=linex",
-    "kerncap @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=kerncap",
-    "rocm-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=rocm_mcp",
-    "uprof-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=uprof_mcp",
 ]
 all = [
     "mcp>=1.0.0",
-    "metrix @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=metrix",
-    "accordo @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=accordo",
-    "nexus @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=nexus",
-    "linex @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=linex",
-    "kerncap @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=kerncap",
-    "rocm-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=rocm_mcp",
-    "uprof-mcp @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=uprof_mcp",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/skills/magpie/SKILL.md
+++ b/skills/magpie/SKILL.md
@@ -12,7 +12,7 @@ Magpie is a GPU kernel evaluation and LLM benchmarking framework. Use this skill
 ## Entry point
 
 - **CLI:** `magpie` or `python -m Magpie`. Run from the Magpie repo root (or with `PYTHONPATH` including the Magpie package).
-- **Setup:** From repo root, `pip install -e .` for core Magpie. Use `pip install -e ".[all]"` when MCP and IntelliKit integrations are needed.
+- **Setup:** From repo root, `pip install -e .` for core Magpie. Use `pip install -e ".[all]"` for broadly supported extras, or `pip install -e ".[intellikit]"` for IntelliKit integrations on supported systems.
 
 ## Analyze (single or multi-kernel)
 


### PR DESCRIPTION
## Summary

- Limit the `all` extra to broadly supported optional dependencies
- Keep only the IntelliKit components Magpie may directly use: `metrix` and `accordo`
- Remove unrelated IntelliKit packages from Magpie extras to avoid unnecessary native/system dependencies
- Update install docs, compatibility notes, release notes, and skill setup guidance

## Context

The full `[all]` install path can pull IntelliKit native components that require additional system dependencies. Keeping those behind explicit IntelliKit extras makes the public `[all]` install path safer for general users.

## Testing

- Parsed `pyproject.toml` and validated optional dependency requirement strings
- Confirmed `all = ["mcp>=1.0.0"]`
- Ran `git diff --check`