### PR TITLE
Add TraceLens simple roofline summaries

### DIFF
--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -1633,7 +1633,7 @@ class BenchmarkMode:
         
         NOTE: This runs on the HOST machine (not in container) after the
         Docker benchmark completes. TraceLens will be auto-installed from
-        https://github.com/AMD-AIG-AIMA/TraceLens.git if not present.
+        https://github.com/AMD-AGI/TraceLens.git if not present.
         
         Args:
             torch_trace_dir: Directory containing torch trace files

--- a/Magpie/modes/benchmark/tracelens.py
+++ b/Magpie/modes/benchmark/tracelens.py
@@ -26,7 +26,7 @@ from .config import TraceLensConfig
 logger = logging.getLogger(__name__)
 
 # TraceLens installation URL
-TRACELENS_INSTALL_URL = "git+https://github.com/AMD-AIG-AIMA/TraceLens.git"
+TRACELENS_INSTALL_URL = "git+https://github.com/AMD-AGI/TraceLens.git"
 
 # CLI command names
 CLI_GENERATE_REPORT = "TraceLens_generate_perf_report_pytorch"

--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -39,6 +39,38 @@ CLI_INFERENCE_REPORT = "TraceLens_generate_perf_report_pytorch_inference"
 SGLANG_PROFILE_CUDA_GRAPH_FLAG = "--enable-profile-cuda-graph"
 SGLANG_SHAPE_DISCOVERY_FLAG = "--enable-shape-discovery-for-cuda-graph-profile"
 
+TRACELENS_SIMPLE_SUMMARY_COLUMNS = [
+    "source_category",
+    "op_name",
+    "param_signature",
+    "operation_count",
+    "num_kernels",
+    "kernel_time_ms_sum",
+    "time_pct",
+    "kernel_time_us_mean",
+    "gflops",
+    "data_moved_mb",
+    "arithmetic_intensity_flops_per_byte",
+    "achieved_tflops_mean",
+    "achieved_tbps_mean",
+    "compute_spec",
+    "roofline_bound",
+    "pct_roofline_mean",
+    "roofline_time_us",
+    "has_perf_model",
+    "params_json",
+    "input_dims",
+    "input_type",
+]
+
+TRACELENS_GENERIC_REPORT_CSVS = {
+    "gpu_timeline.csv",
+    "ops_summary.csv",
+    "ops_summary_by_category.csv",
+    "ops_unique_args.csv",
+    "unified_perf_summary.csv",
+}
+
 
 @dataclass
 class InferencePhasePick:
@@ -1120,6 +1152,151 @@ class TraceLensInferencePipeline:
             return "PREFILL"
         return None
 
