### PR TITLE
Make TraceLens patch support dynamic

### DIFF
--- a/Magpie/modes/benchmark/tracelens_runtime.py
+++ b/Magpie/modes/benchmark/tracelens_runtime.py
@@ -27,8 +27,8 @@ logger = logging.getLogger(__name__)
 
 
 TRACELENS_INFERENCE_WORKFLOW = Path("examples/custom_workflows/inference_analysis")
-SUPPORTED_SGLANG_PATCH_VERSIONS = ("0.5.9", "0.5.11", "0.5.12")
-SUPPORTED_VLLM_PATCH_VERSIONS = tuple(range(14, 22))
+SGLANG_PATCH_ROOT = TRACELENS_INFERENCE_WORKFLOW / "sglang_roofline_patches"
+VLLM_PATCH_DIR = TRACELENS_INFERENCE_WORKFLOW / "vllm_patches"
 
 
 def is_tracelens_ready_runtime_image(framework: str, image_name: Optional[str]) -> bool:
@@ -40,26 +40,151 @@ def is_tracelens_ready_runtime_image(framework: str, image_name: Optional[str]) 
     return "tracelens" in lowered and framework.lower() in lowered
 
 
-def infer_sglang_patch_version(image_name: str) -> Optional[str]:
-    """Infer supported TraceLens SGLang patch version from an image tag."""
-    lowered = image_name.lower()
-    for version in SUPPORTED_SGLANG_PATCH_VERSIONS:
-        if version in lowered:
-            return version
-    return None
+def _version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", version))
 
 
-def infer_vllm_patch_version(image_name: str) -> Optional[str]:
-    """Infer TraceLens vLLM patch shorthand such as v19 from an image tag."""
+def _sort_semver_versions(versions: set[str]) -> list[str]:
+    return sorted(versions, key=_version_key)
+
+
+def available_tracelens_sglang_patch_versions(tracelens_repo: Path) -> list[str]:
+    """Return SGLang versions supported by the selected TraceLens checkout."""
+    workflow_dir = tracelens_repo / TRACELENS_INFERENCE_WORKFLOW
+    patch_root = tracelens_repo / SGLANG_PATCH_ROOT
+
+    patch_versions = {
+        match.group(1).replace("_", ".")
+        for patch_dir in patch_root.glob("sglang_*")
+        if patch_dir.is_dir()
+        and (match := re.match(r"sglang_((?:\d+_)+\d+)$", patch_dir.name))
+    }
+
+    build_script = workflow_dir / "build_docker_sglang.sh"
+    if not build_script.is_file():
+        return []
+
+    script_versions = {
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\d+(?:\.\d+)+)(?:[)|])",
+            build_script.read_text(encoding="utf-8", errors="replace"),
+            re.MULTILINE,
+        )
+    }
+
+    return _sort_semver_versions(patch_versions & script_versions)
+
+
+def infer_sglang_patch_version(
+    image_name: str,
+    tracelens_repo: Optional[Path] = None,
+) -> Optional[str]:
+    """Infer TraceLens SGLang patch version from an image tag."""
     lowered = image_name.lower()
-    match = re.search(r"(?:^|[^0-9])v?0\.(1[4-9]|2[0-1])(?:\.\d+)?", lowered)
+    match = re.search(r"(?:^|[^0-9])v?(\d+\.\d+\.\d+)(?:[^0-9]|$)", lowered)
     if not match:
         return None
 
-    minor = int(match.group(1))
-    if minor not in SUPPORTED_VLLM_PATCH_VERSIONS:
+    patch_version = match.group(1)
+    if (
+        tracelens_repo is not None
+        and patch_version
+        not in available_tracelens_sglang_patch_versions(tracelens_repo)
+    ):
         return None
