### PR TITLE
fix(benchmark): pass --trust-remote-code on both sglang client paths

### DIFF
--- a/Magpie/scripts/benchmark/sglang_mi300x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi300x.sh
@@ -118,7 +118,7 @@ if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
     # Remote server: call Python benchmark_serving.py directly. Older
     # InferenceX benchmark_lib.sh run_benchmark_serving() rejects --base-url.
     SERVER_MONITOR_ARGS=()
-    magpie_run_benchmark_serving_remote_direct || exit $?
+    magpie_run_benchmark_serving_remote_direct trust || exit $?
   else
     run_benchmark_serving \
         --model "$MODEL" \
@@ -131,7 +131,8 @@ if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
         --max-concurrency "$CONC" \
         --result-filename "$RESULT_FILENAME" \
         "${SERVER_MONITOR_ARGS[@]}" \
-        --result-dir ${RESULT_DIR:-/workspace/} || exit $?
+        --result-dir ${RESULT_DIR:-/workspace/} \
+        --trust-remote-code || exit $?
   fi
 fi
 

--- a/Magpie/scripts/benchmark/sglang_mi355x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi355x.sh
@@ -113,7 +113,7 @@ fi
 if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
   if [[ -n "${BENCHMARK_BASE_URL:-}" ]]; then
     SERVER_MONITOR_ARGS=()
-    magpie_run_benchmark_serving_remote_direct || exit $?
+    magpie_run_benchmark_serving_remote_direct trust || exit $?
   else
     run_benchmark_serving \
         --model "$MODEL" \
@@ -126,7 +126,8 @@ if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
         --max-concurrency "$CONC" \
         --result-filename "$RESULT_FILENAME" \
         "${SERVER_MONITOR_ARGS[@]}" \
-        --result-dir ${RESULT_DIR:-/workspace/} || exit $?
+        --result-dir ${RESULT_DIR:-/workspace/} \
+        --trust-remote-code || exit $?
   fi
 fi
 


### PR DESCRIPTION
## Motivation

SGLang benchmarks of custom-code models fail at the **client-side tokenizer
load**. When a model's tokenizer is declared via `auto_map` (e.g. moonshotai
`Kimi-K2.7-Code` -> `tokenization_kimi.TikTokenTokenizer`), the benchmark
client's `AutoTokenizer.from_pretrained` raises the `trust_remote_code`
ValueError. The SGLang server boots fine; only the benchmark client crashes,
so the run yields no throughput/accuracy.

## Root cause

`scripts/benchmark/sglang_mi300x.sh` and `sglang_mi355x.sh` omit
`--trust-remote-code` on **both** client dispatch paths:

- remote path: `magpie_run_benchmark_serving_remote_direct` is called without
  the `trust` positional arg (the helper only appends `--trust-remote-code`
  when passed `trust`).
- local path: `run_benchmark_serving` is called without `--trust-remote-code`.

The sibling scripts `vllm_mi300x.sh`, `vllm_mi355x.sh`, `atom_mi300x.sh` and
`atom_mi355x.sh` already pass trust on both paths. The SGLang scripts are the
odd ones out — this is a consistency gap, not a new feature.

## Change

Align the two SGLang scripts with the existing vllm/atom scripts:
- remote path: `magpie_run_benchmark_serving_remote_direct trust`
- local path: append `--trust-remote-code`

`run_benchmark_serving` (InferenceX `benchmark_lib.sh`) already accepts the flag
and forwards it to `benchmark_serving.py --trust-remote-code` ->
`get_tokenizer(trust_remote_code=True)`, so no downstream change is needed.

## Impact

- Custom-code tokenizers load on both SGLang client paths.
- No behavior change for models that don't need it — passing trust is already
  the norm across the other benchmark scripts.

## Verification

- `bash -n` on both patched scripts: OK.
- Line-for-line alignment with the already-shipping `vllm_mi355x.sh` trust
  handling (both client paths).
- Root cause confirmed: the affected model's `tokenizer_config.json` declares
  `auto_map -> tokenization_kimi.TikTokenTokenizer`; the un-patched client run
  fails with the `trust_remote_code` ValueError.
- End-to-end GPU rerun of the affected SGLang baseline is pending on an AMD
  spur cluster (no local GPU); can be provided before merge if required.

## Out of scope (noted for maintainers)

The same missing `--trust-remote-code` also exists on both client paths of
`vllm_mi300x_mm.sh` and `vllm_mi355x_mm.sh`. This PR intentionally scopes to
the SGLang scripts, which have a concrete reproduction. Happy to follow up on
the `_mm` scripts in a separate PR if you'd like them aligned too.
