### PR TITLE
Add TraceLens extension wheel support for benchmark images

### DIFF
--- a/Magpie/benchmark_config.yaml.example
+++ b/Magpie/benchmark_config.yaml.example
@@ -219,6 +219,7 @@ benchmark:
 #       export_format: csv       # "csv" or "excel"
 #       perf_report_enabled: true          # Single-rank report
 #       multi_rank_report_enabled: true    # Multi-rank collective report
+#       # extension_wheel_path: /secure/path/to/TraceLens_extension.whl
 #       # gpu_arch_config: null            # Optional: GPU arch config for roofline
 #       
 #   timeout_seconds: 1200

--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -12,25 +12,26 @@ Orchestrates benchmark execution using InferenceX as backend.
 import json
 import logging
 import os
-import signal
 import shutil
+import signal
 import subprocess
 import tempfile
 import time
-import uuid
 import urllib.error
 import urllib.request
+import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from ...core.ray_executor import RayJobExecutor
     from ...core.task import Task
 
+from ...utils.gpu import GPUVendor, detect_gpu, find_idle_gpus
+from ...utils.gpu_monitor import GPUMonitor
 from .config import BenchmarkConfig
 from .image_selector import ImageSelector
 from .inferencex import ensure_inferencex_available
-from .workspace import WorkspaceManager
 from .result import BenchmarkResult, LatencyMetrics, ResultParser, ThroughputMetrics
 from .tracelens import TraceLensAnalyzer
 from .tracelens_inference import (
@@ -38,9 +39,7 @@ from .tracelens_inference import (
     is_tracelens_inference_enabled,
 )
 from .tracelens_runtime import prepare_tracelens_runtime_image
-
-from ...utils.gpu import detect_gpu, find_idle_gpus, GPUVendor
-from ...utils.gpu_monitor import GPUMonitor
+from .workspace import WorkspaceManager
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +85,7 @@ class BenchmarkMode:
         self.workspace_mgr = WorkspaceManager(
             base_dir=output_dir,
             framework=config.framework,
+            container_writable=config.run_mode == "docker",
         )
         self._task_id: Optional[str] = None
     
@@ -1795,7 +1795,7 @@ class BenchmarkMode:
     
     def _build_ray_benchmark_task(self) -> Tuple[Optional["Task"], Optional[str]]:
         """Build the ``Task`` for a Ray benchmark; sets ``self._task_id`` if unset."""
-        from ...core.task import Task, ModeType, ModeConfig
+        from ...core.task import ModeConfig, ModeType, Task
 
         if self.config.ray_config is None:
             return None, "ray_config is required when run_mode='ray'"
@@ -1870,8 +1870,8 @@ class BenchmarkMode:
         and blocks until the task completes.  Returns a BenchmarkResult
         with the full results from the worker.
         """
-        from ...core.ray_executor import RayJobExecutor
         from ...core.executor import ExecutorConfig, ExecutorType
+        from ...core.ray_executor import RayJobExecutor
 
         result = BenchmarkResult()
         rc = self.config.ray_config

--- a/Magpie/modes/benchmark/config.py
+++ b/Magpie/modes/benchmark/config.py
@@ -8,8 +8,8 @@ Configuration classes for benchmark mode.
 """
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
 from enum import Enum
+from typing import Any, Dict, List, Optional
 
 
 class BenchmarkFramework(Enum):
@@ -123,6 +123,8 @@ class TraceLensConfig:
         tracelens_repo_path: Path to a public TraceLens source checkout used
             for runtime image patching. Defaults to $TRACELENS_REPO_PATH or
             common sibling checkout locations.
+        extension_wheel_path: Optional local TraceLens extension wheel to install
+            as a final layer on the TraceLens-ready runtime image.
         runtime_patch_image_tag: Optional Docker tag for the derived image.
         runtime_patch_force_rebuild: Rebuild the derived image even if the tag exists.
         export_format: Export format - "csv" or "excel" (default: "csv")
@@ -140,6 +142,7 @@ class TraceLensConfig:
     cli_timeout_seconds: int = 1800
     auto_patch_runtime: bool = True
     tracelens_repo_path: Optional[str] = None
+    extension_wheel_path: Optional[str] = None
     runtime_patch_image_tag: Optional[str] = None
     runtime_patch_force_rebuild: bool = False
     restore_patches: bool = True
@@ -259,6 +262,7 @@ class TraceLensConfig:
             "cli_timeout_seconds": self.cli_timeout_seconds,
             "auto_patch_runtime": self.auto_patch_runtime,
             "tracelens_repo_path": self.tracelens_repo_path,
+            "extension_wheel_path": self.extension_wheel_path,
             "runtime_patch_image_tag": self.runtime_patch_image_tag,
             "runtime_patch_force_rebuild": self.runtime_patch_force_rebuild,
             "restore_patches": self.restore_patches,
@@ -290,6 +294,7 @@ class TraceLensConfig:
             cli_timeout_seconds=int(data.get("cli_timeout_seconds", 1800)),
             auto_patch_runtime=bool(data.get("auto_patch_runtime", True)),
             tracelens_repo_path=data.get("tracelens_repo_path"),
+            extension_wheel_path=data.get("extension_wheel_path"),
             runtime_patch_image_tag=data.get("runtime_patch_image_tag"),
             runtime_patch_force_rebuild=bool(
                 data.get("runtime_patch_force_rebuild", False)

--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -23,9 +23,10 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from ...utils.gpu import detect_gpu
 from .config import BenchmarkConfig
@@ -38,6 +39,14 @@ CLI_SPLIT_INFERENCE_TRACE = "TraceLens_split_inference_trace"
 CLI_INFERENCE_REPORT = "TraceLens_generate_perf_report_pytorch_inference"
 SGLANG_PROFILE_CUDA_GRAPH_FLAG = "--enable-profile-cuda-graph"
 SGLANG_SHAPE_DISCOVERY_FLAG = "--enable-shape-discovery-for-cuda-graph-profile"
+TRACELENS_PLATFORM_PROBE_SCRIPT = (
+    "import sys; "
+    "from TraceLens.Agent.Analysis.utils.arch_utils import list_platforms; "
+    "candidate = sys.argv[1]; "
+    "platforms = list_platforms(); "
+    "print('available=' + ','.join(platforms)); "
+    "raise SystemExit(0 if candidate in platforms else 3)"
+)
 
 TRACELENS_SIMPLE_SUMMARY_COLUMNS = [
     "source_category",
@@ -237,6 +246,98 @@ class TraceLensInferencePipeline:
         self.tl_extension = resolve_tl_extension(benchmark_config.envs)
         self._created_backups: List[Path] = []
 
+    def _select_gpu_arch_platform(
+        self,
+        runner_type: Optional[str],
+        probe: Callable[[str], subprocess.CompletedProcess[str]],
+        runtime_label: str,
+    ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        """Use an inferred platform only when the selected TraceLens supports it."""
+        candidate = trace_arch_platform_from_runner(runner_type)
+        if self.tl_config.gpu_arch_config:
+            return candidate, None, None
+
+        if not candidate:
+            return (
+                None,
+                None,
+                (
+                    "Could not infer a TraceLens GPU architecture platform; "
+                    "running without architecture-specific roofline data"
+                ),
+            )
+
+        try:
+            proc = probe(candidate)
+        except Exception as exc:
+            return (
+                candidate,
+                None,
+                (
+                    f"Could not verify auto-detected TraceLens platform {candidate} "
+                    f"in {runtime_label}: {exc}. Running without "
+                    "--gpu_arch_platform."
+                ),
+            )
+
+        if proc.returncode == 0:
+            logger.info(
+                "Auto-detected TraceLens GPU platform %s is supported in %s",
+                candidate,
+                runtime_label,
+            )
+            return candidate, candidate, None
+
+        detail = (proc.stderr or proc.stdout or "").strip()
+        if len(detail) > 500:
+            detail = detail[-500:]
+        suffix = f" ({detail})" if detail else ""
+        return (
+            candidate,
+            None,
+            (
+                f"Auto-detected TraceLens platform {candidate} is not supported "
+                f"in {runtime_label}{suffix}; running without "
+                "--gpu_arch_platform. Set tracelens.gpu_arch_config for an "
+                "explicit architecture JSON."
+            ),
+        )
+
+    def _probe_local_gpu_arch_platform(
+        self,
+        candidate: str,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                TRACELENS_PLATFORM_PROBE_SCRIPT,
+                candidate,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=min(self.tl_config.cli_timeout_seconds, 60),
+            env=self._subprocess_env(),
+        )
+
+    def _probe_container_gpu_arch_platform(
+        self,
+        docker_image: str,
+        workspace: Path,
+        candidate: str,
+    ) -> subprocess.CompletedProcess[str]:
+        return self._run_container_command(
+            docker_image,
+            workspace,
+            [
+                "python3",
+                "-c",
+                TRACELENS_PLATFORM_PROBE_SCRIPT,
+                candidate,
+            ],
+            timeout_seconds=min(self.tl_config.cli_timeout_seconds, 60),
+        )
+
     def prepare(self, workspace: Path) -> Dict[str, Any]:
         """Patch config/envs and mutable InferenceX files before benchmark."""
         result: Dict[str, Any] = {
@@ -329,14 +430,23 @@ class TraceLensInferencePipeline:
         split_dir = torch_trace_dir / "trace_split"
         capture_folder = torch_trace_dir / "capture_traces"
         output_csvs_dir = output_dir / "tracelens"
-        # Do not infer TraceLens platform by default. TraceLens' bundled
-        # platform list can lag newly-supported hardware; explicit
-        # gpu_arch_config remains the reliable roofline path.
-        gpu_arch_platform: Optional[str] = None
+        (
+            gpu_arch_platform_candidate,
+            gpu_arch_platform,
+            platform_warning,
+        ) = self._select_gpu_arch_platform(
+            runner_type,
+            self._probe_local_gpu_arch_platform,
+            "the local TraceLens installation",
+        )
+        if platform_warning:
+            logger.warning(platform_warning)
+            results["warnings"].append(platform_warning)
 
         results["split_dir"] = str(split_dir)
         results["capture_folder"] = str(capture_folder)
         results["output_dir"] = str(output_csvs_dir)
+        results["gpu_arch_platform_candidate"] = gpu_arch_platform_candidate
         results["gpu_arch_platform"] = gpu_arch_platform
 
         rank0_trace = self._locate_rank0_trace(torch_trace_dir)
@@ -438,14 +548,27 @@ class TraceLensInferencePipeline:
         split_dir = torch_trace_dir / "trace_split"
         capture_folder = torch_trace_dir / "capture_traces"
         output_csvs_dir = output_dir / "tracelens"
-        # Do not infer TraceLens platform by default. TraceLens' bundled
-        # platform list can lag newly-supported hardware; explicit
-        # gpu_arch_config remains the reliable roofline path.
-        gpu_arch_platform: Optional[str] = None
+        (
+            gpu_arch_platform_candidate,
+            gpu_arch_platform,
+            platform_warning,
+        ) = self._select_gpu_arch_platform(
+            runner_type,
+            lambda candidate: self._probe_container_gpu_arch_platform(
+                docker_image,
+                workspace,
+                candidate,
+            ),
+            f"TraceLens image {docker_image}",
+        )
+        if platform_warning:
+            logger.warning(platform_warning)
+            results["warnings"].append(platform_warning)
 
         results["split_dir"] = str(split_dir)
         results["capture_folder"] = str(capture_folder)
         results["output_dir"] = str(output_csvs_dir)
+        results["gpu_arch_platform_candidate"] = gpu_arch_platform_candidate
         results["gpu_arch_platform"] = gpu_arch_platform
 
         rank0_trace = self._locate_rank0_trace(torch_trace_dir)
@@ -1372,7 +1495,7 @@ class TraceLensInferencePipeline:
         if gpu_arch_platform:
             cmd.extend(["--gpu_arch_platform", gpu_arch_platform])
         if self.tl_config.gpu_arch_config:
-            # Explicit JSON is the supported way to provide roofline hardware data.
+            # Explicit JSON takes priority over auto-detected platform probing.
             cmd.extend(["--gpu_arch_json_path", str(self.tl_config.gpu_arch_config)])
 
         logger.info(
@@ -1455,7 +1578,7 @@ class TraceLensInferencePipeline:
         if gpu_arch_platform:
             cmd.extend(["--gpu_arch_platform", gpu_arch_platform])
         if self.tl_config.gpu_arch_config:
-            # Explicit JSON is the supported way to provide roofline hardware data.
+            # Explicit JSON takes priority over auto-detected platform probing.
             gpu_arch_config = (
                 Path(self.tl_config.gpu_arch_config).expanduser().resolve()
             )
@@ -1517,7 +1640,9 @@ class TraceLensInferencePipeline:
         docker_image: str,
         workspace: Path,
         cmd: Sequence[str],
+        timeout_seconds: Optional[int] = None,
     ) -> subprocess.CompletedProcess[str]:
+        timeout = timeout_seconds or self.tl_config.cli_timeout_seconds
         docker_cmd = [
             "docker",
             "run",
@@ -1544,7 +1669,7 @@ class TraceLensInferencePipeline:
                 docker_cmd,
                 capture_output=True,
                 text=True,
-                timeout=self.tl_config.cli_timeout_seconds,
+                timeout=timeout,
             )
         except subprocess.TimeoutExpired as exc:
             return subprocess.CompletedProcess(
@@ -1553,8 +1678,7 @@ class TraceLensInferencePipeline:
                 stdout=exc.stdout or "",
                 stderr=(
                     exc.stderr
-                    or f"TraceLens container command timed out after "
-                    f"{self.tl_config.cli_timeout_seconds}s"
+                    or f"TraceLens container command timed out after {timeout}s"
                 ),
             )
         except FileNotFoundError as exc:

--- a/Magpie/modes/benchmark/tracelens_inference.py
+++ b/Magpie/modes/benchmark/tracelens_inference.py
@@ -27,9 +27,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
+from ...utils.gpu import detect_gpu
 from .config import BenchmarkConfig
 from .tracelens import ensure_tracelens_installed
-from ...utils.gpu import detect_gpu
 
 logger = logging.getLogger(__name__)
 
@@ -123,13 +123,17 @@ class _TraceCandidate:
 
 
 def resolve_tl_extension(envs: Dict[str, Any]) -> Optional[str]:
-    """Resolve TL_EXTENSION from host env first, then benchmark envs."""
-    host_value = os.environ.get("TL_EXTENSION", "").strip()
-    if host_value:
-        return host_value
-
-    cfg_value = str(envs.get("TL_EXTENSION", "") or "").strip()
-    return cfg_value or None
+    """Merge host and benchmark TL_EXTENSION modules without duplicates."""
+    values = [
+        os.environ.get("TL_EXTENSION", "").strip(),
+        str(envs.get("TL_EXTENSION", "") or "").strip(),
+    ]
+    modules: List[str] = []
+    for value in values:
+        for module in value.split(":"):
+            if module and module not in modules:
+                modules.append(module)
+    return ":".join(modules) or None
 
 
 def is_tracelens_patched_sglang_image(image_name: Optional[str]) -> bool:

--- a/Magpie/modes/benchmark/tracelens_runtime.py
+++ b/Magpie/modes/benchmark/tracelens_runtime.py
@@ -17,7 +17,10 @@ import hashlib
 import logging
 import os
 import re
+import shutil
 import subprocess
+import tempfile
+import zipfile
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -305,6 +308,141 @@ def derive_tracelens_image_tag(
     )
 
 
+def inspect_tracelens_extension_wheel(wheel_path: Path) -> Dict[str, str]:
+    """Validate a TraceLens extension wheel and infer its import module."""
+    wheel_path = wheel_path.expanduser().resolve()
+    if not wheel_path.is_file():
+        raise FileNotFoundError(
+            f"TraceLens extension wheel not found: {wheel_path}"
+        )
+    if wheel_path.suffix.lower() != ".whl":
+        raise ValueError(
+            "TraceLens extension_wheel_path must point to a .whl file, "
+            f"got: {wheel_path}"
+        )
+
+    digest = hashlib.sha256()
+    with wheel_path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+
+    try:
+        with zipfile.ZipFile(wheel_path) as wheel:
+            candidates = set()
+            for member in wheel.namelist():
+                parts = tuple(part for part in member.split("/") if part)
+                if len(parts) < 5:
+                    continue
+                if parts[1:4] != ("Agent", "Analysis", "utils"):
+                    continue
+                if parts[4] == "agent_extension.py" or parts[4] == "arch":
+                    candidates.add(parts[0])
+    except zipfile.BadZipFile as exc:
+        raise ValueError(
+            f"Invalid TraceLens extension wheel: {wheel_path}"
+        ) from exc
+
+    if len(candidates) != 1:
+        found = ", ".join(sorted(candidates)) or "none"
+        raise ValueError(
+            "TraceLens extension wheel must contain exactly one top-level "
+            "extension package with Agent/Analysis/utils/agent_extension.py "
+            "or Agent/Analysis/utils/arch/. "
+            f"Found candidates: {found}"
+        )
+
+    module = next(iter(candidates))
+    if not all(part.isidentifier() for part in module.split(".")):
+        raise ValueError(
+            f"Invalid TraceLens extension import module inferred from wheel: {module}"
+        )
+
+    staged_name = re.sub(r"\s+\d+(?=\.whl$)", "", wheel_path.name)
+    if " " in staged_name:
+        raise ValueError(
+            "TraceLens extension wheel filename contains unsupported spaces. "
+            "Rename it to its original PEP 427 wheel filename."
+        )
+
+    return {
+        "path": str(wheel_path),
+        "filename": staged_name,
+        "module": module,
+        "sha256": digest.hexdigest(),
+    }
+
+
+def derive_tracelens_extension_image_tag(
+    base_image: str,
+    wheel_sha256: str,
+) -> str:
+    """Append a content-addressed extension suffix to a Docker image tag."""
+    suffix = f"ext-{wheel_sha256[:12]}"
+    last_slash = base_image.rfind("/")
+    last_colon = base_image.rfind(":")
+    if last_colon > last_slash:
+        return f"{base_image}-{suffix}"
+    return f"{base_image}:{suffix}"
+
+
+def _build_extension_overlay_image(
+    base_image: str,
+    derived_image: str,
+    extension: Dict[str, str],
+) -> list[str]:
+    """Install a local TraceLens extension wheel as a final Docker layer."""
+    staged_name = extension["filename"]
+    module = extension["module"]
+    wheel_sha256 = extension["sha256"]
+    arch_check = (
+        "import TraceLens.Agent.Analysis.utils.arch_utils as a; "
+        "print(a.list_platforms())"
+    )
+    dockerfile = f"""\
+ARG BASE_IMAGE
+FROM ${{BASE_IMAGE}}
+COPY {staged_name} /tmp/{staged_name}
+RUN python3 -m pip install --no-cache-dir --no-deps /tmp/{staged_name} \\
+    && rm -f /tmp/{staged_name}
+ENV TL_EXTENSION={module}
+LABEL org.opencontainers.image.tracelens-extension.module={module}
+LABEL org.opencontainers.image.tracelens-extension.sha256={wheel_sha256}
+RUN python3 -c "import importlib; importlib.import_module('{module}')" \\
+    && TL_EXTENSION={module} python3 -c "{arch_check}"
+WORKDIR /workspace
+"""
+
+    with tempfile.TemporaryDirectory(
+        prefix="magpie-tracelens-extension-"
+    ) as temp_dir:
+        build_context = Path(temp_dir)
+        shutil.copy2(extension["path"], build_context / staged_name)
+        (build_context / "Dockerfile").write_text(dockerfile, encoding="utf-8")
+        cmd = [
+            "docker",
+            "build",
+            "--build-arg",
+            f"BASE_IMAGE={base_image}",
+            "-t",
+            derived_image,
+            str(build_context),
+        ]
+        proc = subprocess.run(
+            cmd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+    if proc.returncode != 0:
+        tail = (proc.stdout or "")[-4000:]
+        raise RuntimeError(
+            "TraceLens extension image build failed with exit code "
+            f"{proc.returncode}. Image: {derived_image}\n{tail}"
+        )
+    return cmd
+
+
 def docker_image_exists(image_tag: str) -> bool:
     """Return True when Docker can inspect the image tag locally."""
     proc = subprocess.run(
@@ -419,16 +557,21 @@ def prepare_tracelens_runtime_image(
         "built": False,
         "skipped": True,
     }
+    extension: Optional[Dict[str, str]] = None
+    extension_requested = bool(tl_config.extension_wheel_path)
 
     if not result["enabled"]:
         result["reason"] = "TraceLens inference mode is not enabled"
         return result
 
     if config.is_local or config.is_ray:
-        result["reason"] = f"run_mode={config.run_mode} does not use Docker image patching"
+        result["reason"] = (
+            f"run_mode={config.run_mode} does not use Docker image patching"
+        )
         return result
 
-    if is_tracelens_ready_runtime_image(config.framework, base_image):
+    base_is_ready = is_tracelens_ready_runtime_image(config.framework, base_image)
+    if base_is_ready and not extension_requested:
         result["reason"] = "image already appears TraceLens-ready"
         return result
 
@@ -436,106 +579,181 @@ def prepare_tracelens_runtime_image(
         result["reason"] = "auto_patch_runtime=false"
         return result
 
-    tracelens_repo = resolve_tracelens_repo_path(tl_config.tracelens_repo_path)
-    package_name = FRAMEWORK_PACKAGE_NAMES.get(config.framework)
-    installed_version = (
-        docker_image_package_version(base_image, package_name)
-        if package_name
-        else None
-    )
-    if installed_version:
-        result["runtime_package_version"] = installed_version
-
-    if config.framework == "sglang":
-        patch_version = infer_sglang_patch_version(
-            base_image,
-            tracelens_repo,
-            installed_version=installed_version,
+    if tl_config.extension_wheel_path:
+        extension = inspect_tracelens_extension_wheel(
+            Path(tl_config.extension_wheel_path)
         )
-        if patch_version is None:
-            raise RuntimeError(
-                _sglang_patch_error(base_image, tracelens_repo, installed_version)
-            )
-    elif config.framework == "vllm":
-        patch_version = infer_vllm_patch_version(
-            base_image,
-            tracelens_repo,
-            installed_version=installed_version,
+        result.update(
+            {
+                "extension_wheel_name": extension["filename"],
+                "extension_wheel_sha256": extension["sha256"],
+                "extension_module": extension["module"],
+            }
         )
-        if patch_version is None:
-            raise RuntimeError(
-                _vllm_patch_error(base_image, tracelens_repo, installed_version)
-            )
-    else:
-        patch_version = None
-    if patch_version is None:
-        # Let _build_command raise the framework-specific error text.
-        patch_version = "unknown"
 
-    derived_image = tl_config.runtime_patch_image_tag or derive_tracelens_image_tag(
-        framework=config.framework,
-        base_image=base_image,
-        runner_type=runner_type,
-        patch_version=patch_version,
-    )
+    if extension:
+        current_extensions = str(config.envs.get("TL_EXTENSION", "") or "").strip()
+        modules = [item for item in current_extensions.split(":") if item]
+        if extension["module"] not in modules:
+            modules.append(extension["module"])
+        config.envs["TL_EXTENSION"] = ":".join(modules)
+
+    public_image = base_image
+    patch_version: Optional[str] = None
+    installed_version: Optional[str] = None
+    tracelens_repo: Optional[Path] = None
+
+    if not base_is_ready:
+        tracelens_repo = resolve_tracelens_repo_path(tl_config.tracelens_repo_path)
+        package_name = FRAMEWORK_PACKAGE_NAMES.get(config.framework)
+        installed_version = (
+            docker_image_package_version(base_image, package_name)
+            if package_name
+            else None
+        )
+        if installed_version:
+            result["runtime_package_version"] = installed_version
+
+        if config.framework == "sglang":
+            patch_version = infer_sglang_patch_version(
+                base_image,
+                tracelens_repo,
+                installed_version=installed_version,
+            )
+            if patch_version is None:
+                raise RuntimeError(
+                    _sglang_patch_error(base_image, tracelens_repo, installed_version)
+                )
+        elif config.framework == "vllm":
+            patch_version = infer_vllm_patch_version(
+                base_image,
+                tracelens_repo,
+                installed_version=installed_version,
+            )
+            if patch_version is None:
+                raise RuntimeError(
+                    _vllm_patch_error(base_image, tracelens_repo, installed_version)
+                )
+        else:
+            patch_version = "unknown"
+
+        public_image = derive_tracelens_image_tag(
+            framework=config.framework,
+            base_image=base_image,
+            runner_type=runner_type,
+            patch_version=patch_version,
+        )
+        if not extension and tl_config.runtime_patch_image_tag:
+            public_image = tl_config.runtime_patch_image_tag
+
+    derived_image = public_image
+    if extension:
+        derived_image = (
+            tl_config.runtime_patch_image_tag
+            or derive_tracelens_extension_image_tag(
+                public_image,
+                extension["sha256"],
+            )
+        )
 
     result.update(
         {
             "image": derived_image,
-            "tracelens_repo_path": str(tracelens_repo),
-            "patch_version": patch_version,
-            "patch_version_source": "package" if installed_version else "image",
+            "public_runtime_image": public_image,
         }
     )
+    if tracelens_repo is not None:
+        result["tracelens_repo_path"] = str(tracelens_repo)
+    if patch_version is not None:
+        result["patch_version"] = patch_version
+        result["patch_version_source"] = (
+            "package" if installed_version else "image"
+        )
 
     if docker_image_exists(derived_image) and not tl_config.runtime_patch_force_rebuild:
         result["reason"] = "derived image already exists"
         return result
 
-    cmd = _build_command(
-        config=config,
-        base_image=base_image,
-        runner_type=runner_type,
-        derived_image=derived_image,
-        tracelens_repo=tracelens_repo,
-        patch_version=patch_version,
-    )
-    result["command"] = cmd
-    result["skipped"] = False
-
-    logger.info(
-        "Building TraceLens-ready %s image from %s as %s",
-        config.framework,
-        base_image,
-        derived_image,
-    )
-    proc = subprocess.run(
-        cmd,
-        cwd=str(tracelens_repo),
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-    if proc.returncode != 0:
-        tail = (proc.stdout or "")[-4000:]
-        raise RuntimeError(
-            "TraceLens runtime image build failed with exit code "
-            f"{proc.returncode}. Command: {' '.join(cmd)}\n{tail}"
+    public_built = False
+    if not base_is_ready and (
+        tl_config.runtime_patch_force_rebuild
+        or not docker_image_exists(public_image)
+    ):
+        assert tracelens_repo is not None
+        assert patch_version is not None
+        cmd = _build_command(
+            config=config,
+            base_image=base_image,
+            runner_type=runner_type,
+            derived_image=public_image,
+            tracelens_repo=tracelens_repo,
+            patch_version=patch_version,
         )
+        result["command"] = cmd
+        logger.info(
+            "Building TraceLens-ready %s image from %s as %s",
+            config.framework,
+            base_image,
+            public_image,
+        )
+        proc = subprocess.run(
+            cmd,
+            cwd=str(tracelens_repo),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        if proc.returncode != 0:
+            tail = (proc.stdout or "")[-4000:]
+            raise RuntimeError(
+                "TraceLens runtime image build failed with exit code "
+                f"{proc.returncode}. Command: {' '.join(cmd)}\n{tail}"
+            )
+        public_built = True
 
-    result["built"] = True
-    result["reason"] = "derived image built"
+    extension_built = False
+    if extension:
+        logger.info(
+            "Installing TraceLens extension %s (%s) into %s",
+            extension["filename"],
+            extension["sha256"][:12],
+            derived_image,
+        )
+        extension_cmd = _build_extension_overlay_image(
+            base_image=public_image,
+            derived_image=derived_image,
+            extension=extension,
+        )
+        result["extension_command"] = extension_cmd[:-1] + [
+            "<temporary-build-context>"
+        ]
+        extension_built = True
+
+    result["public_runtime_built"] = public_built
+    result["extension_built"] = extension_built
+    result["built"] = public_built or extension_built
+    result["skipped"] = not result["built"]
+    if public_built and extension_built:
+        result["reason"] = "derived image and extension built"
+    elif extension_built:
+        result["reason"] = "extension image built"
+    elif public_built:
+        result["reason"] = "derived image built"
+    else:
+        result["reason"] = "derived image already exists"
     return result
 
 
 __all__ = [
     "available_tracelens_sglang_patch_versions",
     "available_tracelens_vllm_patch_versions",
+    "derive_tracelens_extension_image_tag",
     "derive_tracelens_image_tag",
     "docker_image_package_version",
     "docker_image_exists",
     "infer_sglang_patch_version",
     "infer_vllm_patch_version",
+    "inspect_tracelens_extension_wheel",
     "is_tracelens_ready_runtime_image",
     "prepare_tracelens_runtime_image",
     "resolve_tracelens_repo_path",

--- a/Magpie/modes/benchmark/workspace.py
+++ b/Magpie/modes/benchmark/workspace.py
@@ -38,6 +38,7 @@ class WorkspaceManager:
         self,
         base_dir: str = "./results",
         framework: str = "benchmark",
+        container_writable: bool = False,
     ):
         """
         Initialize workspace manager.
@@ -45,9 +46,12 @@ class WorkspaceManager:
         Args:
             base_dir: Base directory for all benchmark results
             framework: Framework name for directory naming
+            container_writable: Allow container users, including remapped root,
+                to write to bind-mounted workspace directories.
         """
         self.base_dir = Path(base_dir)
         self.framework = framework
+        self.container_writable = container_writable
         self._workspace_path: Optional[Path] = None
     
     def create(self, config: Optional[Dict[str, Any]] = None) -> Path:
@@ -69,8 +73,18 @@ class WorkspaceManager:
         workspace_path.mkdir(parents=True, exist_ok=True)
         
         # Create subdirectories
-        (workspace_path / "torch_trace").mkdir(exist_ok=True)
-        (workspace_path / "system_profile").mkdir(exist_ok=True)
+        torch_trace_path = workspace_path / "torch_trace"
+        system_profile_path = workspace_path / "system_profile"
+        torch_trace_path.mkdir(exist_ok=True)
+        system_profile_path.mkdir(exist_ok=True)
+
+        if self.container_writable:
+            # Docker may run with user-namespace remapping or an NFS
+            # root-squash policy. In either case container root is not the
+            # workspace owner on the host, so ordinary 0755/0775 directories
+            # reject server logs and profiler traces.
+            for path in (workspace_path, torch_trace_path, system_profile_path):
+                path.chmod(0o777)
         
         # Save configuration snapshot
         if config:

--- a/docs/how-to/benchmarking/profiling-options.md
+++ b/docs/how-to/benchmarking/profiling-options.md
@@ -48,6 +48,25 @@ is tagged locally as `magpie-tracelens-<framework>:...` and reused on later runs
 Set `profiler.tracelens.tracelens_repo_path` or `TRACELENS_REPO_PATH` to a public
 TraceLens source checkout if Magpie cannot auto-locate it.
 
+To install an optional local TraceLens extension in the derived image, set
+`extension_wheel_path`:
+
+```yaml
+profiler:
+  tracelens:
+    enabled: true
+    auto_patch_runtime: true
+    extension_wheel_path: /secure/path/to/TraceLens_extension.whl
+```
+
+Magpie infers the extension's import module from its wheel layout, installs the
+wheel with `--no-deps` as a final image layer, and adds the module to
+`TL_EXTENSION`. The wheel SHA-256 is included in the derived image tag, so a
+changed wheel creates a new image instead of silently reusing an older one.
+The wheel remains in a temporary Docker build context and is not copied into
+the public TraceLens checkout. This option also works when `docker_image`
+already names a TraceLens-ready image.
+
 For `run_mode: docker`, TraceLens inference post-processing also runs inside the
 resolved runtime image after the benchmark container exits. The post-processing
 container is CPU-only, mounts the benchmark workspace at `/workspace`, and writes

--- a/docs/how-to/benchmarking/profiling-options.md
+++ b/docs/how-to/benchmarking/profiling-options.md
@@ -92,9 +92,15 @@ profiler:
 ```
 
 Supported stage names are `prefilldecode` (alias: `mixed`), `prefill`, and
-`decode`. Magpie does not pass TraceLens' `--gpu_arch_platform` by default;
-provide `tracelens.gpu_arch_config` when roofline columns need hardware-specific
-bandwidth and TFLOP/s data.
+`decode`. Magpie infers a candidate TraceLens architecture from the benchmark
+runner (for example, `mi355x` maps to `MI355X`) and asks the TraceLens
+installation used for post-processing whether that platform is supported. It
+passes `--gpu_arch_platform` only when the candidate appears in TraceLens'
+`list_platforms()` result. This check runs with `TL_EXTENSION`, so platforms
+provided by an extension wheel are included. If the platform is unavailable,
+Magpie logs a warning and continues without architecture-specific roofline
+data. An explicit `tracelens.gpu_arch_config` takes priority and is passed as
+`--gpu_arch_json_path`.
 
 For SGLang, TraceLens inference mode automatically adds
 `--enable-profile-cuda-graph`. It also adds

--- a/docs/reference/benchmark-config.md
+++ b/docs/reference/benchmark-config.md
@@ -225,12 +225,14 @@ and category-specific `param:*` CSVs. They are designed for quick review and
 include operation category, operation name, `param_signature`, `params_json`,
 kernel time, total time percentage, arithmetic intensity, achieved TFLOP/s,
 achieved TB/s, roofline bound, and percent of roofline. The filename records
-the benchmark `ISL`, `OSL`, and `CONC` values. Magpie passes
-`gpu_arch_config` to the inference CLI as `--gpu_arch_json_path`; when it is
-not configured, architecture-dependent roofline columns are omitted from the
-simple summary. Magpie does not pass TraceLens' `--gpu_arch_platform` by
-default because bundled platform support can lag new hardware; use
-`gpu_arch_config` for hardware-specific roofline data.
+the benchmark `ISL`, `OSL`, and `CONC` values. Without an explicit
+`gpu_arch_config`, Magpie infers a candidate platform from `runner_type` and
+checks it against `list_platforms()` in the actual TraceLens post-processing
+environment. The check includes `TL_EXTENSION`, so an extension wheel can add
+platform support such as `MI355X`. Magpie passes `--gpu_arch_platform` only
+when the candidate is supported; otherwise it warns and continues without
+architecture-specific roofline data. An explicit `gpu_arch_config` takes
+priority and is passed as `--gpu_arch_json_path`.
 
 ### SGLang benchmark
 

--- a/docs/reference/benchmark-config.md
+++ b/docs/reference/benchmark-config.md
@@ -76,6 +76,7 @@ benchmark:
       analysis_stages: all          # Optional, default: all
       auto_patch_runtime: true      # Optional, default: true for Docker runs
       tracelens_repo_path: null     # Optional public TraceLens source checkout
+      extension_wheel_path: null    # Optional local TraceLens extension wheel
       cli_timeout_seconds: 2400     # TraceLens postprocess timeout per command
       export_format: csv            # "csv" or "excel"
       perf_report_enabled: true           # Single-rank performance report
@@ -164,6 +165,7 @@ benchmark:
       # analysis_stages defaults to all (prefilldecode, decode, prefill)
       # auto_patch_runtime defaults to true for Docker runs
       # tracelens_repo_path can point to a public TraceLens checkout
+      # extension_wheel_path can add a local TraceLens extension to the image
       # cli_timeout_seconds defaults to 1800
       export_format: csv
       multi_rank_report_enabled: false  # Skip multi-rank for speed
@@ -197,6 +199,7 @@ benchmark:
       analysis_stages: all
       auto_patch_runtime: true
       # tracelens_repo_path: /path/to/TraceLens
+      # extension_wheel_path: /secure/path/to/TraceLens_extension.whl
       cli_timeout_seconds: 2400
       export_format: csv
       perf_report_enabled: true

--- a/examples/benchmarks/benchmark_sqlang_amd_dsr1_fp4.yaml
+++ b/examples/benchmarks/benchmark_sqlang_amd_dsr1_fp4.yaml
@@ -22,7 +22,6 @@ benchmark:
     ISL: 1024
     OSL: 1024
     RANDOM_RANGE_RATIO: 1
-    TL_EXTENSION: "TraceLens_NDA" # Optional: specify TraceLens extension to load
   
   # Profiler configuration
   profiler:
@@ -32,6 +31,8 @@ benchmark:
       enabled: false
     tracelens:
       enabled: true
+      auto_patch_runtime: true
+      # extension_wheel_path: "/secure/path/to/TraceLens_extension.whl"
       
   gap_analysis:
     enabled: false
@@ -40,7 +41,7 @@ benchmark:
 
   # Will auto-clone InferenceX if not specified
   # inferencex_path: ""
-  # image: "image with TraceLens_NDA extension pre-installed" 
+  # hf_cache_path: ""
   benchmark_script: "dsr1_fp4_mi355x.sh"
 
   timeout_seconds: 3600

--- a/examples/benchmarks/benchmark_vllm_tracelens.yaml
+++ b/examples/benchmarks/benchmark_vllm_tracelens.yaml
@@ -53,6 +53,7 @@ benchmark:
       analysis_stages: all        # all | [prefilldecode, decode, prefill]
       auto_patch_runtime: true    # Build TraceLens-ready Docker image if needed
       # tracelens_repo_path: /path/to/TraceLens
+      # extension_wheel_path: /secure/path/to/TraceLens_extension.whl
       export_format: csv          # "csv" or "excel"
       perf_report_enabled: true   # Single-rank performance report
       multi_rank_report_enabled: true   # Multi-rank collective report

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -231,6 +231,109 @@ def test_tracelens_inference_iteration_and_arg_helpers():
     assert not TraceLensInferencePipeline(cfg)._should_enable_sglang_shape_discovery()
 
 
+def test_tracelens_auto_selects_only_a_supported_gpu_platform():
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "sglang",
+            "model": "demo",
+            "profiler": {"tracelens": {"enabled": True}},
+        }
+    )
+    pipeline = TraceLensInferencePipeline(cfg)
+
+    candidate, selected, warning = pipeline._select_gpu_arch_platform(
+        "mi355x",
+        lambda _candidate: subprocess.CompletedProcess(
+            [], 0, "available=MI300X,MI355X\n", ""
+        ),
+        "test TraceLens",
+    )
+
+    assert candidate == "MI355X"
+    assert selected == "MI355X"
+    assert warning is None
+
+    candidate, selected, warning = pipeline._select_gpu_arch_platform(
+        "mi355x",
+        lambda _candidate: subprocess.CompletedProcess(
+            [], 3, "available=MI300X,MI325X\n", ""
+        ),
+        "test TraceLens",
+    )
+
+    assert candidate == "MI355X"
+    assert selected is None
+    assert "MI355X is not supported" in warning
+    assert "available=MI300X,MI325X" in warning
+
+
+def test_tracelens_explicit_gpu_arch_config_skips_platform_probe(tmp_path):
+    arch_config = tmp_path / "mi355x.json"
+    arch_config.write_text("{}", encoding="utf-8")
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "sglang",
+            "model": "demo",
+            "profiler": {
+                "tracelens": {
+                    "enabled": True,
+                    "gpu_arch_config": str(arch_config),
+                }
+            },
+        }
+    )
+
+    def unexpected_probe(_candidate):
+        raise AssertionError("platform probe should not run")
+
+    candidate, selected, warning = TraceLensInferencePipeline(
+        cfg
+    )._select_gpu_arch_platform("mi355x", unexpected_probe, "test TraceLens")
+
+    assert candidate == "MI355X"
+    assert selected is None
+    assert warning is None
+
+
+def test_tracelens_container_platform_probe_uses_extension(
+    tmp_path,
+    monkeypatch,
+):
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "sglang",
+            "model": "demo",
+            "run_mode": "docker",
+            "envs": {"TL_EXTENSION": "TraceLens_NDA"},
+            "profiler": {"tracelens": {"enabled": True}},
+        }
+    )
+    commands = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, "available=MI300X,MI355X\n", "")
+
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_inference.subprocess.run",
+        fake_run,
+    )
+
+    proc = TraceLensInferencePipeline(cfg)._probe_container_gpu_arch_platform(
+        "tracelens-sglang:test",
+        tmp_path,
+        "MI355X",
+    )
+
+    assert proc.returncode == 0
+    assert len(commands) == 1
+    cmd, kwargs = commands[0]
+    assert "TL_EXTENSION=TraceLens_NDA" in cmd
+    assert "MI355X" in cmd[-1]
+    assert "list_platforms" in cmd[-1]
+    assert kwargs["timeout"] == 60
+
+
 def test_resolve_tl_extension_merges_host_and_config(monkeypatch):
     monkeypatch.setenv("TL_EXTENSION", "HostExtension:SharedExtension")
 
@@ -1170,6 +1273,7 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
     assert result["errors"] == []
     assert result["analysis_stages"] == ["decode"]
     assert result["tl_extension"] == "TraceLens_NDA"
+    assert result["gpu_arch_platform_candidate"] == "MI355X"
     assert result["gpu_arch_platform"] is None
     assert result["postprocess_runtime"]["mode"] == "docker"
     assert str(workspace / "tracelens" / "decode_only" / "summary.csv") in result[

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -2,6 +2,8 @@ import csv
 import gzip
 import json
 import subprocess
+import zipfile
+from pathlib import Path
 
 import pytest
 import yaml
@@ -24,15 +26,18 @@ from Magpie.modes.benchmark.tracelens_inference import (
     append_flag_value_args,
     compute_steady_state_iters,
     is_tracelens_patched_sglang_image,
+    resolve_tl_extension,
     trace_arch_platform_from_runner,
 )
 from Magpie.modes.benchmark.tracelens_runtime import (
     available_tracelens_sglang_patch_versions,
     available_tracelens_vllm_patch_versions,
+    derive_tracelens_extension_image_tag,
     derive_tracelens_image_tag,
     docker_image_package_version,
     infer_sglang_patch_version,
     infer_vllm_patch_version,
+    inspect_tracelens_extension_wheel,
     is_tracelens_ready_runtime_image,
     prepare_tracelens_runtime_image,
     runner_type_to_gpu_type,
@@ -129,6 +134,20 @@ def test_tracelens_config_supports_legacy_export_flags():
     assert cfg.export_csv is False
 
 
+def test_tracelens_config_round_trips_extension_wheel_path():
+    cfg = TraceLensConfig.from_dict(
+        {
+            "enabled": True,
+            "extension_wheel_path": "/secure/extensions/custom.whl",
+        }
+    )
+
+    assert cfg.extension_wheel_path == "/secure/extensions/custom.whl"
+    assert cfg.to_dict()["extension_wheel_path"] == (
+        "/secure/extensions/custom.whl"
+    )
+
+
 def test_tracelens_config_normalizes_inference_stages():
     cfg = TraceLensConfig.from_dict(
         {
@@ -183,6 +202,14 @@ def test_tracelens_inference_iteration_and_arg_helpers():
     assert not TraceLensInferencePipeline(cfg)._should_enable_sglang_shape_discovery()
 
 
+def test_resolve_tl_extension_merges_host_and_config(monkeypatch):
+    monkeypatch.setenv("TL_EXTENSION", "HostExtension:SharedExtension")
+
+    assert resolve_tl_extension(
+        {"TL_EXTENSION": "ConfigExtension:SharedExtension"}
+    ) == "HostExtension:SharedExtension:ConfigExtension"
+
+
 def test_tracelens_runtime_image_helpers():
     assert infer_sglang_patch_version("lmsysorg/sglang:v0.5.12-rocm720-mi35x") == "0.5.12"
     assert infer_sglang_patch_version("lmsysorg/sglang:v0.5.13-rocm720-mi35x") == "0.5.13"
@@ -215,6 +242,50 @@ def test_tracelens_runtime_image_helpers():
         "0.5.12",
     )
     assert tag.startswith("magpie-tracelens-sglang:0_5_12-mi355x-")
+    assert derive_tracelens_extension_image_tag(
+        tag,
+        "abcdef0123456789",
+    ).endswith("-ext-abcdef012345")
+
+
+def test_inspect_tracelens_extension_wheel_infers_module_and_normalizes_name(
+    tmp_path,
+):
+    wheel = (
+        tmp_path
+        / "TraceLens_Ext-0.1.0.dev20260529+gacb7fbc6-py3-none-any 1.whl"
+    )
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("TraceLens_Ext/__init__.py", "")
+        archive.writestr(
+            "TraceLens_Ext/Agent/Analysis/utils/arch/ExampleGPU.json",
+            '{"name": "ExampleGPU"}',
+        )
+        archive.writestr(
+            "TraceLens_Ext/Agent/Analysis/utils/agent_extension.py",
+            "",
+        )
+
+    inspected = inspect_tracelens_extension_wheel(wheel)
+
+    assert inspected["module"] == "TraceLens_Ext"
+    assert inspected["filename"] == (
+        "TraceLens_Ext-0.1.0.dev20260529+gacb7fbc6-py3-none-any.whl"
+    )
+    assert len(inspected["sha256"]) == 64
+
+
+def test_inspect_tracelens_extension_wheel_rejects_ambiguous_packages(tmp_path):
+    wheel = tmp_path / "ambiguous-0.1.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        for module in ("ExtensionOne", "ExtensionTwo"):
+            archive.writestr(
+                f"{module}/Agent/Analysis/utils/arch/ExampleGPU.json",
+                "{}",
+            )
+
+    with pytest.raises(ValueError, match="exactly one top-level"):
+        inspect_tracelens_extension_wheel(wheel)
 
 
 def test_sglang_runtime_support_is_read_from_tracelens_checkout(tmp_path):
@@ -411,6 +482,154 @@ def test_prepare_tracelens_runtime_image_prefers_installed_package_version(
     assert result["patch_version_source"] == "package"
     assert result["runtime_package_version"] == "0.22.0+rocm722"
     assert result["image"].startswith("magpie-tracelens-vllm:v22-mi355x-")
+
+
+def test_prepare_tracelens_runtime_image_builds_extension_overlay(
+    tmp_path,
+    monkeypatch,
+):
+    tracelens_repo = tmp_path / "TraceLens"
+    workflow_dir = tracelens_repo / "examples/custom_workflows/inference_analysis"
+    patch_dir = workflow_dir / "vllm_patches"
+    patch_dir.mkdir(parents=True)
+    (workflow_dir / "build_docker_vllm.sh").write_text(
+        "case ${VLLM_VERSION} in\n"
+        "    v21)\n"
+        "        ;;\n"
+        "esac\n"
+    )
+    (patch_dir / "config_vllm_v0.21.0.patch").write_text("patch")
+
+    extension_wheel = (
+        tmp_path
+        / "TraceLens_Ext-0.1.0.dev20260529+gacb7fbc6-py3-none-any 1.whl"
+    )
+    with zipfile.ZipFile(extension_wheel, "w") as archive:
+        archive.writestr("TraceLens_Ext/__init__.py", "")
+        archive.writestr(
+            "TraceLens_Ext/Agent/Analysis/utils/arch/ExampleGPU.json",
+            '{"name": "ExampleGPU"}',
+        )
+
+    monkeypatch.setenv("TRACELENS_REPO_PATH", str(tracelens_repo))
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.docker_image_exists",
+        lambda _image: False,
+    )
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.docker_image_package_version",
+        lambda _image, _package: None,
+    )
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        call = {"cmd": cmd, "kwargs": kwargs}
+        if cmd[:2] == ["docker", "build"]:
+            build_context = Path(cmd[-1])
+            call["dockerfile"] = (build_context / "Dockerfile").read_text()
+            call["context_files"] = sorted(
+                path.name for path in build_context.iterdir()
+            )
+        calls.append(call)
+        return subprocess.CompletedProcess(cmd, 0, stdout="built\n")
+
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.subprocess.run",
+        fake_run,
+    )
+
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "vllm",
+            "model": "demo",
+            "docker_image": "vllm/vllm-openai-rocm:v0.21.0",
+            "envs": {"TL_EXTENSION": "ExistingExtension"},
+            "profiler": {
+                "tracelens": {
+                    "enabled": True,
+                    "extension_wheel_path": str(extension_wheel),
+                }
+            },
+        }
+    )
+
+    result = prepare_tracelens_runtime_image(
+        cfg,
+        base_image=cfg.docker_image,
+        runner_type="mi355x",
+    )
+
+    assert result["built"] is True
+    assert result["public_runtime_built"] is True
+    assert result["extension_built"] is True
+    assert result["extension_module"] == "TraceLens_Ext"
+    assert result["image"].endswith(
+        f"-ext-{result['extension_wheel_sha256'][:12]}"
+    )
+    assert cfg.envs["TL_EXTENSION"] == "ExistingExtension:TraceLens_Ext"
+    assert calls[0]["cmd"][0] == "bash"
+    assert calls[1]["cmd"][:2] == ["docker", "build"]
+    assert "ENV TL_EXTENSION=TraceLens_Ext" in calls[1]["dockerfile"]
+    assert (
+        "TraceLens_Ext-0.1.0.dev20260529+gacb7fbc6-py3-none-any.whl"
+        in calls[1]["context_files"]
+    )
+
+
+def test_prepare_tracelens_runtime_image_overlays_ready_image(
+    tmp_path,
+    monkeypatch,
+):
+    extension_wheel = tmp_path / "Custom_Ext-1.0-py3-none-any.whl"
+    with zipfile.ZipFile(extension_wheel, "w") as archive:
+        archive.writestr("Custom_Ext/__init__.py", "")
+        archive.writestr(
+            "Custom_Ext/Agent/Analysis/utils/agent_extension.py",
+            "",
+        )
+
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.docker_image_exists",
+        lambda _image: False,
+    )
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="built\n")
+
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.subprocess.run",
+        fake_run,
+    )
+
+    base_image = "magpie-tracelens-vllm:v21-mi355x-public"
+    cfg = BenchmarkConfig.from_dict(
+        {
+            "framework": "vllm",
+            "model": "demo",
+            "docker_image": base_image,
+            "profiler": {
+                "tracelens": {
+                    "enabled": True,
+                    "extension_wheel_path": str(extension_wheel),
+                }
+            },
+        }
+    )
+
+    result = prepare_tracelens_runtime_image(
+        cfg,
+        base_image=base_image,
+        runner_type="mi355x",
+    )
+
+    assert result["public_runtime_built"] is False
+    assert result["extension_built"] is True
+    assert result["public_runtime_image"] == base_image
+    assert result["extension_module"] == "Custom_Ext"
+    assert calls[0][:2] == ["docker", "build"]
 
 
 def test_tracelens_inference_prepare_patches_and_restores(tmp_path):

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -42,7 +42,36 @@ from Magpie.modes.benchmark.tracelens_runtime import (
     prepare_tracelens_runtime_image,
     runner_type_to_gpu_type,
 )
+from Magpie.modes.benchmark.workspace import WorkspaceManager
 from Magpie.utils.gpu import GPUVendor
+
+
+def test_workspace_manager_makes_docker_mounts_container_writable(tmp_path):
+    workspace = WorkspaceManager(
+        base_dir=str(tmp_path),
+        framework="vllm",
+        container_writable=True,
+    ).create()
+
+    assert workspace.stat().st_mode & 0o777 == 0o777
+    assert (workspace / "torch_trace").stat().st_mode & 0o777 == 0o777
+    assert (workspace / "system_profile").stat().st_mode & 0o777 == 0o777
+
+
+def test_benchmark_mode_only_requests_container_writable_workspace_for_docker(
+    tmp_path,
+):
+    docker_mode = BenchmarkMode(
+        BenchmarkConfig(framework="vllm", model="demo", run_mode="docker"),
+        output_dir=str(tmp_path / "docker"),
+    )
+    local_mode = BenchmarkMode(
+        BenchmarkConfig(framework="vllm", model="demo", run_mode="local"),
+        output_dir=str(tmp_path / "local"),
+    )
+
+    assert docker_mode.workspace_mgr.container_writable is True
+    assert local_mode.workspace_mgr.container_writable is False
 
 
 def test_benchmark_server_lifecycle_requires_local_runtime():


### PR DESCRIPTION
### Summary

This PR adds an optional `extension_wheel_path` setting for TraceLens-enabled benchmarks. Magpie inspects the wheel, infers its extension module, builds a SHA-addressed overlay image on top of the public TraceLens-patched runtime, and automatically passes TL_EXTENSION to the benchmark container.
It also makes Docker benchmark workspaces writable for containers running with user-namespace remapping or NFS root squash, so server logs and profiler traces can be written reliably.

### Validation

93 unit tests passed.
Built and validated a vLLM + extension_wheel overlay image on MI355X. Benchmark has been validated.