-    return f"v{minor}"
+    return patch_version
+
+
+def _sort_vllm_patch_versions(versions: set[str]) -> list[str]:
+    return sorted(versions, key=lambda version: int(version.removeprefix("v")))
+
+
+def available_tracelens_vllm_patch_versions(tracelens_repo: Path) -> list[str]:
+    """Return vLLM versions supported by the selected TraceLens checkout."""
+    workflow_dir = tracelens_repo / TRACELENS_INFERENCE_WORKFLOW
+    patch_dir = tracelens_repo / VLLM_PATCH_DIR
+
+    patch_versions = {
+        f"v{match.group(1)}"
+        for patch_file in patch_dir.glob("config_vllm_v0.*.0.patch")
+        if (match := re.match(r"config_vllm_v0\.(\d+)\.0\.patch$", patch_file.name))
+    }
+
+    build_script = workflow_dir / "build_docker_vllm.sh"
+    if not build_script.is_file():
+        return []
+
+    script_versions = {
+        f"v{match.group(1)}"
+        for match in re.finditer(
+            r"^\s*v(\d+)\)",
+            build_script.read_text(encoding="utf-8", errors="replace"),
+            re.MULTILINE,
+        )
+    }
+
+    return _sort_vllm_patch_versions(patch_versions & script_versions)
+
+
+def infer_vllm_patch_version(
+    image_name: str,
+    tracelens_repo: Optional[Path] = None,
+) -> Optional[str]:
+    """Infer TraceLens vLLM patch shorthand such as v19 from an image tag."""
+    lowered = image_name.lower()
+    match = re.search(r"(?:^|[^0-9])v?0\.(\d+)(?:\.\d+)?", lowered)
+    if not match:
+        return None
+
+    patch_version = f"v{int(match.group(1))}"
+    if (
+        tracelens_repo is not None
+        and patch_version not in available_tracelens_vllm_patch_versions(tracelens_repo)
+    ):
+        return None
+    return patch_version
+
+
+def _vllm_patch_error(base_image: str, tracelens_repo: Path) -> str:
+    inferred = infer_vllm_patch_version(base_image)
+    if inferred is None:
+        return (
+            "TraceLens auto_patch_runtime cannot infer a vLLM version from "
+            f"image {base_image!r}. Set docker_image to a versioned official "
+            "vLLM tag, use a TraceLens-ready image, or set "
+            "auto_patch_runtime=false."
+        )
+
+    supported = available_tracelens_vllm_patch_versions(tracelens_repo)
+    supported_text = ", ".join(supported) if supported else "none found"
+    return (
+        "TraceLens auto_patch_runtime cannot find matching TraceLens support "
+        f"for vLLM {inferred} from image {base_image!r}. Available vLLM patch "
+        f"versions in {tracelens_repo}: {supported_text}. Update TraceLens, "
+        "use a TraceLens-ready image, or set auto_patch_runtime=false."
+    )
+
+
+def _sglang_patch_error(base_image: str, tracelens_repo: Path) -> str:
+    inferred = infer_sglang_patch_version(base_image)
+    if inferred is None:
+        return (
+            "TraceLens auto_patch_runtime cannot infer an SGLang version from "
+            f"image {base_image!r}. Set docker_image to a versioned official "
+            "SGLang tag, use a TraceLens-ready image, or set "
+            "auto_patch_runtime=false."
+        )
+
+    supported = available_tracelens_sglang_patch_versions(tracelens_repo)
+    supported_text = ", ".join(supported) if supported else "none found"
+    return (
+        "TraceLens auto_patch_runtime cannot find matching TraceLens support "
+        f"for SGLang {inferred} from image {base_image!r}. Available SGLang "
+        f"patch versions in {tracelens_repo}: {supported_text}. Update "
+        "TraceLens, use a TraceLens-ready image, or set "
+        "auto_patch_runtime=false."
+    )
 
 
 def runner_type_to_gpu_type(runner_type: str) -> str:
@@ -150,15 +275,9 @@ def _build_command(
 ) -> list[str]:
     workflow_dir = tracelens_repo / TRACELENS_INFERENCE_WORKFLOW
     if config.framework == "sglang":
-        patch_version = infer_sglang_patch_version(base_image)
+        patch_version = infer_sglang_patch_version(base_image, tracelens_repo)
         if patch_version is None:
-            raise RuntimeError(
-                "TraceLens auto_patch_runtime cannot infer a supported SGLang "
-                f"version from image {base_image!r}. Supported versions: "
-                f"{', '.join(SUPPORTED_SGLANG_PATCH_VERSIONS)}. Set docker_image "
-                "to a supported official SGLang tag, use a TraceLens-ready image, "
-                "or set auto_patch_runtime=false."
-            )
+            raise RuntimeError(_sglang_patch_error(base_image, tracelens_repo))
         return [
             "bash",
             str(workflow_dir / "build_docker_sglang.sh"),
@@ -174,15 +293,9 @@ def _build_command(
         ]
 
     if config.framework == "vllm":
-        patch_version = infer_vllm_patch_version(base_image)
+        patch_version = infer_vllm_patch_version(base_image, tracelens_repo)
         if patch_version is None:
-            raise RuntimeError(
-                "TraceLens auto_patch_runtime cannot infer a supported vLLM "
-                f"version from image {base_image!r}. Supported versions: "
-                "v0.14.x through v0.21.x. Set docker_image to a supported "
-                "official vLLM tag, use a TraceLens-ready image, or set "
-                "auto_patch_runtime=false."
-            )
+            raise RuntimeError(_vllm_patch_error(base_image, tracelens_repo))
         return [
             "bash",
             str(workflow_dir / "build_docker_vllm.sh"),
@@ -237,11 +350,16 @@ def prepare_tracelens_runtime_image(
 
     tracelens_repo = resolve_tracelens_repo_path(tl_config.tracelens_repo_path)
 
-    patch_version = (
-        infer_sglang_patch_version(base_image)
-        if config.framework == "sglang"
-        else infer_vllm_patch_version(base_image)
-    )
+    if config.framework == "sglang":
+        patch_version = infer_sglang_patch_version(base_image, tracelens_repo)
+        if patch_version is None:
+            raise RuntimeError(_sglang_patch_error(base_image, tracelens_repo))
+    elif config.framework == "vllm":
+        patch_version = infer_vllm_patch_version(base_image, tracelens_repo)
+        if patch_version is None:
+            raise RuntimeError(_vllm_patch_error(base_image, tracelens_repo))
+    else:
+        patch_version = None
     if patch_version is None:
         # Let _build_command raise the framework-specific error text.
         patch_version = "unknown"
@@ -301,6 +419,8 @@ def prepare_tracelens_runtime_image(
 
 
 __all__ = [
+    "available_tracelens_sglang_patch_versions",
+    "available_tracelens_vllm_patch_versions",
     "derive_tracelens_image_tag",
     "docker_image_exists",
     "infer_sglang_patch_version",

--- a/Magpie/modes/benchmark/tracelens_runtime.py
+++ b/Magpie/modes/benchmark/tracelens_runtime.py
@@ -29,6 +29,17 @@ logger = logging.getLogger(__name__)
 TRACELENS_INFERENCE_WORKFLOW = Path("examples/custom_workflows/inference_analysis")
 SGLANG_PATCH_ROOT = TRACELENS_INFERENCE_WORKFLOW / "sglang_roofline_patches"
 VLLM_PATCH_DIR = TRACELENS_INFERENCE_WORKFLOW / "vllm_patches"
+FRAMEWORK_PACKAGE_NAMES = {
+    "sglang": "sglang",
+    "vllm": "vllm",
+}
+
+PACKAGE_VERSION_SCRIPT = r"""
+import importlib.metadata as metadata
+import sys
+
+print(metadata.version(sys.argv[1]))
+"""
 
 
 def is_tracelens_ready_runtime_image(framework: str, image_name: Optional[str]) -> bool:
@@ -76,17 +87,29 @@ def available_tracelens_sglang_patch_versions(tracelens_repo: Path) -> list[str]
     return _sort_semver_versions(patch_versions & script_versions)
 
 
+def _parse_sglang_patch_version(version_text: str) -> Optional[str]:
+    match = re.search(r"(?:^|[^0-9])v?(\d+\.\d+\.\d+)(?:[^0-9]|$)", version_text)
+    if not match:
+        return None
+    return match.group(1)
+
+
 def infer_sglang_patch_version(
     image_name: str,
     tracelens_repo: Optional[Path] = None,
+    installed_version: Optional[str] = None,
 ) -> Optional[str]:
-    """Infer TraceLens SGLang patch version from an image tag."""
-    lowered = image_name.lower()
-    match = re.search(r"(?:^|[^0-9])v?(\d+\.\d+\.\d+)(?:[^0-9]|$)", lowered)
-    if not match:
+    """Infer TraceLens SGLang patch version from package version or image tag."""
+    patch_version = (
+        _parse_sglang_patch_version(installed_version)
+        if installed_version
+        else None
+    )
+    if patch_version is None:
+        patch_version = _parse_sglang_patch_version(image_name.lower())
+    if patch_version is None:
         return None
 
-    patch_version = match.group(1)
     if (
         tracelens_repo is not None
         and patch_version
@@ -127,17 +150,29 @@ def available_tracelens_vllm_patch_versions(tracelens_repo: Path) -> list[str]:
     return _sort_vllm_patch_versions(patch_versions & script_versions)
 
 
+def _parse_vllm_patch_version(version_text: str) -> Optional[str]:
+    match = re.search(r"(?:^|[^0-9])v?0\.(\d+)(?:\.\d+)?", version_text.lower())
+    if not match:
+        return None
+    return f"v{int(match.group(1))}"
+
+
 def infer_vllm_patch_version(
     image_name: str,
     tracelens_repo: Optional[Path] = None,
+    installed_version: Optional[str] = None,
 ) -> Optional[str]:
-    """Infer TraceLens vLLM patch shorthand such as v19 from an image tag."""
-    lowered = image_name.lower()
-    match = re.search(r"(?:^|[^0-9])v?0\.(\d+)(?:\.\d+)?", lowered)
-    if not match:
+    """Infer TraceLens vLLM patch shorthand such as v19."""
+    patch_version = (
+        _parse_vllm_patch_version(installed_version)
+        if installed_version
+        else None
+    )
+    if patch_version is None:
+        patch_version = _parse_vllm_patch_version(image_name)
+    if patch_version is None:
         return None
 
-    patch_version = f"v{int(match.group(1))}"
     if (
         tracelens_repo is not None
         and patch_version not in available_tracelens_vllm_patch_versions(tracelens_repo)
@@ -146,13 +181,19 @@ def infer_vllm_patch_version(
     return patch_version
 
 
-def _vllm_patch_error(base_image: str, tracelens_repo: Path) -> str:
-    inferred = infer_vllm_patch_version(base_image)
+def _vllm_patch_error(
+    base_image: str,
+    tracelens_repo: Path,
+    installed_version: Optional[str] = None,
+) -> str:
+    inferred = infer_vllm_patch_version(base_image, installed_version=installed_version)
     if inferred is None:
         return (
             "TraceLens auto_patch_runtime cannot infer a vLLM version from "
-            f"image {base_image!r}. Set docker_image to a versioned official "
-            "vLLM tag, use a TraceLens-ready image, or set "
+            f"image {base_image!r} or installed package version "
+            f"{installed_version!r}. Set docker_image to a versioned official "
+            "vLLM tag, use an image with vLLM installed, use a TraceLens-ready "
+            "image, or set "
             "auto_patch_runtime=false."
         )
 
@@ -166,13 +207,22 @@ def _vllm_patch_error(base_image: str, tracelens_repo: Path) -> str:
     )
 
 
-def _sglang_patch_error(base_image: str, tracelens_repo: Path) -> str:
-    inferred = infer_sglang_patch_version(base_image)
+def _sglang_patch_error(
+    base_image: str,
+    tracelens_repo: Path,
+    installed_version: Optional[str] = None,
+) -> str:
+    inferred = infer_sglang_patch_version(
+        base_image,
+        installed_version=installed_version,
+    )
     if inferred is None:
         return (
             "TraceLens auto_patch_runtime cannot infer an SGLang version from "
-            f"image {base_image!r}. Set docker_image to a versioned official "
-            "SGLang tag, use a TraceLens-ready image, or set "
+            f"image {base_image!r} or installed package version "
+            f"{installed_version!r}. Set docker_image to a versioned official "
+            "SGLang tag, use an image with SGLang installed, use a "
+            "TraceLens-ready image, or set "
             "auto_patch_runtime=false."
         )
 
@@ -266,18 +316,59 @@ def docker_image_exists(image_tag: str) -> bool:
     return proc.returncode == 0
 
 
+def docker_image_package_version(image_tag: str, package_name: str) -> Optional[str]:
+    """Read an installed Python package version from a Docker image."""
+    try:
+        proc = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--entrypoint",
+                "python3",
+                image_tag,
+                "-c",
+                PACKAGE_VERSION_SCRIPT,
+                package_name,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning(
+            "Could not read %s package version from Docker image %s: %s",
+            package_name,
+            image_tag,
+            exc,
+        )
+        return None
+
+    if proc.returncode == 0:
+        version = (proc.stdout or "").strip().splitlines()
+        if version:
+            return version[-1].strip()
+
+    logger.warning(
+        "Could not read %s package version from Docker image %s: %s",
+        package_name,
+        image_tag,
+        (proc.stderr or proc.stdout or "").strip()[-1000:],
+    )
+    return None
+
+
 def _build_command(
     config: BenchmarkConfig,
     base_image: str,
     runner_type: str,
     derived_image: str,
     tracelens_repo: Path,
+    patch_version: str,
 ) -> list[str]:
     workflow_dir = tracelens_repo / TRACELENS_INFERENCE_WORKFLOW
     if config.framework == "sglang":
-        patch_version = infer_sglang_patch_version(base_image, tracelens_repo)
-        if patch_version is None:
-            raise RuntimeError(_sglang_patch_error(base_image, tracelens_repo))
         return [
             "bash",
             str(workflow_dir / "build_docker_sglang.sh"),
@@ -293,9 +384,6 @@ def _build_command(
         ]
 
     if config.framework == "vllm":
-        patch_version = infer_vllm_patch_version(base_image, tracelens_repo)
-        if patch_version is None:
-            raise RuntimeError(_vllm_patch_error(base_image, tracelens_repo))
         return [
             "bash",
             str(workflow_dir / "build_docker_vllm.sh"),
@@ -349,15 +437,35 @@ def prepare_tracelens_runtime_image(
         return result
 
     tracelens_repo = resolve_tracelens_repo_path(tl_config.tracelens_repo_path)
+    package_name = FRAMEWORK_PACKAGE_NAMES.get(config.framework)
+    installed_version = (
+        docker_image_package_version(base_image, package_name)
+        if package_name
+        else None
+    )
+    if installed_version:
+        result["runtime_package_version"] = installed_version
 
     if config.framework == "sglang":
-        patch_version = infer_sglang_patch_version(base_image, tracelens_repo)
+        patch_version = infer_sglang_patch_version(
+            base_image,
+            tracelens_repo,
+            installed_version=installed_version,
+        )
         if patch_version is None:
-            raise RuntimeError(_sglang_patch_error(base_image, tracelens_repo))
+            raise RuntimeError(
+                _sglang_patch_error(base_image, tracelens_repo, installed_version)
+            )
     elif config.framework == "vllm":
-        patch_version = infer_vllm_patch_version(base_image, tracelens_repo)
+        patch_version = infer_vllm_patch_version(
+            base_image,
+            tracelens_repo,
+            installed_version=installed_version,
+        )
         if patch_version is None:
-            raise RuntimeError(_vllm_patch_error(base_image, tracelens_repo))
+            raise RuntimeError(
+                _vllm_patch_error(base_image, tracelens_repo, installed_version)
+            )
     else:
         patch_version = None
     if patch_version is None:
@@ -376,6 +484,7 @@ def prepare_tracelens_runtime_image(
             "image": derived_image,
             "tracelens_repo_path": str(tracelens_repo),
             "patch_version": patch_version,
+            "patch_version_source": "package" if installed_version else "image",
         }
     )
 
@@ -389,6 +498,7 @@ def prepare_tracelens_runtime_image(
         runner_type=runner_type,
         derived_image=derived_image,
         tracelens_repo=tracelens_repo,
+        patch_version=patch_version,
     )
     result["command"] = cmd
     result["skipped"] = False
@@ -422,6 +532,7 @@ __all__ = [
     "available_tracelens_sglang_patch_versions",
     "available_tracelens_vllm_patch_versions",
     "derive_tracelens_image_tag",
+    "docker_image_package_version",
     "docker_image_exists",
     "infer_sglang_patch_version",
     "infer_vllm_patch_version",

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -30,6 +30,7 @@ from Magpie.modes.benchmark.tracelens_runtime import (
     available_tracelens_sglang_patch_versions,
     available_tracelens_vllm_patch_versions,
     derive_tracelens_image_tag,
+    docker_image_package_version,
     infer_sglang_patch_version,
     infer_vllm_patch_version,
     is_tracelens_ready_runtime_image,
@@ -185,9 +186,23 @@ def test_tracelens_inference_iteration_and_arg_helpers():
 def test_tracelens_runtime_image_helpers():
     assert infer_sglang_patch_version("lmsysorg/sglang:v0.5.12-rocm720-mi35x") == "0.5.12"
     assert infer_sglang_patch_version("lmsysorg/sglang:v0.5.13-rocm720-mi35x") == "0.5.13"
+    assert (
+        infer_sglang_patch_version(
+            "internal/sglang:rocm",
+            installed_version="0.5.13+rocm720",
+        )
+        == "0.5.13"
+    )
     assert infer_sglang_patch_version("lmsysorg/sglang:latest") is None
     assert infer_vllm_patch_version("vllm/vllm-openai-rocm:v0.19.1") == "v19"
     assert infer_vllm_patch_version("vllm/vllm-openai-rocm:v0.23.0") == "v23"
+    assert (
+        infer_vllm_patch_version(
+            "internal/vllm:rocm",
+            installed_version="0.22.0+rocm722",
+        )
+        == "v22"
+    )
     assert infer_vllm_patch_version("vllm/vllm-openai-rocm:nightly") is None
     assert runner_type_to_gpu_type("mi355x") == "mi355"
     assert is_tracelens_ready_runtime_image("sglang", "tracelens-sglang:0.5.12")
@@ -273,6 +288,35 @@ def test_vllm_runtime_support_is_read_from_tracelens_checkout(tmp_path):
     )
 
 
+def test_docker_image_package_version_reads_importlib_metadata(monkeypatch):
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0, stdout="0.22.0+rocm722\n")
+
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.subprocess.run",
+        fake_run,
+    )
+
+    assert docker_image_package_version("internal/vllm:latest", "vllm") == (
+        "0.22.0+rocm722"
+    )
+    assert seen["cmd"][:6] == [
+        "docker",
+        "run",
+        "--rm",
+        "--entrypoint",
+        "python3",
+        "internal/vllm:latest",
+    ]
+    assert "importlib.metadata" in seen["cmd"][7]
+    assert seen["cmd"][8] == "vllm"
+    assert seen["kwargs"]["timeout"] == 120
+
+
 def test_prepare_tracelens_runtime_image_reuses_existing_derived_image(
     tmp_path,
     monkeypatch,
@@ -297,6 +341,10 @@ def test_prepare_tracelens_runtime_image_reuses_existing_derived_image(
         "Magpie.modes.benchmark.tracelens_runtime.docker_image_exists",
         lambda _image: True,
     )
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.docker_image_package_version",
+        lambda _image, _package: None,
+    )
 
     cfg = BenchmarkConfig.from_dict(
         {
@@ -316,6 +364,53 @@ def test_prepare_tracelens_runtime_image_reuses_existing_derived_image(
     assert result["built"] is False
     assert result["reason"] == "derived image already exists"
     assert result["image"].startswith("magpie-tracelens-sglang:0_5_12-mi355x-")
+
+
+def test_prepare_tracelens_runtime_image_prefers_installed_package_version(
+    tmp_path,
+    monkeypatch,
+):
+    tracelens_repo = tmp_path / "TraceLens"
+    workflow_dir = tracelens_repo / "examples/custom_workflows/inference_analysis"
+    patch_dir = workflow_dir / "vllm_patches"
+    patch_dir.mkdir(parents=True)
+    (workflow_dir / "build_docker_vllm.sh").write_text(
+        "case ${VLLM_VERSION} in\n"
+        "    v22)\n"
+        "        ;;\n"
+        "esac\n"
+    )
+    (patch_dir / "config_vllm_v0.22.0.patch").write_text("patch")
+    monkeypatch.setenv("TRACELENS_REPO_PATH", str(tracelens_repo))
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.docker_image_exists",
+        lambda _image: True,
+    )
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.docker_image_package_version",
+        lambda _image, package: "0.22.0+rocm722" if package == "vllm" else None,
+    )
+
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "vllm",
+            "model": "demo",
+            "docker_image": "internal/vllm-rocm:latest",
+            "profiler": {"tracelens": {"enabled": True}},
+        }
+    )
+
+    result = prepare_tracelens_runtime_image(
+        cfg,
+        base_image=cfg.docker_image,
+        runner_type="mi355x",
+    )
+
+    assert result["built"] is False
+    assert result["patch_version"] == "v22"
+    assert result["patch_version_source"] == "package"
+    assert result["runtime_package_version"] == "0.22.0+rocm722"
+    assert result["image"].startswith("magpie-tracelens-vllm:v22-mi355x-")
 
 
 def test_tracelens_inference_prepare_patches_and_restores(tmp_path):

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -27,6 +27,8 @@ from Magpie.modes.benchmark.tracelens_inference import (
     trace_arch_platform_from_runner,
 )
 from Magpie.modes.benchmark.tracelens_runtime import (
+    available_tracelens_sglang_patch_versions,
+    available_tracelens_vllm_patch_versions,
     derive_tracelens_image_tag,
     infer_sglang_patch_version,
     infer_vllm_patch_version,
@@ -182,9 +184,11 @@ def test_tracelens_inference_iteration_and_arg_helpers():
 
 def test_tracelens_runtime_image_helpers():
     assert infer_sglang_patch_version("lmsysorg/sglang:v0.5.12-rocm720-mi35x") == "0.5.12"
-    assert infer_sglang_patch_version("lmsysorg/sglang:v0.5.8") is None
+    assert infer_sglang_patch_version("lmsysorg/sglang:v0.5.13-rocm720-mi35x") == "0.5.13"
+    assert infer_sglang_patch_version("lmsysorg/sglang:latest") is None
     assert infer_vllm_patch_version("vllm/vllm-openai-rocm:v0.19.1") == "v19"
-    assert infer_vllm_patch_version("vllm/vllm-openai-rocm:v0.13.0") is None
+    assert infer_vllm_patch_version("vllm/vllm-openai-rocm:v0.23.0") == "v23"
+    assert infer_vllm_patch_version("vllm/vllm-openai-rocm:nightly") is None
     assert runner_type_to_gpu_type("mi355x") == "mi355"
     assert is_tracelens_ready_runtime_image("sglang", "tracelens-sglang:0.5.12")
     assert not is_tracelens_ready_runtime_image("vllm", "lmsysorg/sglang:v0.5.12")
@@ -198,6 +202,77 @@ def test_tracelens_runtime_image_helpers():
     assert tag.startswith("magpie-tracelens-sglang:0_5_12-mi355x-")
 
 
+def test_sglang_runtime_support_is_read_from_tracelens_checkout(tmp_path):
+    tracelens_repo = tmp_path / "TraceLens"
+    workflow_dir = tracelens_repo / "examples/custom_workflows/inference_analysis"
+    patch_root = workflow_dir / "sglang_roofline_patches"
+    (patch_root / "sglang_0_5_13").mkdir(parents=True)
+    (patch_root / "sglang_0_5_14").mkdir(parents=True)
+    (workflow_dir / "build_docker_sglang.sh").write_text(
+        "normalize_version() {\n"
+        "    case \"$1\" in\n"
+        "        0.5.12|v0512|0512|5.12)\n"
+        "            echo \"0.5.12\"\n"
+        "            ;;\n"
+        "        0.5.13|v0513|0513|5.13)\n"
+        "            echo \"0.5.13\"\n"
+        "            ;;\n"
+        "    esac\n"
+        "}\n"
+    )
+
+    assert available_tracelens_sglang_patch_versions(tracelens_repo) == [
+        "0.5.13"
+    ]
+    assert (
+        infer_sglang_patch_version(
+            "lmsysorg/sglang:v0.5.13-rocm720-mi35x",
+            tracelens_repo,
+        )
+        == "0.5.13"
+    )
+    assert (
+        infer_sglang_patch_version(
+            "lmsysorg/sglang:v0.5.14-rocm720-mi35x",
+            tracelens_repo,
+        )
+        is None
+    )
+
+
+def test_vllm_runtime_support_is_read_from_tracelens_checkout(tmp_path):
+    tracelens_repo = tmp_path / "TraceLens"
+    workflow_dir = tracelens_repo / "examples/custom_workflows/inference_analysis"
+    patch_dir = workflow_dir / "vllm_patches"
+    patch_dir.mkdir(parents=True)
+    (workflow_dir / "build_docker_vllm.sh").write_text(
+        "case ${VLLM_VERSION} in\n"
+        "    v22)\n"
+        "        ;;\n"
+        "    v23)\n"
+        "        ;;\n"
+        "esac\n"
+    )
+    (patch_dir / "config_vllm_v0.23.0.patch").write_text("patch")
+    (patch_dir / "config_vllm_v0.24.0.patch").write_text("patch")
+
+    assert available_tracelens_vllm_patch_versions(tracelens_repo) == ["v23"]
+    assert (
+        infer_vllm_patch_version(
+            "vllm/vllm-openai-rocm:v0.23.0",
+            tracelens_repo,
+        )
+        == "v23"
+    )
+    assert (
+        infer_vllm_patch_version(
+            "vllm/vllm-openai-rocm:v0.24.0",
+            tracelens_repo,
+        )
+        is None
+    )
+
+
 def test_prepare_tracelens_runtime_image_reuses_existing_derived_image(
     tmp_path,
     monkeypatch,
@@ -205,6 +280,18 @@ def test_prepare_tracelens_runtime_image_reuses_existing_derived_image(
     tracelens_repo = tmp_path / "TraceLens"
     workflow_dir = tracelens_repo / "examples/custom_workflows/inference_analysis"
     workflow_dir.mkdir(parents=True)
+    (workflow_dir / "build_docker_sglang.sh").write_text(
+        "normalize_version() {\n"
+        "    case \"$1\" in\n"
+        "        0.5.12|v0512|0512|5.12)\n"
+        "            echo \"0.5.12\"\n"
+        "            ;;\n"
+        "    esac\n"
+        "}\n"
+    )
+    (workflow_dir / "sglang_roofline_patches" / "sglang_0_5_12").mkdir(
+        parents=True
+    )
     monkeypatch.setenv("TRACELENS_REPO_PATH", str(tracelens_repo))
     monkeypatch.setattr(
         "Magpie.modes.benchmark.tracelens_runtime.docker_image_exists",


### PR DESCRIPTION
Remove Magpie's hardcoded TraceLens patch version lists.

Magpie now checks the configured TraceLens checkout to decide whether vLLM and SGLang runtime auto-patching is supported. This allows new TraceLens-supported versions, such as vLLM v0.23.0, to work without updating Magpie each time.

Tested with:
uv run --frozen pytest tests/test_benchmark_support.py -q