+    def _write_simple_roofline_summary(
+        self,
+        stage: str,
+        output_dir: Path,
+    ) -> Optional[Path]:
+        """Write a compact stage-level roofline summary from TraceLens CSVs."""
+        unified_csv = output_dir / "unified_perf_summary.csv"
+        if not unified_csv.exists():
+            return None
+
+        params_by_key, params_by_name = self._load_stage_param_rows(output_dir)
+        output_path = (
+            output_dir.parent / f"{output_dir.name}_kernel_roofline_simple.csv"
+        )
+        rows: List[Dict[str, str]] = []
+
+        with unified_csv.open(newline="", encoding="utf-8") as handle:
+            for row in csv.DictReader(handle):
+                source_category = row.get("op category", "")
+                op_name = row.get("name", "")
+                param_row = self._match_param_row(
+                    source_category,
+                    op_name,
+                    params_by_key,
+                    params_by_name,
+                )
+                params = self._extract_param_values(param_row)
+                rows.append(
+                    {
+                        "source_category": source_category,
+                        "op_name": op_name,
+                        "param_signature": self._format_param_signature(params),
+                        "operation_count": row.get("operation_count", ""),
+                        "num_kernels": (
+                            param_row.get("num_kernels", "") if param_row else ""
+                        ),
+                        "kernel_time_ms_sum": self._microseconds_to_milliseconds(
+                            row.get("Kernel Time (µs)_sum", "")
+                        ),
+                        "time_pct": row.get("Percentage (%)", ""),
+                        "kernel_time_us_mean": row.get("Kernel Time (µs)_mean", ""),
+                        "gflops": row.get("GFLOPS", ""),
+                        "data_moved_mb": row.get("Data Moved (MB)", ""),
+                        "arithmetic_intensity_flops_per_byte": row.get(
+                            "FLOPS/Byte", ""
+                        ),
+                        "achieved_tflops_mean": row.get("TFLOPS/s_mean", ""),
+                        "achieved_tbps_mean": row.get("TB/s_mean", ""),
+                        "compute_spec": row.get("Compute Spec", ""),
+                        "roofline_bound": row.get("Roofline Bound", ""),
+                        "pct_roofline_mean": row.get("Pct Roofline_mean", ""),
+                        "roofline_time_us": row.get("Roofline Time (µs)_first", ""),
+                        "has_perf_model": row.get("has_perf_model", ""),
+                        "params_json": (
+                            json.dumps(params, sort_keys=True, separators=(",", ":"))
+                            if params
+                            else ""
+                        ),
+                        "input_dims": row.get("Input Dims", ""),
+                        "input_type": row.get("Input type", ""),
+                    }
+                )
+
+        with output_path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(
+                handle,
+                fieldnames=TRACELENS_SIMPLE_SUMMARY_COLUMNS,
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+
+        return output_path
+
+    def _load_stage_param_rows(
+        self,
+        output_dir: Path,
+    ) -> Tuple[
+        Dict[Tuple[str, str], List[Dict[str, str]]],
+        Dict[str, List[Dict[str, str]]],
+    ]:
+        by_key: Dict[Tuple[str, str], List[Dict[str, str]]] = {}
+        by_name: Dict[str, List[Dict[str, str]]] = {}
+        for path in sorted(output_dir.glob("*.csv")):
+            if path.name in TRACELENS_GENERIC_REPORT_CSVS:
+                continue
+            category = self._normalize_op_category(path.stem)
+            with path.open(newline="", encoding="utf-8") as handle:
+                for row in csv.DictReader(handle):
+                    if not any(key.startswith("param: ") for key in row):
+                        continue
+                    op_name = row.get("name", "")
+                    by_key.setdefault((category, op_name), []).append(row)
+                    by_name.setdefault(op_name, []).append(row)
+        return by_key, by_name
+
+    def _match_param_row(
+        self,
+        source_category: str,
+        op_name: str,
+        params_by_key: Dict[Tuple[str, str], List[Dict[str, str]]],
+        params_by_name: Dict[str, List[Dict[str, str]]],
+    ) -> Optional[Dict[str, str]]:
+        key = (self._normalize_op_category(source_category), op_name)
+        matches = params_by_key.get(key)
+        if matches:
+            return matches.pop(0)
+
+        name_matches = params_by_name.get(op_name)
+        if name_matches and len(name_matches) == 1:
+            return name_matches.pop(0)
+        return None
+
+    @staticmethod
+    def _extract_param_values(row: Optional[Dict[str, str]]) -> Dict[str, str]:
+        if not row:
+            return {}
+        params: Dict[str, str] = {}
+        for key, value in row.items():
+            if not key.startswith("param: "):
+                continue
+            if value in (None, ""):
+                continue
+            params[key[len("param: ") :]] = value
+        return params
+
+    @staticmethod
+    def _format_param_signature(params: Dict[str, str]) -> str:
+        return ",".join(f"{key}={value}" for key, value in params.items())
+
+    @staticmethod
+    def _normalize_op_category(value: str) -> str:
+        normalized = value.strip().lower()
+        if normalized.endswith("_fwd"):
+            normalized = normalized[:-4]
+        return re.sub(r"[^a-z0-9]+", "", normalized)
+
+    @staticmethod
+    def _microseconds_to_milliseconds(value: str) -> str:
+        if value in (None, ""):
+            return ""
+        try:
+            return f"{float(value) / 1000.0:.6g}"
+        except (TypeError, ValueError):
+            return ""
+
     def _run_perf_report(
         self,
         stage: str,
@@ -1161,12 +1338,29 @@ class TraceLensInferencePipeline:
             env=self._subprocess_env(),
         )
 
+        files = [str(path) for path in sorted(out_dir.glob("*.csv"))]
+        simple_summary: Optional[Path] = None
+        if proc.returncode == 0:
+            try:
+                simple_summary = self._write_simple_roofline_summary(stage, out_dir)
+            except Exception as exc:  # Keep benchmark postprocess best-effort.
+                logger.warning(
+                    "Failed to write TraceLens simple roofline summary for %s: %s",
+                    stage,
+                    exc,
+                )
+                simple_summary = None
+            if simple_summary:
+                files.append(str(simple_summary))
+
         result: Dict[str, Any] = {
             "stage": stage,
             "trace_path": str(trace_path),
             "output_dir": str(out_dir),
-            "files": [str(path) for path in sorted(out_dir.glob("*.csv"))],
+            "files": files,
         }
+        if simple_summary:
+            result["simple_summary_file"] = str(simple_summary)
         if proc.returncode != 0:
             result["error"] = (
                 f"TraceLens inference perf report failed for {stage}: "
@@ -1221,12 +1415,29 @@ class TraceLensInferencePipeline:
         )
         proc = self._run_container_command(docker_image, workspace, cmd)
 
+        files = [str(path) for path in sorted(out_dir.glob("*.csv"))]
+        simple_summary: Optional[Path] = None
+        if proc.returncode == 0:
+            try:
+                simple_summary = self._write_simple_roofline_summary(stage, out_dir)
+            except Exception as exc:  # Keep benchmark postprocess best-effort.
+                logger.warning(
+                    "Failed to write TraceLens simple roofline summary for %s: %s",
+                    stage,
+                    exc,
+                )
+                simple_summary = None
+            if simple_summary:
+                files.append(str(simple_summary))
+
         result: Dict[str, Any] = {
             "stage": stage,
             "trace_path": str(trace_path),
             "output_dir": str(out_dir),
-            "files": [str(path) for path in sorted(out_dir.glob("*.csv"))],
+            "files": files,
         }
+        if simple_summary:
+            result["simple_summary_file"] = str(simple_summary)
         if proc.returncode != 0:
             result["error"] = (
                 f"TraceLens inference perf report failed for {stage} in container "

--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -1362,6 +1362,7 @@ class TraceLensInferencePipeline:
         if gpu_arch_platform:
             cmd.extend(["--gpu_arch_platform", gpu_arch_platform])
         if self.tl_config.gpu_arch_config:
+            # TraceLens gives the explicit JSON priority over gpu_arch_platform.
             cmd.extend(["--gpu_arch_json_path", str(self.tl_config.gpu_arch_config)])
 
         logger.info(
@@ -1444,6 +1445,7 @@ class TraceLensInferencePipeline:
         if gpu_arch_platform:
             cmd.extend(["--gpu_arch_platform", gpu_arch_platform])
         if self.tl_config.gpu_arch_config:
+            # TraceLens gives the explicit JSON priority over gpu_arch_platform.
             gpu_arch_config = (
                 Path(self.tl_config.gpu_arch_config).expanduser().resolve()
             )

--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -63,6 +63,12 @@ TRACELENS_SIMPLE_SUMMARY_COLUMNS = [
     "input_type",
 ]
 
+TRACELENS_ARCH_SIMPLE_SUMMARY_COLUMNS = {
+    "roofline_bound": "Roofline Bound",
+    "pct_roofline_mean": "Pct Roofline_mean",
+    "roofline_time_us": "Roofline Time (µs)_first",
+}
+
 TRACELENS_GENERIC_REPORT_CSVS = {
     "gpu_timeline.csv",
     "ops_summary.csv",
@@ -1188,7 +1194,15 @@ class TraceLensInferencePipeline:
         rows: List[Dict[str, str]] = []
 
         with unified_csv.open(newline="", encoding="utf-8") as handle:
-            for row in csv.DictReader(handle):
+            reader = csv.DictReader(handle)
+            source_columns = set(reader.fieldnames or [])
+            fieldnames = [
+                column
+                for column in TRACELENS_SIMPLE_SUMMARY_COLUMNS
+                if column not in TRACELENS_ARCH_SIMPLE_SUMMARY_COLUMNS
+                or TRACELENS_ARCH_SIMPLE_SUMMARY_COLUMNS[column] in source_columns
+            ]
+            for row in reader:
                 source_category = row.get("op category", "")
                 op_name = row.get("name", "")
                 param_row = self._match_param_row(
@@ -1198,46 +1212,46 @@ class TraceLensInferencePipeline:
                     params_by_name,
                 )
                 params = self._extract_param_values(param_row)
-                rows.append(
-                    {
-                        "source_category": source_category,
-                        "op_name": op_name,
-                        "param_signature": self._format_param_signature(params),
-                        "operation_count": row.get("operation_count", ""),
-                        "num_kernels": (
-                            param_row.get("num_kernels", "") if param_row else ""
-                        ),
-                        "kernel_time_ms_sum": self._microseconds_to_milliseconds(
-                            row.get("Kernel Time (µs)_sum", "")
-                        ),
-                        "time_pct": row.get("Percentage (%)", ""),
-                        "kernel_time_us_mean": row.get("Kernel Time (µs)_mean", ""),
-                        "gflops": row.get("GFLOPS", ""),
-                        "data_moved_mb": row.get("Data Moved (MB)", ""),
-                        "arithmetic_intensity_flops_per_byte": row.get(
-                            "FLOPS/Byte", ""
-                        ),
-                        "achieved_tflops_mean": row.get("TFLOPS/s_mean", ""),
-                        "achieved_tbps_mean": row.get("TB/s_mean", ""),
-                        "compute_spec": row.get("Compute Spec", ""),
-                        "roofline_bound": row.get("Roofline Bound", ""),
-                        "pct_roofline_mean": row.get("Pct Roofline_mean", ""),
-                        "roofline_time_us": row.get("Roofline Time (µs)_first", ""),
-                        "has_perf_model": row.get("has_perf_model", ""),
-                        "params_json": (
-                            json.dumps(params, sort_keys=True, separators=(",", ":"))
-                            if params
-                            else ""
-                        ),
-                        "input_dims": row.get("Input Dims", ""),
-                        "input_type": row.get("Input type", ""),
-                    }
-                )
+                summary_row = {
+                    "source_category": source_category,
+                    "op_name": op_name,
+                    "param_signature": self._format_param_signature(params),
+                    "operation_count": row.get("operation_count", ""),
+                    "num_kernels": (
+                        param_row.get("num_kernels", "") if param_row else ""
+                    ),
+                    "kernel_time_ms_sum": self._microseconds_to_milliseconds(
+                        row.get("Kernel Time (µs)_sum", "")
+                    ),
+                    "time_pct": row.get("Percentage (%)", ""),
+                    "kernel_time_us_mean": row.get("Kernel Time (µs)_mean", ""),
+                    "gflops": row.get("GFLOPS", ""),
+                    "data_moved_mb": row.get("Data Moved (MB)", ""),
+                    "arithmetic_intensity_flops_per_byte": row.get("FLOPS/Byte", ""),
+                    "achieved_tflops_mean": row.get("TFLOPS/s_mean", ""),
+                    "achieved_tbps_mean": row.get("TB/s_mean", ""),
+                    "compute_spec": row.get("Compute Spec", ""),
+                    "has_perf_model": row.get("has_perf_model", ""),
+                    "params_json": (
+                        json.dumps(params, sort_keys=True, separators=(",", ":"))
+                        if params
+                        else ""
+                    ),
+                    "input_dims": row.get("Input Dims", ""),
+                    "input_type": row.get("Input type", ""),
+                }
+                for (
+                    output_column,
+                    source_column,
+                ) in TRACELENS_ARCH_SIMPLE_SUMMARY_COLUMNS.items():
+                    if source_column in source_columns:
+                        summary_row[output_column] = row.get(source_column, "")
+                rows.append(summary_row)
 
         with output_path.open("w", newline="", encoding="utf-8") as handle:
             writer = csv.DictWriter(
                 handle,
-                fieldnames=TRACELENS_SIMPLE_SUMMARY_COLUMNS,
+                fieldnames=fieldnames,
             )
             writer.writeheader()
             writer.writerows(rows)
@@ -1347,8 +1361,12 @@ class TraceLensInferencePipeline:
             )
         if gpu_arch_platform:
             cmd.extend(["--gpu_arch_platform", gpu_arch_platform])
+        if self.tl_config.gpu_arch_config:
+            cmd.extend(["--gpu_arch_json_path", str(self.tl_config.gpu_arch_config)])
 
-        logger.info("Running TraceLens inference perf report (%s): %s", stage, " ".join(cmd))
+        logger.info(
+            "Running TraceLens inference perf report (%s): %s", stage, " ".join(cmd)
+        )
         proc = subprocess.run(
             cmd,
             capture_output=True,
@@ -1425,6 +1443,24 @@ class TraceLensInferencePipeline:
             )
         if gpu_arch_platform:
             cmd.extend(["--gpu_arch_platform", gpu_arch_platform])
+        if self.tl_config.gpu_arch_config:
+            gpu_arch_config = (
+                Path(self.tl_config.gpu_arch_config).expanduser().resolve()
+            )
+            if not gpu_arch_config.is_file():
+                raise FileNotFoundError(
+                    f"TraceLens GPU architecture JSON not found: {gpu_arch_config}"
+                )
+            container_config = workspace / "tracelens" / gpu_arch_config.name
+            if gpu_arch_config != container_config.resolve():
+                container_config.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(gpu_arch_config, container_config)
+            cmd.extend(
+                [
+                    "--gpu_arch_json_path",
+                    self._container_path(container_config, workspace),
+                ]
+            )
 
         logger.info(
             "Running TraceLens inference perf report in container %s (%s): %s",

--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -1152,6 +1152,25 @@ class TraceLensInferencePipeline:
             return "PREFILL"
         return None
 
+    def _simple_roofline_summary_filename(self, output_label: str) -> str:
+        dims = "_".join(
+            f"{key}{self._sanitize_summary_filename_value(self.config.envs.get(key))}"
+            for key in ("ISL", "OSL", "CONC")
+        )
+        return f"{output_label}_{dims}_kernel_roofline_simple.csv"
+
+    @staticmethod
+    def _sanitize_summary_filename_value(value: Any) -> str:
+        if value in (None, ""):
+            return "unknown"
+
+        text = str(value).strip()
+        if not text:
+            return "unknown"
+
+        text = text.replace(".", "p")
+        return re.sub(r"[^A-Za-z0-9]+", "", text) or "unknown"
+
     def _write_simple_roofline_summary(
         self,
         stage: str,
@@ -1163,8 +1182,8 @@ class TraceLensInferencePipeline:
             return None
 
         params_by_key, params_by_name = self._load_stage_param_rows(output_dir)
-        output_path = (
-            output_dir.parent / f"{output_dir.name}_kernel_roofline_simple.csv"
+        output_path = output_dir.parent / self._simple_roofline_summary_filename(
+            output_dir.name
         )
         rows: List[Dict[str, str]] = []
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A lightweight, general-purpose framework for evaluating GPU kernel correctness a
 - **Execution Environments**: Local, Sandbox Container, and Remote Ray Cluster
 - **Hardware Control**: Hardware-aware kernel evaluation under controlled execution settings
 - **Auto GPU Selection**: Benchmark mode picks idle GPU(s) before launching (AMD + NVIDIA)
-- **Trace Analysis**: TraceLens integration for performance profiling analysis
+- **Trace Analysis**: TraceLens integration with per-stage roofline summaries for benchmark traces
 - **MCP Server**: Model Context Protocol integration for AI agents
 - **Structured Reports**: JSON output for pipeline integration
 

--- a/docs/conceptual/benchmarking-architecture.md
+++ b/docs/conceptual/benchmarking-architecture.md
@@ -22,6 +22,7 @@ Benchmark mode consists of the following Python modules.
 | `BenchmarkMode` | `benchmarker.py` | Main orchestrator |
 | `BenchmarkConfig` | `config.py` | Configuration dataclasses |
 | `TraceLensAnalyzer` | `tracelens.py` | TraceLens CLI integration |
+| `TraceLensInferencePipeline` | `tracelens_inference.py` | Inference-aware TraceLens split/report flow and simple roofline summaries |
 | `GapAnalyzer` | `gap_analysis.py` | Kernel bottleneck analysis |
 | `BenchmarkResult` | `result.py` | Result data structures |
 
@@ -34,8 +35,9 @@ Each benchmark run proceeds through the following stages.
 3. **Server Launch**: Start vLLM/SGLang server (in container or on host per `run_mode`)
 4. **Client Execution**: Run benchmark client with profiling enabled
 5. **Trace Collection**: Torch profiler traces saved to workspace
-6. **TraceLens Analysis**: Run TraceLens CLI commands inside the runtime image
-   for Docker inference mode, or on host for local/classic mode (if enabled)
+6. **TraceLens Analysis**: Split inference traces, run TraceLens CLI commands
+   inside the runtime image for Docker inference mode or on host for
+   local/classic mode, and write per-stage simple roofline summaries (if enabled)
 7. **Gap Analysis**: Analyze kernel bottlenecks within time window (if enabled)
 8. **Result Generation**: Aggregate metrics and generate reports
 
@@ -68,9 +70,9 @@ The following diagram shows how Magpie orchestrates the benchmark pipeline.
 │                      ▼                 ▼                            │
 │  ┌────────────────────────┐  ┌─────────────────────────────────┐    │
 │  │  Gap Analysis          │  │  TraceLens Analysis             │    │
-│  │  • Time window filter  │  │  • Perf report (per-rank)       │    │
-│  │  • Category filter     │  │  • Multi-rank collective report │    │
-│  │  • Kernel stats CSV    │  │                                 │    │
+│  │  • Time window filter  │  │  • Inference stage reports      │    │
+│  │  • Category filter     │  │  • Simple roofline summaries    │    │
+│  │  • Kernel stats CSV    │  │  • Legacy per-rank reports      │    │
 │  └────────────────────────┘  └─────────────────────────────────┘    │
 └─────────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -146,7 +146,13 @@ traces.
 
 Magpie launches the benchmark, collects throughput and latency metrics, and (for
 the TraceLens config) produces a trace analysis report under the benchmark
-workspace in `./results`. See [Benchmark frameworks with Magpie](../how-to/benchmarking/benchmark.md) for
+workspace in `./results`. In TraceLens inference mode, the full per-stage CSVs
+are written under `tracelens/prefilldecode/`, `tracelens/decode_only/`, and
+`tracelens/prefill_only/` when those stages are available. Magpie also writes
+compact review files such as `tracelens/decode_only_kernel_roofline_simple.csv`
+and `tracelens/prefilldecode_kernel_roofline_simple.csv`; sort them by
+`kernel_time_ms_sum` or `time_pct` to find the dominant operations quickly.
+See [Benchmark frameworks with Magpie](../how-to/benchmarking/benchmark.md) for
 the full result layout and metric descriptions.
 
 ## Standalone gap analysis on existing traces

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -149,9 +149,11 @@ the TraceLens config) produces a trace analysis report under the benchmark
 workspace in `./results`. In TraceLens inference mode, the full per-stage CSVs
 are written under `tracelens/prefilldecode/`, `tracelens/decode_only/`, and
 `tracelens/prefill_only/` when those stages are available. Magpie also writes
-compact review files such as `tracelens/decode_only_kernel_roofline_simple.csv`
-and `tracelens/prefilldecode_kernel_roofline_simple.csv`; sort them by
-`kernel_time_ms_sum` or `time_pct` to find the dominant operations quickly.
+compact review files such as
+`tracelens/decode_only_ISL1024_OSL1024_CONC64_kernel_roofline_simple.csv` and
+`tracelens/prefilldecode_ISL1024_OSL1024_CONC64_kernel_roofline_simple.csv`;
+sort them by `kernel_time_ms_sum` or `time_pct` to find the dominant operations
+quickly.
 See [Benchmark frameworks with Magpie](../how-to/benchmarking/benchmark.md) for
 the full result layout and metric descriptions.
 

--- a/docs/how-to/benchmarking/benchmark.md
+++ b/docs/how-to/benchmarking/benchmark.md
@@ -83,13 +83,22 @@ results/benchmark_vllm_<timestamp>/
 │   ├── gap_analysis_rank0.csv # Per-rank kernel stats
 │   ├── gap_analysis_rank1.csv
 │   └── ...
-├── tracelens_rank0_csvs/      # Single-rank TraceLens analysis
-│   ├── gpu_timeline.csv
-│   ├── ops_summary.csv
-│   └── ...
-└── tracelens_collective_csvs/ # Multi-rank TraceLens analysis
-    └── ...
+├── tracelens/                 # TraceLens inference reports (if enabled)
+│   ├── prefilldecode/         # Full TraceLens CSVs for mixed prefill+decode
+│   ├── decode_only/           # Full TraceLens CSVs for decode
+│   ├── prefill_only/          # Full TraceLens CSVs for prefill, when available
+│   ├── prefilldecode_kernel_roofline_simple.csv
+│   ├── decode_only_kernel_roofline_simple.csv
+│   └── prefill_only_kernel_roofline_simple.csv
+├── tracelens_rank0_csvs/      # Legacy/direct PyTorch single-rank report
+└── tracelens_collective_csvs/ # Legacy/direct PyTorch multi-rank collective report
 ```
+
+For TraceLens inference runs, the `*_kernel_roofline_simple.csv` files are the
+fastest starting point for review. Each file covers one inference stage, keeps
+the most important roofline and timing columns, and includes both a compact
+`param_signature` and machine-readable `params_json` for matched TraceLens
+`param:*` metadata.
 
 ## Benchmark report
 

--- a/docs/how-to/benchmarking/benchmark.md
+++ b/docs/how-to/benchmarking/benchmark.md
@@ -87,18 +87,19 @@ results/benchmark_vllm_<timestamp>/
 │   ├── prefilldecode/         # Full TraceLens CSVs for mixed prefill+decode
 │   ├── decode_only/           # Full TraceLens CSVs for decode
 │   ├── prefill_only/          # Full TraceLens CSVs for prefill, when available
-│   ├── prefilldecode_kernel_roofline_simple.csv
-│   ├── decode_only_kernel_roofline_simple.csv
-│   └── prefill_only_kernel_roofline_simple.csv
+│   ├── prefilldecode_ISL1024_OSL1024_CONC64_kernel_roofline_simple.csv
+│   ├── decode_only_ISL1024_OSL1024_CONC64_kernel_roofline_simple.csv
+│   └── prefill_only_ISL1024_OSL1024_CONC64_kernel_roofline_simple.csv
 ├── tracelens_rank0_csvs/      # Legacy/direct PyTorch single-rank report
 └── tracelens_collective_csvs/ # Legacy/direct PyTorch multi-rank collective report
 ```
 
-For TraceLens inference runs, the `*_kernel_roofline_simple.csv` files are the
-fastest starting point for review. Each file covers one inference stage, keeps
-the most important roofline and timing columns, and includes both a compact
-`param_signature` and machine-readable `params_json` for matched TraceLens
-`param:*` metadata.
+For TraceLens inference runs, the
+`*_ISL*_OSL*_CONC*_kernel_roofline_simple.csv` files are the fastest starting
+point for review. Each file covers one inference stage, encodes the benchmark
+`ISL`, `OSL`, and `CONC` values in the filename, keeps the most important
+roofline and timing columns, and includes both a compact `param_signature` and
+machine-readable `params_json` for matched TraceLens `param:*` metadata.
 
 ## Benchmark report
 

--- a/docs/how-to/benchmarking/profiling-options.md
+++ b/docs/how-to/benchmarking/profiling-options.md
@@ -30,7 +30,7 @@ TraceLens provides automated analysis of torch profiler traces:
 | Command | Description | Output |
 |---------|-------------|--------|
 | `TraceLens_`<br>`split_`<br>`inference`<br>`_trace` | Split vLLM/SGLang inference traces into phase windows | `torch_trace/trace_split/` |
-| `TraceLens_`<br>`generate_perf`<br>`_report_pytorch`<br>`_inference` | Inference-aware prefill/decode reports | `tracelens/` |
+| `TraceLens_`<br>`generate_perf`<br>`_report_pytorch`<br>`_inference` | Inference-aware prefill/decode reports and compact roofline summaries | `tracelens/` |
 | `TraceLens_`<br>`generate_perf`<br>`_report_pytorch` | Single-rank performance report | `tracelens_rank0_csvs/` |
 | `TraceLens_`<br>`generate_multi`<br>`_rank_collective`<br>`_report_pytorch` | Multi-rank collective analysis | `tracelens_collective_csvs/` |
 
@@ -115,6 +115,54 @@ TraceLens writes results into the following directories under the benchmark work
 - `prefilldecode/` - Mixed prefill+decode phase report
 - `decode_only/` - Pure decode phase report
 - `prefill_only/` - Pure prefill phase report
+- `prefilldecode_kernel_roofline_simple.csv` - Compact roofline summary for the mixed phase
+- `decode_only_kernel_roofline_simple.csv` - Compact roofline summary for decode
+- `prefill_only_kernel_roofline_simple.csv` - Compact roofline summary for prefill, when a prefill trace is available
+
+TraceLens inference mode runs this post-processing flow:
+
+1. Capture torch profiler traces during the benchmark run.
+2. Split the rank-0 trace into representative inference phase windows under `torch_trace/trace_split/`.
+3. Run TraceLens perf reports for the configured `analysis_stages`.
+4. Write the full TraceLens CSV set into one subdirectory per stage.
+5. Write one stage-level `*_kernel_roofline_simple.csv` file in the `tracelens/` root.
+
+The simple roofline files are intended as the first file to open when reviewing
+TraceLens output. They keep the most useful roofline and timing columns from
+`unified_perf_summary.csv` and add matched `param:*` metadata from the
+category-specific TraceLens CSVs. The stage is encoded in the filename, so the
+CSV itself does not include a `stage` column.
+
+Simple roofline columns:
+
+| Column | Meaning |
+|--------|---------|
+| `source_category` | TraceLens op category, such as `GEMM`, `MoE_unfused`, or `InferenceAttention` |
+| `op_name` | Operation or pseudo-op name |
+| `param_signature` | Human-readable parameter summary from category CSV `param:*` columns |
+| `operation_count` | Number of operation instances aggregated into this row |
+| `num_kernels` | Number of GPU kernels associated with the matched category row, when available |
+| `kernel_time_ms_sum` | Total kernel time for the row, converted from microseconds to milliseconds |
+| `time_pct` | Percent of total kernel time in the current stage |
+| `kernel_time_us_mean` | Mean kernel time per operation instance, in microseconds |
+| `gflops` | Estimated operation work in GFLOPs |
+| `data_moved_mb` | Estimated data movement in MB |
+| `arithmetic_intensity_flops_per_byte` | Arithmetic intensity, the roofline x-axis |
+| `achieved_tflops_mean` | Mean achieved compute throughput in TFLOP/s |
+| `achieved_tbps_mean` | Mean achieved memory bandwidth in TB/s |
+| `compute_spec` | Compute capability/model used by TraceLens, for example `matrix_bf16` or `matrix_fp4` |
+| `roofline_bound` | TraceLens roofline classification, such as `COMPUTE_BOUND` or `MEMORY_BOUND` |
+| `pct_roofline_mean` | Mean percentage of the modeled roofline achieved |
+| `roofline_time_us` | Modeled roofline time in microseconds |
+| `has_perf_model` | Whether TraceLens had a performance model for the row |
+| `params_json` | Machine-readable JSON copy of the matched params |
+| `input_dims` | Input shapes recorded by TraceLens |
+| `input_type` | Input dtypes/types recorded by TraceLens |
+
+Sort the simple CSV by `kernel_time_ms_sum` or `time_pct` to find the dominant
+operations first, then use `roofline_bound`, arithmetic intensity, achieved
+TFLOP/s, achieved TB/s, and `pct_roofline_mean` to decide whether to investigate
+compute efficiency, memory traffic, or missing performance-model coverage.
 
 **Single-rank report (`tracelens_rank0_csvs/`):**
 - `gpu_timeline.csv` - GPU kernel timeline
@@ -173,4 +221,3 @@ python -m Magpie benchmark \
 The `--trace-dir` argument accepts either a benchmark workspace directory (auto-detects `torch_trace/` inside) or a direct path to the trace directory.
 
 Output is written to a `gap_analysis/` subfolder under the trace directory's parent.
-

--- a/docs/how-to/benchmarking/profiling-options.md
+++ b/docs/how-to/benchmarking/profiling-options.md
@@ -115,9 +115,9 @@ TraceLens writes results into the following directories under the benchmark work
 - `prefilldecode/` - Mixed prefill+decode phase report
 - `decode_only/` - Pure decode phase report
 - `prefill_only/` - Pure prefill phase report
-- `prefilldecode_kernel_roofline_simple.csv` - Compact roofline summary for the mixed phase
-- `decode_only_kernel_roofline_simple.csv` - Compact roofline summary for decode
-- `prefill_only_kernel_roofline_simple.csv` - Compact roofline summary for prefill, when a prefill trace is available
+- `prefilldecode_ISL1024_OSL1024_CONC64_kernel_roofline_simple.csv` - Compact roofline summary for the mixed phase
+- `decode_only_ISL1024_OSL1024_CONC64_kernel_roofline_simple.csv` - Compact roofline summary for decode
+- `prefill_only_ISL1024_OSL1024_CONC64_kernel_roofline_simple.csv` - Compact roofline summary for prefill, when a prefill trace is available
 
 TraceLens inference mode runs this post-processing flow:
 
@@ -125,13 +125,14 @@ TraceLens inference mode runs this post-processing flow:
 2. Split the rank-0 trace into representative inference phase windows under `torch_trace/trace_split/`.
 3. Run TraceLens perf reports for the configured `analysis_stages`.
 4. Write the full TraceLens CSV set into one subdirectory per stage.
-5. Write one stage-level `*_kernel_roofline_simple.csv` file in the `tracelens/` root.
+5. Write one stage-level `*_ISL*_OSL*_CONC*_kernel_roofline_simple.csv` file in the `tracelens/` root.
 
 The simple roofline files are intended as the first file to open when reviewing
 TraceLens output. They keep the most useful roofline and timing columns from
 `unified_perf_summary.csv` and add matched `param:*` metadata from the
-category-specific TraceLens CSVs. The stage is encoded in the filename, so the
-CSV itself does not include a `stage` column.
+category-specific TraceLens CSVs. The stage and benchmark `ISL`, `OSL`, and
+`CONC` values are encoded in the filename, so the CSV itself does not include a
+`stage` column.
 
 Simple roofline columns:
 

--- a/docs/reference/benchmark-config.md
+++ b/docs/reference/benchmark-config.md
@@ -225,7 +225,9 @@ achieved TB/s, roofline bound, and percent of roofline. The filename records
 the benchmark `ISL`, `OSL`, and `CONC` values. Magpie passes
 `gpu_arch_config` to the inference CLI as `--gpu_arch_json_path`; when it is
 not configured, architecture-dependent roofline columns are omitted from the
-simple summary.
+simple summary. When both the auto-detected `--gpu_arch_platform` and an
+explicit `--gpu_arch_json_path` are passed, TraceLens gives the JSON file
+priority.
 
 ### SGLang benchmark
 

--- a/docs/reference/benchmark-config.md
+++ b/docs/reference/benchmark-config.md
@@ -205,6 +205,24 @@ benchmark:
   timeout_seconds: 7200
 ```
 
+When `profiler.tracelens.analysis_mode: inference` is enabled, Magpie writes
+the full TraceLens CSV reports under stage subdirectories such as
+`tracelens/prefilldecode/`, `tracelens/decode_only/`, and
+`tracelens/prefill_only/`. It also creates one compact roofline review file per
+stage in the `tracelens/` root:
+
+```text
+tracelens/prefilldecode_kernel_roofline_simple.csv
+tracelens/decode_only_kernel_roofline_simple.csv
+tracelens/prefill_only_kernel_roofline_simple.csv
+```
+
+These simple files are generated from each stage's `unified_perf_summary.csv`
+and category-specific `param:*` CSVs. They are designed for quick review and
+include operation category, operation name, `param_signature`, `params_json`,
+kernel time, total time percentage, arithmetic intensity, achieved TFLOP/s,
+achieved TB/s, roofline bound, and percent of roofline.
+
 ### SGLang benchmark
 
 Basic SGLang benchmark with torch profiler enabled:

--- a/docs/reference/benchmark-config.md
+++ b/docs/reference/benchmark-config.md
@@ -80,7 +80,7 @@ benchmark:
       export_format: csv            # "csv" or "excel"
       perf_report_enabled: true           # Single-rank performance report
       multi_rank_report_enabled: true     # Multi-rank collective report
-      gpu_arch_config: null         # Optional: GPU arch config for roofline
+      gpu_arch_config: null         # Optional: GPU arch JSON passed to TraceLens
 
   # Gap analysis (kernel bottleneck report)
   gap_analysis:
@@ -222,7 +222,10 @@ and category-specific `param:*` CSVs. They are designed for quick review and
 include operation category, operation name, `param_signature`, `params_json`,
 kernel time, total time percentage, arithmetic intensity, achieved TFLOP/s,
 achieved TB/s, roofline bound, and percent of roofline. The filename records
-the benchmark `ISL`, `OSL`, and `CONC` values.
+the benchmark `ISL`, `OSL`, and `CONC` values. Magpie passes
+`gpu_arch_config` to the inference CLI as `--gpu_arch_json_path`; when it is
+not configured, architecture-dependent roofline columns are omitted from the
+simple summary.
 
 ### SGLang benchmark
 

--- a/docs/reference/benchmark-config.md
+++ b/docs/reference/benchmark-config.md
@@ -212,16 +212,17 @@ the full TraceLens CSV reports under stage subdirectories such as
 stage in the `tracelens/` root:
 
 ```text
-tracelens/prefilldecode_kernel_roofline_simple.csv
-tracelens/decode_only_kernel_roofline_simple.csv
-tracelens/prefill_only_kernel_roofline_simple.csv
+tracelens/prefilldecode_ISL1024_OSL1024_CONC64_kernel_roofline_simple.csv
+tracelens/decode_only_ISL1024_OSL1024_CONC64_kernel_roofline_simple.csv
+tracelens/prefill_only_ISL1024_OSL1024_CONC64_kernel_roofline_simple.csv
 ```
 
 These simple files are generated from each stage's `unified_perf_summary.csv`
 and category-specific `param:*` CSVs. They are designed for quick review and
 include operation category, operation name, `param_signature`, `params_json`,
 kernel time, total time percentage, arithmetic intensity, achieved TFLOP/s,
-achieved TB/s, roofline bound, and percent of roofline.
+achieved TB/s, roofline bound, and percent of roofline. The filename records
+the benchmark `ISL`, `OSL`, and `CONC` values.
 
 ### SGLang benchmark
 

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -77,6 +77,8 @@ The following profiling and trace analysis capabilities are included.
   (NVIDIA), and IntelliKit Metrix.
 - Optional correctness validation using a testcase or IntelliKit Accordo.
 - TraceLens integration for performance trace analysis.
+- TraceLens inference runs emit per-stage simple roofline summary CSVs for
+  quick kernel/op review.
 - Kernel-level gap analysis from torch profiler traces, including a standalone
   mode that runs on existing traces.
 - Kernel source finder to locate kernel source files and test commands for AMD

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -43,7 +43,7 @@ The following errors are frequently reported in benchmark mode.
 |-------|----------|
 | `ValueError: Free memory on device (...) is less than desired GPU memory utilization` | Reduce `GPU_MEM_UTIL` in config (for example, `0.85`). |
 | `docker: permission denied` | Add your user to the docker group or run with sudo. |
-| `Required TraceLens inference CLI command(s) not found on PATH` | Applies to `run_mode: local` or classic host post-processing. TraceLens auto-installs on first run. If issues persist, run: `pip install git+https://github.com/AMD-AIG-AIMA/TraceLens.git`. If `TL_EXTENSION=TraceLens_NDA` is set, install the matching internal extension package. For `run_mode: docker`, commands are resolved from the runtime image. |
+| `Required TraceLens inference CLI command(s) not found on PATH` | Applies to `run_mode: local` or classic host post-processing. TraceLens auto-installs on first run. If issues persist, run: `pip install git+https://github.com/AMD-AGI/TraceLens.git`. If `TL_EXTENSION=TraceLens_NDA` is set, install the matching internal extension package. For `run_mode: docker`, commands are resolved from the runtime image. |
 | Timeout during model loading | Large models (for example, DeepSeek-R1) might need longer timeouts. Set `timeout_seconds: 7200` in your benchmark config. |
 | `gpu_selection.auto failed: ...` | Not enough idle GPUs on the host. Free a GPU, lower `gpu_selection.min_free_memory_gb`, narrow `gpu_selection.candidates`, or pin manually using `envs.ROCR_VISIBLE_DEVICES` (AMD) or `envs.CUDA_VISIBLE_DEVICES` (NVIDIA). See [Automatic GPU selection in Magpie's benchmark mode](../how-to/benchmarking/automatic-gpu.md). |
 

--- a/examples/benchmarks/benchmark_vllm_tracelens.yaml
+++ b/examples/benchmarks/benchmark_vllm_tracelens.yaml
@@ -8,6 +8,9 @@
 # Output:
 #   - Torch profiler traces: results/benchmark_vllm_<timestamp>/torch_trace/
 #   - TraceLens CSV reports: results/benchmark_vllm_<timestamp>/tracelens/
+#   - Simple roofline summaries:
+#       results/benchmark_vllm_<timestamp>/tracelens/decode_only_kernel_roofline_simple.csv
+#       results/benchmark_vllm_<timestamp>/tracelens/prefilldecode_kernel_roofline_simple.csv
 #
 # Note: 
 #   - num_prompts = CONC * 10 (hardcoded in script), so CONC=4 gives 40 prompts

--- a/examples/benchmarks/benchmark_vllm_tracelens.yaml
+++ b/examples/benchmarks/benchmark_vllm_tracelens.yaml
@@ -9,8 +9,8 @@
 #   - Torch profiler traces: results/benchmark_vllm_<timestamp>/torch_trace/
 #   - TraceLens CSV reports: results/benchmark_vllm_<timestamp>/tracelens/
 #   - Simple roofline summaries:
-#       results/benchmark_vllm_<timestamp>/tracelens/decode_only_kernel_roofline_simple.csv
-#       results/benchmark_vllm_<timestamp>/tracelens/prefilldecode_kernel_roofline_simple.csv
+#       results/benchmark_vllm_<timestamp>/tracelens/decode_only_ISL128_OSL128_CONC4_kernel_roofline_simple.csv
+#       results/benchmark_vllm_<timestamp>/tracelens/prefilldecode_ISL128_OSL128_CONC4_kernel_roofline_simple.csv
 #
 # Note: 
 #   - num_prompts = CONC * 10 (hardcoded in script), so CONC=4 gives 40 prompts

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -558,6 +558,8 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
     monkeypatch,
 ):
     workspace = tmp_path / "workspace"
+    gpu_arch_config = tmp_path / "mi355x.json"
+    gpu_arch_config.write_text('{"mem_bw_gbps": 8000}', encoding="utf-8")
     torch_trace_dir = workspace / "torch_trace"
     capture_dir = torch_trace_dir / "capture_traces"
     capture_dir.mkdir(parents=True)
@@ -589,6 +591,7 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
                 "tracelens": {
                     "enabled": True,
                     "analysis_stages": ["decode"],
+                    "gpu_arch_config": str(gpu_arch_config),
                 }
             },
         }
@@ -760,6 +763,13 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
         for cmd in docker_cmds
     )
     assert any("TL_EXTENSION=TraceLens_NDA" in cmd for cmd in docker_cmds)
+    assert any(
+        "--gpu_arch_json_path /workspace/tracelens/mi355x.json" in cmd[-1]
+        for cmd in docker_cmds
+    )
+    assert (workspace / "tracelens" / "mi355x.json").read_text(
+        encoding="utf-8"
+    ) == gpu_arch_config.read_text(encoding="utf-8")
 
     rows = list(
         csv.DictReader(
@@ -822,6 +832,53 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
             "input_type": "['bf16', 'bf16']",
         }
     ]
+
+
+def test_tracelens_simple_summary_omits_arch_columns_without_arch_json(tmp_path):
+    output_dir = tmp_path / "tracelens" / "decode_only"
+    output_dir.mkdir(parents=True)
+    with (output_dir / "unified_perf_summary.csv").open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "name",
+                "op category",
+                "operation_count",
+                "Kernel Time (µs)_sum",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "name": "aten::add",
+                "op category": "ELEMENTWISE",
+                "operation_count": "3",
+                "Kernel Time (µs)_sum": "250",
+            }
+        )
+
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "vllm",
+            "model": "demo",
+            "profiler": {"tracelens": {"enabled": True}},
+        }
+    )
+    summary = TraceLensInferencePipeline(cfg)._write_simple_roofline_summary(
+        "decode",
+        output_dir,
+    )
+
+    assert summary is not None
+    reader = csv.DictReader(summary.open())
+    assert "roofline_bound" not in reader.fieldnames
+    assert "pct_roofline_mean" not in reader.fieldnames
+    assert "roofline_time_us" not in reader.fieldnames
+    assert list(reader)[0]["kernel_time_ms_sum"] == "0.25"
 
 
 def test_benchmark_mode_uses_container_for_docker_tracelens_inference(tmp_path):

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -579,6 +579,7 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
             "run_mode": "docker",
             "docker_image": "tracelens-sglang:0.5.12-mi355-fix",
             "envs": {
+                "ISL": 8192,
                 "CONC": 64,
                 "OSL": 1024,
                 "RANDOM_RANGE_RATIO": 1,
@@ -740,7 +741,11 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
     assert str(workspace / "tracelens" / "decode_only" / "summary.csv") in result[
         "output_files"
     ]
-    simple_summary = workspace / "tracelens" / "decode_only_kernel_roofline_simple.csv"
+    simple_summary = (
+        workspace
+        / "tracelens"
+        / "decode_only_ISL8192_OSL1024_CONC64_kernel_roofline_simple.csv"
+    )
     assert str(simple_summary) in result["output_files"]
     assert result["stage_results"]["decode"]["simple_summary_file"] == str(
         simple_summary

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -640,6 +640,84 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
                 "name,value\nok,1\n",
                 encoding="utf-8",
             )
+            with (out_dir / "unified_perf_summary.csv").open(
+                "w",
+                newline="",
+                encoding="utf-8",
+            ) as handle:
+                writer = csv.DictWriter(
+                    handle,
+                    fieldnames=[
+                        "name",
+                        "op category",
+                        "operation_count",
+                        "Kernel Time (µs)_sum",
+                        "Percentage (%)",
+                        "Kernel Time (µs)_mean",
+                        "GFLOPS",
+                        "Data Moved (MB)",
+                        "FLOPS/Byte",
+                        "TFLOPS/s_mean",
+                        "TB/s_mean",
+                        "Compute Spec",
+                        "Roofline Bound",
+                        "Pct Roofline_mean",
+                        "Roofline Time (µs)_first",
+                        "has_perf_model",
+                        "Input Dims",
+                        "Input type",
+                    ],
+                )
+                writer.writeheader()
+                writer.writerow(
+                    {
+                        "name": "vllm::rocm_unquantized_gemm",
+                        "op category": "GEMM",
+                        "operation_count": "61",
+                        "Kernel Time (µs)_sum": "1500",
+                        "Percentage (%)": "12.5",
+                        "Kernel Time (µs)_mean": "24.59",
+                        "GFLOPS": "1.25",
+                        "Data Moved (MB)": "32",
+                        "FLOPS/Byte": "40",
+                        "TFLOPS/s_mean": "100",
+                        "TB/s_mean": "2.5",
+                        "Compute Spec": "matrix_bf16",
+                        "Roofline Bound": "MEMORY_BOUND",
+                        "Pct Roofline_mean": "70",
+                        "Roofline Time (µs)_first": "20",
+                        "has_perf_model": "True",
+                        "Input Dims": "[[8192, 7168], [7168, 512]]",
+                        "Input type": "['bf16', 'bf16']",
+                    }
+                )
+            with (out_dir / "GEMM.csv").open(
+                "w",
+                newline="",
+                encoding="utf-8",
+            ) as handle:
+                writer = csv.DictWriter(
+                    handle,
+                    fieldnames=[
+                        "name",
+                        "param: M",
+                        "param: N",
+                        "param: K",
+                        "param: dtype_A_B",
+                        "num_kernels",
+                    ],
+                )
+                writer.writeheader()
+                writer.writerow(
+                    {
+                        "name": "vllm::rocm_unquantized_gemm",
+                        "param: M": "8192",
+                        "param: N": "512",
+                        "param: K": "7168",
+                        "param: dtype_A_B": "bf16",
+                        "num_kernels": "2",
+                    }
+                )
         return subprocess.CompletedProcess(cmd, 0, "", "")
 
     monkeypatch.setattr(
@@ -662,6 +740,11 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
     assert str(workspace / "tracelens" / "decode_only" / "summary.csv") in result[
         "output_files"
     ]
+    simple_summary = workspace / "tracelens" / "decode_only_kernel_roofline_simple.csv"
+    assert str(simple_summary) in result["output_files"]
+    assert result["stage_results"]["decode"]["simple_summary_file"] == str(
+        simple_summary
+    )
     assert len(docker_cmds) == 2
     assert all(
         cmd[:5] == ["docker", "run", "--rm", "--network", "none"]
@@ -681,6 +764,59 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
     assert rows[0]["output_path"] == str(
         torch_trace_dir / "trace_split" / "decode.trace.json.gz"
     )
+
+    simple_reader = csv.DictReader(simple_summary.open())
+    assert simple_reader.fieldnames == [
+        "source_category",
+        "op_name",
+        "param_signature",
+        "operation_count",
+        "num_kernels",
+        "kernel_time_ms_sum",
+        "time_pct",
+        "kernel_time_us_mean",
+        "gflops",
+        "data_moved_mb",
+        "arithmetic_intensity_flops_per_byte",
+        "achieved_tflops_mean",
+        "achieved_tbps_mean",
+        "compute_spec",
+        "roofline_bound",
+        "pct_roofline_mean",
+        "roofline_time_us",
+        "has_perf_model",
+        "params_json",
+        "input_dims",
+        "input_type",
+    ]
+    simple_rows = list(simple_reader)
+    assert simple_rows == [
+        {
+            "source_category": "GEMM",
+            "op_name": "vllm::rocm_unquantized_gemm",
+            "param_signature": "M=8192,N=512,K=7168,dtype_A_B=bf16",
+            "operation_count": "61",
+            "num_kernels": "2",
+            "kernel_time_ms_sum": "1.5",
+            "time_pct": "12.5",
+            "kernel_time_us_mean": "24.59",
+            "gflops": "1.25",
+            "data_moved_mb": "32",
+            "arithmetic_intensity_flops_per_byte": "40",
+            "achieved_tflops_mean": "100",
+            "achieved_tbps_mean": "2.5",
+            "compute_spec": "matrix_bf16",
+            "roofline_bound": "MEMORY_BOUND",
+            "pct_roofline_mean": "70",
+            "roofline_time_us": "20",
+            "has_perf_model": "True",
+            "params_json": (
+                '{"K":"7168","M":"8192","N":"512","dtype_A_B":"bf16"}'
+            ),
+            "input_dims": "[[8192, 7168], [7168, 512]]",
+            "input_type": "['bf16', 'bf16']",
+        }
+    ]
 
 
 def test_benchmark_mode_uses_container_for_docker_tracelens_inference(tmp_path):


### PR DESCRIPTION
## Summary

- Add per-stage TraceLens simple roofline summary CSV generation for inference postprocessing
- Include matched `param:*` metadata as both `param_signature` and `params_json`
- Include benchmark `ISL`, `OSL`, and `CONC` values in simple summary filenames
- Document the new TraceLens inference review flow and output files

## Details

TraceLens inference reports now emit compact review files under the benchmark workspace `tracelens/` root, alongside the full per-stage report directories:

- `decode_only_ISL<value>_OSL<value>_CONC<value>_kernel_roofline_simple.csv`
- `prefilldecode_ISL<value>_OSL<value>_CONC<value>_kernel_roofline_simple.csv`
- `prefill_only_ISL<value>_OSL<value>_CONC<value>_kernel_roofline_simple.csv`

Each file keeps the key roofline/timing fields from `unified_perf_summary.csv` and enriches rows with parameters from category-specific TraceLens CSVs.

## Testing

```bash
pytest tests/test_benchmark_support.py
```
Result:
52 passed