### PR TITLE
Bump Magpie version to 0.2.0

### DIFF
--- a/Magpie/__init__.py
+++ b/Magpie/__init__.py
@@ -17,7 +17,7 @@ Modules:
     - utils: Utility functions
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __author__ = "Magpie Team"
 
 # Re-export commonly used classes for convenience

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ flavor defines the site header display, select the flavor for the corresponding 
 flavor options: rocm, rocm-docs-home, rocm-blogs, rocm-ds, instinct, ai-developer-hub, local, generic
 """
 
-version_number = "0.1.0"
+version_number = "0.2.0"
 
 html_theme = "rocm_docs_theme"
 html_theme_options = {

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -36,10 +36,10 @@ This installs Magpie from GitHub with its core dependencies:
 pip install git+https://github.com/AMD-AGI/Magpie.git
 ```
 
-For a reproducible Magpie 0.1.0 beta install, pin the release tag:
+For a reproducible Magpie 0.2.0 beta install, pin the release tag:
 
 ```bash
-pip install "magpie-eval @ git+https://github.com/AMD-AGI/Magpie.git@v0.1.0"
+pip install "magpie-eval @ git+https://github.com/AMD-AGI/Magpie.git@v0.2.0"
 ```
 
 To install the broadly supported optional Magpie integrations, request the
@@ -49,11 +49,11 @@ To install the broadly supported optional Magpie integrations, request the
 pip install "magpie-eval[all] @ git+https://github.com/AMD-AGI/Magpie.git"
 ```
 
-To install the same optional set from the Magpie 0.1.0 beta release, pin the
+To install the same optional set from the Magpie 0.2.0 beta release, pin the
 same tag:
 
 ```bash
-pip install "magpie-eval[all] @ git+https://github.com/AMD-AGI/Magpie.git@v0.1.0"
+pip install "magpie-eval[all] @ git+https://github.com/AMD-AGI/Magpie.git@v0.2.0"
 ```
 
 IntelliKit integrations are intentionally not part of `all` because some
@@ -128,7 +128,7 @@ default. Install them based on the features you need:
   kernel correctness validation through HSA interception, and related ROCm tools):
 
   ```bash
-  pip install "magpie-eval[intellikit] @ git+https://github.com/AMD-AGI/Magpie.git@v0.1.0"
+  pip install "magpie-eval[intellikit] @ git+https://github.com/AMD-AGI/Magpie.git@v0.2.0"
   ```
 
   From a source checkout, use:

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -9,6 +9,34 @@ myst:
 
 This topic summarizes the features available in each Magpie release. For the hardware and software versions validated for a release, see the [Compatibility matrix](compatibility-matrix.md).
 
+## Magpie 0.2.0
+
+Released July 21, 2026, Magpie 0.2.0 improves TraceLens inference analysis and
+refreshes the documentation and compatibility guidance introduced in the
+initial beta.
+
+### Release highlights
+
+- TraceLens inference runs now produce compact, per-stage simple roofline CSV
+  summaries for mixed prefill/decode, prefill, and decode analysis.
+- Summary filenames include the input sequence length, output sequence length,
+  and concurrency, making results from benchmark sweeps easier to identify.
+- TraceLens runtime patch selection is now based on the framework version
+  installed in the runtime image and the patches available in the selected
+  TraceLens checkout, instead of a hard-coded version list.
+- Trace processing now selects non-empty inference traces, improving report
+  generation when profiler output contains empty trace files.
+- The compatibility matrix and the benchmarking, profiling, Ray, MCP, and
+  troubleshooting documentation have been updated for the 0.2.0 release.
+
+### Packaging and installation
+
+- The Python package, importable package version, and documentation version are
+  now `0.2.0`.
+- Reproducible GitHub install examples now pin the `v0.2.0` release tag.
+- Magpie remains beta software and retains the lightweight core install and
+  optional extras introduced in 0.1.0.
+
 ## Magpie 0.1.0
 
 The initial public beta release of Magpie establishes a lightweight,
@@ -100,4 +128,3 @@ Magpie provides the following configuration mechanisms.
 - Framework-level configuration using `config.yaml`.
 - Per-evaluation kernel configuration files for analyze and compare modes.
 - Benchmark configuration files for framework benchmarks.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "magpie-eval"
-version = "0.1.0"
+version = "0.2.0"
 description = "A general-purpose evaluation framework for GPU kernel implementations"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- bump the package, runtime, and documentation version from 0.1.0 to 0.2.0
- update pinned GitHub installation examples to use the v0.2.0 tag
- add Magpie 0.2.0 release notes covering TraceLens reporting and runtime patch improvements
- retain the Magpie 0.1.0 notes as historical release documentation

## Validation

- `git diff --check`
- verified `pyproject.toml`, `Magpie.__version__`, and the Sphinx version all report `0.2.0`

