### PR TITLE
Update default benchmark images for vLLM and SGLang

### DIFF
--- a/Magpie/benchmark_images.yaml
+++ b/Magpie/benchmark_images.yaml
@@ -11,21 +11,21 @@
 
 vllm:
   # AMD GPUs
-  gfx942: "vllm/vllm-openai-rocm:v0.19.1"
-  gfx950: "vllm/vllm-openai-rocm:v0.19.1"
+  gfx942: "vllm/vllm-openai-rocm:v0.23.0"
+  gfx950: "vllm/vllm-openai-rocm:v0.23.0"
   # NVIDIA GPUs
-  sm_80: "vllm/vllm-openai:v0.19.1"
-  sm_90: "vllm/vllm-openai:v0.19.1"
-  sm_100: "vllm/vllm-openai:v0.19.1"
+  sm_80: "vllm/vllm-openai:v0.23.0"
+  sm_90: "vllm/vllm-openai:v0.23.0"
+  sm_100: "vllm/vllm-openai:v0.23.0"
 
 sglang:
   # AMD GPUs
   gfx942: "lmsysorg/sglang:v0.5.12-rocm720-mi30x"
   gfx950: "lmsysorg/sglang:v0.5.12-rocm720-mi35x"
   # NVIDIA GPUs
-  sm_80: "lmsysorg/sglang:v0.5.8-cu130-amd64-runtime"
-  sm_90: "lmsysorg/sglang:v0.5.8-cu130-amd64-runtime"
-  sm_100: "lmsysorg/sglang:v0.5.8-cu130-amd64-runtime"
+  sm_80: "lmsysorg/sglang:v0.5.12-cu130-amd64-runtime"
+  sm_90: "lmsysorg/sglang:v0.5.12-cu130-amd64-runtime"
+  sm_100: "lmsysorg/sglang:v0.5.12-cu130-amd64-runtime"
 
 # Atom exposes an OpenAI-compatible HTTP server (atom.entrypoints.openai_server)
 # that is wire-compatible with vLLM, so the bench client reuses --backend vllm.

--- a/examples/benchmarks/benchmark_vllm_amd_kimi_k2_6_mxfp4.yaml
+++ b/examples/benchmarks/benchmark_vllm_amd_kimi_k2_6_mxfp4.yaml
@@ -30,7 +30,7 @@ benchmark:
     tracelens:
       enabled: false
 
-  docker_image: "vllm/vllm-openai-rocm:nightly"
+  docker_image: "vllm/vllm-openai-rocm:v0.23.0"
   # hf_cache_path: ""
   benchmark_script: "vllm_mi355x.sh"
   timeout_seconds: 3600


### PR DESCRIPTION
## Summary

- Update the default vLLM benchmark images from `v0.19.1` to `v0.23.0` for AMD and NVIDIA GPUs.
- Pin the Kimi K2.6 MXFP4 benchmark image to `vllm/vllm-openai-rocm:v0.23.0` instead of using `nightly`.

## Testing

- All benchmark had tested on AMD GPUs and configuration-only changes so no functional tests were required.