### PR TITLE
Fix tracelens no default gpu arch platform

### DIFF
--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -325,7 +325,10 @@ class TraceLensInferencePipeline:
         split_dir = torch_trace_dir / "trace_split"
         capture_folder = torch_trace_dir / "capture_traces"
         output_csvs_dir = output_dir / "tracelens"
-        gpu_arch_platform = trace_arch_platform_from_runner(runner_type)
+        # Do not infer TraceLens platform by default. TraceLens' bundled
+        # platform list can lag newly-supported hardware; explicit
+        # gpu_arch_config remains the reliable roofline path.
+        gpu_arch_platform: Optional[str] = None
 
         results["split_dir"] = str(split_dir)
         results["capture_folder"] = str(capture_folder)
@@ -431,7 +434,10 @@ class TraceLensInferencePipeline:
         split_dir = torch_trace_dir / "trace_split"
         capture_folder = torch_trace_dir / "capture_traces"
         output_csvs_dir = output_dir / "tracelens"
-        gpu_arch_platform = trace_arch_platform_from_runner(runner_type)
+        # Do not infer TraceLens platform by default. TraceLens' bundled
+        # platform list can lag newly-supported hardware; explicit
+        # gpu_arch_config remains the reliable roofline path.
+        gpu_arch_platform: Optional[str] = None
 
         results["split_dir"] = str(split_dir)
         results["capture_folder"] = str(capture_folder)
@@ -1362,7 +1368,7 @@ class TraceLensInferencePipeline:
         if gpu_arch_platform:
             cmd.extend(["--gpu_arch_platform", gpu_arch_platform])
         if self.tl_config.gpu_arch_config:
-            # TraceLens gives the explicit JSON priority over gpu_arch_platform.
+            # Explicit JSON is the supported way to provide roofline hardware data.
             cmd.extend(["--gpu_arch_json_path", str(self.tl_config.gpu_arch_config)])
 
         logger.info(
@@ -1445,7 +1451,7 @@ class TraceLensInferencePipeline:
         if gpu_arch_platform:
             cmd.extend(["--gpu_arch_platform", gpu_arch_platform])
         if self.tl_config.gpu_arch_config:
-            # TraceLens gives the explicit JSON priority over gpu_arch_platform.
+            # Explicit JSON is the supported way to provide roofline hardware data.
             gpu_arch_config = (
                 Path(self.tl_config.gpu_arch_config).expanduser().resolve()
             )

--- a/docs/how-to/benchmarking/profiling-options.md
+++ b/docs/how-to/benchmarking/profiling-options.md
@@ -73,8 +73,9 @@ profiler:
 ```
 
 Supported stage names are `prefilldecode` (alias: `mixed`), `prefill`, and
-`decode`. GPU architecture is detected through Magpie's existing runner/GPU
-mapping and passed to TraceLens as `--gpu_arch_platform`.
+`decode`. Magpie does not pass TraceLens' `--gpu_arch_platform` by default;
+provide `tracelens.gpu_arch_config` when roofline columns need hardware-specific
+bandwidth and TFLOP/s data.
 
 For SGLang, TraceLens inference mode automatically adds
 `--enable-profile-cuda-graph`. It also adds

--- a/docs/reference/benchmark-config.md
+++ b/docs/reference/benchmark-config.md
@@ -225,9 +225,9 @@ achieved TB/s, roofline bound, and percent of roofline. The filename records
 the benchmark `ISL`, `OSL`, and `CONC` values. Magpie passes
 `gpu_arch_config` to the inference CLI as `--gpu_arch_json_path`; when it is
 not configured, architecture-dependent roofline columns are omitted from the
-simple summary. When both the auto-detected `--gpu_arch_platform` and an
-explicit `--gpu_arch_json_path` are passed, TraceLens gives the JSON file
-priority.
+simple summary. Magpie does not pass TraceLens' `--gpu_arch_platform` by
+default because bundled platform support can lag new hardware; use
+`gpu_arch_config` for hardware-specific roofline data.
 
 ### SGLang benchmark
 

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -922,6 +922,7 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
     assert result["errors"] == []
     assert result["analysis_stages"] == ["decode"]
     assert result["tl_extension"] == "TraceLens_NDA"
+    assert result["gpu_arch_platform"] is None
     assert result["postprocess_runtime"]["mode"] == "docker"
     assert str(workspace / "tracelens" / "decode_only" / "summary.csv") in result[
         "output_files"
@@ -949,6 +950,7 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
         "--gpu_arch_json_path /workspace/tracelens/mi355x.json" in cmd[-1]
         for cmd in docker_cmds
     )
+    assert all("--gpu_arch_platform" not in cmd[-1] for cmd in docker_cmds)
     assert (workspace / "tracelens" / "mi355x.json").read_text(
         encoding="utf-8"
     ) == gpu_arch_config.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Stop Magpie from passing `--gpu_arch_platform` to TraceLens by default.

This avoids failures when TraceLens does not yet recognize newer GPU names like `MI355X`. Users can still provide `tracelens.gpu_arch_config`, which Magpie passes as `--gpu_arch_json_path`, for hardware-specific roofline data.