### PR TITLE
test: raise coverage above 90% and add CPU-only CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,27 @@ permissions:
   contents: read
 
 jobs:
+  python-310:
+    name: Python 3.10 / tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install package and test dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -e ".[dev,mcp]"
+
+      - name: Run unit tests
+        run: python -m pytest -q tests
+
   coverage:
     name: Python 3.12 / coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,37 @@
+name: Unit tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main, "test/**"]
+  workflow_dispatch:
+
+concurrency:
+  group: unit-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: Python 3.12 / coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package and test dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -e ".[dev,mcp]"
+
+      - name: Run unit tests with coverage gate
+        run: make coverage PYTHON_VENV=python

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Magpie Makefile
 # ========================
-.PHONY: help venv install-dev install lint format test clean verify
+.PHONY: help venv install-dev install lint format test coverage clean verify
 
 PYTHON ?= python3
 VENV_DIR ?= .venv
@@ -19,6 +19,7 @@ help:
 	@echo "  make format        - Format code (black + isort)"
 	@echo "  make lint          - Lint (ruff + mypy)"
 	@echo "  make test          - Run tests (pytest)"
+	@echo "  make coverage      - Run unit tests with the 90% package coverage gate"
 	@echo "  make verify        - Smoke check imports / CLI"
 	@echo "  make clean         - Remove build + cache artifacts"
 
@@ -46,6 +47,9 @@ format:
 
 test:
 	$(PYTHON_VENV) -m pytest -q
+
+coverage:
+	$(PYTHON_VENV) -m pytest -q tests --cov=Magpie --cov-report=term-missing --cov-fail-under=90
 
 verify: venv
 	$(PYTHON_VENV) -c "import Magpie; print('Import OK')"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2",
 ]
 # IntelliKit components are pinned but optional because Accordo builds native
 # ROCm/HIP code and should not be required for a plain Magpie install.
@@ -49,7 +49,7 @@ intellikit = [
     "accordo @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=accordo",
 ]
 all = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/tests/test_benchmark_support.py
+++ b/tests/test_benchmark_support.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -25,6 +26,7 @@ from Magpie.modes.benchmark.tracelens_inference import (
     TraceLensInferencePipeline,
     append_flag_value_args,
     compute_steady_state_iters,
+    host_atom_supports_detailed_annotation,
     is_tracelens_patched_sglang_image,
     resolve_tl_extension,
     trace_arch_platform_from_runner,
@@ -34,6 +36,7 @@ from Magpie.modes.benchmark.tracelens_runtime import (
     available_tracelens_vllm_patch_versions,
     derive_tracelens_extension_image_tag,
     derive_tracelens_image_tag,
+    docker_image_probe,
     docker_image_package_version,
     infer_sglang_patch_version,
     infer_vllm_patch_version,
@@ -174,9 +177,7 @@ def test_tracelens_config_round_trips_extension_wheel_path():
     )
 
     assert cfg.extension_wheel_path == "/secure/extensions/custom.whl"
-    assert cfg.to_dict()["extension_wheel_path"] == (
-        "/secure/extensions/custom.whl"
-    )
+    assert cfg.to_dict()["extension_wheel_path"] == ("/secure/extensions/custom.whl")
 
 
 def test_tracelens_config_normalizes_inference_stages():
@@ -231,6 +232,28 @@ def test_tracelens_inference_iteration_and_arg_helpers():
         }
     )
     assert not TraceLensInferencePipeline(cfg)._should_enable_sglang_shape_discovery()
+
+
+def test_host_atom_detailed_annotation_detection(tmp_path, monkeypatch):
+    atom_package = tmp_path / "atom"
+    envs_file = atom_package / "utils" / "envs.py"
+    envs_file.parent.mkdir(parents=True)
+    envs_file.write_text("ATOM_ENABLE_DETAILED_ANNOTATION = False\n")
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_inference.importlib.util.find_spec",
+        lambda _name: SimpleNamespace(origin=str(atom_package / "__init__.py")),
+    )
+
+    assert host_atom_supports_detailed_annotation() is True
+
+
+def test_host_atom_detailed_annotation_detection_handles_missing_install(monkeypatch):
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_inference.importlib.util.find_spec",
+        lambda _name: None,
+    )
+
+    assert host_atom_supports_detailed_annotation() is False
 
 
 def test_tracelens_auto_selects_only_a_supported_gpu_platform():
@@ -339,14 +362,19 @@ def test_tracelens_container_platform_probe_uses_extension(
 def test_resolve_tl_extension_merges_host_and_config(monkeypatch):
     monkeypatch.setenv("TL_EXTENSION", "HostExtension:SharedExtension")
 
-    assert resolve_tl_extension(
-        {"TL_EXTENSION": "ConfigExtension:SharedExtension"}
-    ) == "HostExtension:SharedExtension:ConfigExtension"
+    assert (
+        resolve_tl_extension({"TL_EXTENSION": "ConfigExtension:SharedExtension"})
+        == "HostExtension:SharedExtension:ConfigExtension"
+    )
 
 
 def test_tracelens_runtime_image_helpers():
-    assert infer_sglang_patch_version("lmsysorg/sglang:v0.5.12-rocm720-mi35x") == "0.5.12"
-    assert infer_sglang_patch_version("lmsysorg/sglang:v0.5.13-rocm720-mi35x") == "0.5.13"
+    assert (
+        infer_sglang_patch_version("lmsysorg/sglang:v0.5.12-rocm720-mi35x") == "0.5.12"
+    )
+    assert (
+        infer_sglang_patch_version("lmsysorg/sglang:v0.5.13-rocm720-mi35x") == "0.5.13"
+    )
     assert (
         infer_sglang_patch_version(
             "internal/sglang:rocm",
@@ -385,10 +413,7 @@ def test_tracelens_runtime_image_helpers():
 def test_inspect_tracelens_extension_wheel_infers_module_and_normalizes_name(
     tmp_path,
 ):
-    wheel = (
-        tmp_path
-        / "TraceLens_Ext-0.1.0.dev20260529+gacb7fbc6-py3-none-any 1.whl"
-    )
+    wheel = tmp_path / "TraceLens_Ext-0.1.0.dev20260529+gacb7fbc6-py3-none-any 1.whl"
     with zipfile.ZipFile(wheel, "w") as archive:
         archive.writestr("TraceLens_Ext/__init__.py", "")
         archive.writestr(
@@ -430,20 +455,18 @@ def test_sglang_runtime_support_is_read_from_tracelens_checkout(tmp_path):
     (patch_root / "sglang_0_5_14").mkdir(parents=True)
     (workflow_dir / "build_docker_sglang.sh").write_text(
         "normalize_version() {\n"
-        "    case \"$1\" in\n"
+        '    case "$1" in\n'
         "        0.5.12|v0512|0512|5.12)\n"
-        "            echo \"0.5.12\"\n"
+        '            echo "0.5.12"\n'
         "            ;;\n"
         "        0.5.13|v0513|0513|5.13)\n"
-        "            echo \"0.5.13\"\n"
+        '            echo "0.5.13"\n'
         "            ;;\n"
         "    esac\n"
         "}\n"
     )
 
-    assert available_tracelens_sglang_patch_versions(tracelens_repo) == [
-        "0.5.13"
-    ]
+    assert available_tracelens_sglang_patch_versions(tracelens_repo) == ["0.5.13"]
     assert (
         infer_sglang_patch_version(
             "lmsysorg/sglang:v0.5.13-rocm720-mi35x",
@@ -584,6 +607,26 @@ def test_prepare_tracelens_runtime_image_installs_tracelens_when_missing(
     assert "pip install --no-cache-dir /tmp/TraceLens" in seen["dockerfile"]
 
 
+def test_prepare_tracelens_runtime_image_honors_custom_overlay_tag(
+    tmp_path, monkeypatch
+):
+    cfg = _upstream_vllm_config(tmp_path, monkeypatch, has_tracelens=False)
+    cfg.profiler.tracelens.runtime_patch_image_tag = "example/custom-tracelens:latest"
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.docker_image_exists",
+        lambda image: image == "example/custom-tracelens:latest",
+    )
+
+    result = prepare_tracelens_runtime_image(
+        cfg,
+        base_image=cfg.docker_image,
+        runner_type="mi355x",
+    )
+
+    assert result["image"] == "example/custom-tracelens:latest"
+    assert result["built"] is False
+
+
 def test_tracelens_inference_prepare_sets_vllm_capture_torch_profiler_flag(tmp_path):
     inferencex = tmp_path / "InferenceX"
     bench_dir = inferencex / "benchmarks"
@@ -719,15 +762,53 @@ def test_tracelens_inference_prepare_does_not_duplicate_atom_mark_trace(tmp_path
     assert cfg.envs["EXTRA_ATOM_ARGS"].count("--mark-trace") == 1
 
 
+def test_tracelens_inference_prepare_probes_local_atom_when_runtime_unknown(
+    tmp_path, monkeypatch
+):
+    cfg = _atom_config(tmp_path)
+    cfg.run_mode = "local"
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_inference.host_atom_supports_detailed_annotation",
+        lambda: True,
+    )
+
+    TraceLensInferencePipeline(cfg).prepare(tmp_path / "workspace")
+
+    assert cfg.envs["ATOM_ENABLE_DETAILED_ANNOTATION"] == "1"
+
+
+def test_tracelens_inference_prepare_probes_docker_atom_when_runtime_unknown(
+    tmp_path, monkeypatch
+):
+    cfg = _atom_config(tmp_path)
+    cfg.docker_image = "example/atom:latest"
+    seen = {}
+
+    def probe(image, script):
+        seen.update(image=image, script=script)
+        return True
+
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_inference.docker_image_probe",
+        probe,
+    )
+
+    TraceLensInferencePipeline(cfg).prepare(tmp_path / "workspace")
+
+    assert seen["image"] == "example/atom:latest"
+    assert "ATOM_ENABLE_DETAILED_ANNOTATION" in seen["script"]
+    assert cfg.envs["ATOM_ENABLE_DETAILED_ANNOTATION"] == "1"
+
+
 def test_tracelens_inference_resolves_atom_rank0_trace_and_capture_folder(tmp_path):
     torch_trace = tmp_path / "torch_trace"
     for rank in range(2):
         capture = torch_trace / f"rank_{rank}" / "capture_traces"
         capture.mkdir(parents=True)
         (capture / f"bs_1_rank{rank}.json.gz").write_bytes(b"")
-        (torch_trace / f"rank_{rank}" / f"demo_ts_2026_{rank}.pt.trace.json.gz").write_bytes(
-            b""
-        )
+        (
+            torch_trace / f"rank_{rank}" / f"demo_ts_2026_{rank}.pt.trace.json.gz"
+        ).write_bytes(b"")
 
     pipeline = TraceLensInferencePipeline(_atom_config(tmp_path))
     rank0_trace = pipeline._locate_rank0_trace(torch_trace)
@@ -824,6 +905,36 @@ def test_docker_image_package_version_reads_importlib_metadata(monkeypatch):
     assert seen["kwargs"]["timeout"] == 120
 
 
+@pytest.mark.parametrize(
+    ("completed", "expected"),
+    [
+        (subprocess.CompletedProcess([], 0, stdout="noise\nTrue\n"), True),
+        (subprocess.CompletedProcess([], 0, stdout="False\n"), False),
+        (subprocess.CompletedProcess([], 2, stdout="True\n"), False),
+        (None, False),
+    ],
+)
+def test_docker_image_probe_interprets_probe_result(monkeypatch, completed, expected):
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime._run_python_in_image",
+        lambda *_args: completed,
+    )
+
+    assert docker_image_probe("example/image:latest", "print(True)") is expected
+
+
+def test_docker_image_probe_handles_docker_errors(monkeypatch):
+    def fail(*_args, **_kwargs):
+        raise OSError("docker unavailable")
+
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.tracelens_runtime.subprocess.run",
+        fail,
+    )
+
+    assert docker_image_probe("example/image:latest", "print(True)") is False
+
+
 def test_resolve_tracelens_repo_path_clones_main_when_unconfigured(
     tmp_path,
     monkeypatch,
@@ -838,9 +949,7 @@ def test_resolve_tracelens_repo_path_clones_main_when_unconfigured(
     def fake_run(cmd, **kwargs):
         clone_calls.append((cmd, kwargs))
         checkout = Path(cmd[-1])
-        (
-            checkout / "examples/custom_workflows/inference_analysis"
-        ).mkdir(parents=True)
+        (checkout / "examples/custom_workflows/inference_analysis").mkdir(parents=True)
         return subprocess.CompletedProcess(cmd, 0)
 
     monkeypatch.setattr(
@@ -887,16 +996,14 @@ def test_prepare_tracelens_runtime_image_reuses_existing_derived_image(
     workflow_dir.mkdir(parents=True)
     (workflow_dir / "build_docker_sglang.sh").write_text(
         "normalize_version() {\n"
-        "    case \"$1\" in\n"
+        '    case "$1" in\n'
         "        0.5.12|v0512|0512|5.12)\n"
-        "            echo \"0.5.12\"\n"
+        '            echo "0.5.12"\n'
         "            ;;\n"
         "    esac\n"
         "}\n"
     )
-    (workflow_dir / "sglang_roofline_patches" / "sglang_0_5_12").mkdir(
-        parents=True
-    )
+    (workflow_dir / "sglang_roofline_patches" / "sglang_0_5_12").mkdir(parents=True)
     monkeypatch.setenv("TRACELENS_REPO_PATH", str(tracelens_repo))
     monkeypatch.setattr(
         "Magpie.modes.benchmark.tracelens_runtime.docker_image_exists",
@@ -936,10 +1043,7 @@ def test_prepare_tracelens_runtime_image_prefers_installed_package_version(
     patch_dir = workflow_dir / "vllm_patches"
     patch_dir.mkdir(parents=True)
     (workflow_dir / "build_docker_vllm.sh").write_text(
-        "case ${VLLM_VERSION} in\n"
-        "    v22)\n"
-        "        ;;\n"
-        "esac\n"
+        "case ${VLLM_VERSION} in\n" "    v22)\n" "        ;;\n" "esac\n"
     )
     (patch_dir / "config_vllm_v0.22.0.patch").write_text("patch")
     monkeypatch.setenv("TRACELENS_REPO_PATH", str(tracelens_repo))
@@ -983,16 +1087,12 @@ def test_prepare_tracelens_runtime_image_builds_extension_overlay(
     patch_dir = workflow_dir / "vllm_patches"
     patch_dir.mkdir(parents=True)
     (workflow_dir / "build_docker_vllm.sh").write_text(
-        "case ${VLLM_VERSION} in\n"
-        "    v21)\n"
-        "        ;;\n"
-        "esac\n"
+        "case ${VLLM_VERSION} in\n" "    v21)\n" "        ;;\n" "esac\n"
     )
     (patch_dir / "config_vllm_v0.21.0.patch").write_text("patch")
 
     extension_wheel = (
-        tmp_path
-        / "TraceLens_Ext-0.1.0.dev20260529+gacb7fbc6-py3-none-any 1.whl"
+        tmp_path / "TraceLens_Ext-0.1.0.dev20260529+gacb7fbc6-py3-none-any 1.whl"
     )
     with zipfile.ZipFile(extension_wheel, "w") as archive:
         archive.writestr("TraceLens_Ext/__init__.py", "")
@@ -1054,9 +1154,7 @@ def test_prepare_tracelens_runtime_image_builds_extension_overlay(
     assert result["public_runtime_built"] is True
     assert result["extension_built"] is True
     assert result["extension_module"] == "TraceLens_Ext"
-    assert result["image"].endswith(
-        f"-ext-{result['extension_wheel_sha256'][:12]}"
-    )
+    assert result["image"].endswith(f"-ext-{result['extension_wheel_sha256'][:12]}")
     assert cfg.envs["TL_EXTENSION"] == "ExistingExtension:TraceLens_Ext"
     assert calls[0]["cmd"][0] == "bash"
     assert calls[1]["cmd"][:2] == ["docker", "build"]
@@ -1273,9 +1371,7 @@ def test_tracelens_inference_sglang_step_marker_fallback(tmp_path):
     assert "wrote 2 trace window" in warnings[-1]
     rows = list(csv.DictReader((split_dir / "execution_details.csv").open()))
     assert {row["stage"] for row in rows} == {"decode", "prefill"}
-    assert {
-        row["phase_avg_bs"] for row in rows
-    } == {"64.0", "4.0"}
+    assert {row["phase_avg_bs"] for row in rows} == {"64.0", "4.0"}
     decode_trace = split_dir / "decode_only_step.trace.json.gz"
     with gzip.open(decode_trace, "rt", encoding="utf-8") as handle:
         decode_events = json.load(handle)["traceEvents"]
@@ -1363,10 +1459,7 @@ def test_tracelens_inference_skips_empty_gpu_trace_candidates(tmp_path):
     assert decode_pick.gpu_duration == 22082.06
     assert decode_pick.gpu_busy_duration == 18000.5
     assert decode_pick.selection_reason is not None
-    assert (
-        "valid single-iteration traces with GPU work"
-        in decode_pick.selection_reason
-    )
+    assert "valid single-iteration traces with GPU work" in decode_pick.selection_reason
 
 
 def test_tracelens_inference_prefers_representative_gpu_work(tmp_path):
@@ -1521,8 +1614,7 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
                 writer.writerow(
                     {
                         "output_path": (
-                            "/workspace/torch_trace/trace_split/"
-                            "decode.trace.json.gz"
+                            "/workspace/torch_trace/trace_split/" "decode.trace.json.gz"
                         ),
                         "num_steps": "1",
                         "phase_avg_bs": "64",
@@ -1637,9 +1729,10 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
     assert result["gpu_arch_platform_candidate"] == "MI355X"
     assert result["gpu_arch_platform"] is None
     assert result["postprocess_runtime"]["mode"] == "docker"
-    assert str(workspace / "tracelens" / "decode_only" / "summary.csv") in result[
-        "output_files"
-    ]
+    assert (
+        str(workspace / "tracelens" / "decode_only" / "summary.csv")
+        in result["output_files"]
+    )
     simple_summary = (
         workspace
         / "tracelens"
@@ -1651,12 +1744,10 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
     )
     assert len(docker_cmds) == 2
     assert all(
-        cmd[:5] == ["docker", "run", "--rm", "--network", "none"]
-        for cmd in docker_cmds
+        cmd[:5] == ["docker", "run", "--rm", "--network", "none"] for cmd in docker_cmds
     )
     assert all(
-        "--gpus" not in cmd and "--device=/dev/kfd" not in cmd
-        for cmd in docker_cmds
+        "--gpus" not in cmd and "--device=/dev/kfd" not in cmd for cmd in docker_cmds
     )
     assert any("TL_EXTENSION=TraceLens_NDA" in cmd for cmd in docker_cmds)
     assert any(
@@ -1722,9 +1813,7 @@ def test_tracelens_inference_analysis_runs_in_cpu_only_container(
             "pct_roofline_mean": "70",
             "roofline_time_us": "20",
             "has_perf_model": "True",
-            "params_json": (
-                '{"K":"7168","M":"8192","N":"512","dtype_A_B":"bf16"}'
-            ),
+            "params_json": ('{"K":"7168","M":"8192","N":"512","dtype_A_B":"bf16"}'),
             "input_dims": "[[8192, 7168], [7168, 512]]",
             "input_type": "['bf16', 'bf16']",
         }
@@ -2079,7 +2168,9 @@ def test_result_parser_finds_atom_nested_rank_traces(tmp_path):
             {"cat": "cpu_op", "name": "ignored", "dur": 999},
         ]
     }
-    with gzip.open(rank_dir / "atom_ts_20260528_120000_001.pt.trace.json.gz", "wt") as f:
+    with gzip.open(
+        rank_dir / "atom_ts_20260528_120000_001.pt.trace.json.gz", "wt"
+    ) as f:
         json.dump(trace, f)
 
     kernels = ResultParser.parse_torch_trace(trace_dir)
@@ -2329,7 +2420,9 @@ def test_benchmark_result_summary_includes_sections():
 
 
 def test_benchmark_config_accepts_xdit_scriptable_framework():
-    cfg = BenchmarkConfig(framework="XDIT", model="/models/FLUX.2-dev", run_mode="local")
+    cfg = BenchmarkConfig(
+        framework="XDIT", model="/models/FLUX.2-dev", run_mode="local"
+    )
     assert cfg.framework == "xdit"
     assert cfg.is_scriptable is True
 
@@ -2350,7 +2443,9 @@ def test_benchmark_config_xdit_requires_local_run_mode():
     # must be rejected at config time.
     for bad_mode in ("docker", "ray"):
         with pytest.raises(ValueError):
-            BenchmarkConfig(framework="xdit", model="/models/FLUX.2-dev", run_mode=bad_mode)
+            BenchmarkConfig(
+                framework="xdit", model="/models/FLUX.2-dev", run_mode=bad_mode
+            )
 
 
 def test_result_parser_fails_on_quality_gate_regression(tmp_path):

--- a/tests/test_benchmark_unit_coverage.py
+++ b/tests/test_benchmark_unit_coverage.py
@@ -1,0 +1,365 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from Magpie.modes.benchmark.image_selector import ImageSelector
+from Magpie.modes.benchmark.inferencex import (
+    InferenceXManager,
+    _resolve_default_inferencex_dir,
+    ensure_inferencex_available,
+    get_manager,
+)
+from Magpie.modes.benchmark.result import (
+    BenchmarkResult,
+    KernelMetrics,
+    LatencyMetrics,
+    ResultParser,
+    ThroughputMetrics,
+)
+from Magpie.modes.benchmark.workspace import WorkspaceManager
+from Magpie.utils.gpu import GPUVendor
+
+
+def test_benchmark_result_serialization_and_full_summary(tmp_path):
+    result = BenchmarkResult(
+        success=True,
+        framework="vllm",
+        model="demo",
+        throughput=ThroughputMetrics(
+            request_throughput=12.5,
+            output_throughput=100,
+            total_token_throughput=150,
+            completed_requests=20,
+            duration_seconds=2,
+        ),
+        latency=LatencyMetrics(
+            ttft_mean=1,
+            ttft_p99=2,
+            tpot_mean=3,
+            tpot_p99=4,
+            itl_mean=5,
+            itl_p99=6,
+            e2el_mean=7,
+            e2el_p99=8,
+        ),
+        kernel_summary=[KernelMetrics("gemm", 2.5, 100, 3)],
+        top_bottlenecks=[f"kernel-{index}" for index in range(7)],
+        tracelens_analysis={
+            "output_files": [
+                str(tmp_path / f"report-{index}.csv") for index in range(5)
+            ],
+            "errors": ["partial report"],
+        },
+        gap_analysis={
+            "config": {
+                "trace_start_pct": 10,
+                "trace_end_pct": 90,
+                "categories": ["gemm", "communication"],
+            },
+            "top_kernels": [
+                {
+                    "name": f"kernel-{index}",
+                    "pct_total": 20,
+                    "self_cuda_total_us": 5,
+                    "calls": 2,
+                }
+                for index in range(7)
+            ],
+        },
+        gpu_monitor={
+            "sample_count": 2,
+            "duration_sec": 1,
+            "temperature_c": {"min": 40, "max": 50, "avg": 45},
+            "gpu_clock_mhz": {"min": 1000, "max": 1200, "avg": 1100},
+            "power_watts": {"min": 200, "max": 250, "avg": 225},
+        },
+        errors=["example warning"],
+        workload_kind="diffusion",
+        throughput_unit="img/s",
+        quality_gate={"passed": True},
+        latency_s=0.5,
+    )
+
+    serialized = result.to_dict()
+    summary = result.get_summary()
+
+    assert serialized["kernel_summary"] == [
+        {"name": "gemm", "time_ms": 2.5, "percent": 100, "calls": 3}
+    ]
+    assert serialized["workload_kind"] == "diffusion"
+    assert serialized["throughput_unit"] == "img/s"
+    assert serialized["quality_gate"] == {"passed": True}
+    assert serialized["latency_s"] == 0.5
+    assert "Request throughput: 12.50 req/s" in summary
+    assert "TTFT (mean/p99): 1.00ms / 2.00ms" in summary
+    assert "Top Bottleneck Kernels:" in summary
+    assert "... and 2 more" in summary
+    assert "TraceLens Analysis:" in summary
+    assert "Warning: partial report" in summary
+    assert "Window: 10%-90%" in summary
+    assert "Categories: gemm, communication" in summary
+    assert "GPU Hardware Monitoring:" in summary
+    assert "Temperature: 40.0°C - 50.0°C" in summary
+    assert "Errors:" in summary
+
+
+def test_result_parser_handles_missing_invalid_and_failed_quality_gate(tmp_path):
+    missing = ResultParser.parse_inferencex_result(tmp_path / "missing.json")
+    assert missing.success is False
+    assert "Result file not found" in missing.errors[0]
+
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{")
+    parsed = ResultParser.parse_inferencex_result(invalid)
+    assert parsed.success is False
+    assert "Failed to parse JSON" in parsed.errors[0]
+
+    failed_gate = tmp_path / "failed-gate.json"
+    failed_gate.write_text(
+        json.dumps({"model_id": "demo", "quality_gate": {"passed": False}})
+    )
+    parsed = ResultParser.parse_inferencex_result(failed_gate)
+    assert parsed.success is False
+    assert parsed.model == "demo"
+    assert "Quality gate failed" in parsed.errors[0]
+
+
+def test_workspace_manager_lifecycle_and_result_collection(tmp_path):
+    manager = WorkspaceManager(str(tmp_path), framework="vllm")
+    assert manager.workspace_path is None
+    assert manager.torch_trace_dir is None
+    assert manager.system_profile_dir is None
+    assert manager.get_result_file_path() is None
+    assert manager.collect_results() == {}
+    manager.save_report({"ignored": True})
+    manager.save_summary("ignored")
+    manager.cleanup()
+
+    workspace = manager.create({"model": "demo"})
+    assert workspace.is_absolute()
+    assert manager.workspace_path == workspace
+    assert manager.torch_trace_dir == workspace / "torch_trace"
+    assert manager.system_profile_dir == workspace / "system_profile"
+    assert manager.get_result_file_path("custom.json") == workspace / "custom.json"
+    assert (workspace / "config.yaml").read_text().strip() == "model: demo"
+
+    manager.save_report({"success": True})
+    manager.save_summary("all good")
+    (workspace / "inferencex_result.json").write_text('{"throughput": 12}')
+    (workspace / "torch_trace" / "trace.json").write_text("{}")
+    (workspace / "system_profile" / "metrics.csv").write_text("metric,value")
+    (workspace / "server.log").write_text("ready")
+    (workspace / "worker.pid").write_text("123")
+
+    results = manager.collect_results()
+    assert results["inferencex_result"] == {"throughput": 12}
+    assert results["torch_trace_files"] == [
+        str(workspace / "torch_trace" / "trace.json")
+    ]
+    assert results["system_profile_files"] == [
+        str(workspace / "system_profile" / "metrics.csv")
+    ]
+    assert results["server_log"] == "ready"
+    assert json.loads((workspace / "benchmark_report.json").read_text()) == {
+        "success": True
+    }
+    assert (workspace / "summary.txt").read_text() == "all good"
+
+    manager.cleanup(keep_results=True)
+    assert not (workspace / "worker.pid").exists()
+    assert workspace.exists()
+    assert manager.workspace_path is None
+
+
+def test_workspace_manager_removes_workspace_and_lists_only_benchmarks(tmp_path):
+    first = WorkspaceManager(str(tmp_path), framework="atom")
+    workspace = first.create()
+    (tmp_path / "unrelated").mkdir()
+    (tmp_path / "plain-file").write_text("x")
+
+    listed = WorkspaceManager.list_workspaces(str(tmp_path))
+    assert listed == [str(workspace)]
+    assert WorkspaceManager.list_workspaces(str(tmp_path / "missing")) == []
+
+    first.cleanup(keep_results=False)
+    assert not workspace.exists()
+    assert first.workspace_path is None
+
+
+def test_workspace_manager_handles_file_io_failures(tmp_path, monkeypatch):
+    manager = WorkspaceManager(str(tmp_path), framework="vllm")
+    workspace = manager.create()
+    (workspace / "inferencex_result.json").touch()
+    (workspace / "server.log").touch()
+
+    def fail_open(*_args, **_kwargs):
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr("builtins.open", fail_open)
+    manager._save_config_snapshot(workspace, {"model": "demo"})
+    manager.save_report({"success": True})
+    manager.save_summary("summary")
+    results = manager.collect_results()
+
+    assert results["inferencex_result"] is None
+    assert results["server_log"] is None
+
+
+def test_image_selector_loads_mapping_and_selects_images(tmp_path, monkeypatch):
+    config = tmp_path / "images.yaml"
+    config.write_text("vllm:\n  gfx942: example/vllm:latest\n")
+    selector = ImageSelector(str(config))
+
+    assert selector.select_image("VLLM", "gfx942") == "example/vllm:latest"
+    assert (
+        selector.select_image("missing", override_image="override:image")
+        == "override:image"
+    )
+    assert selector.list_available_images() == {
+        "vllm": {"gfx942": "example/vllm:latest"}
+    }
+    assert selector.list_available_images("VLLM") == {
+        "VLLM": {"gfx942": "example/vllm:latest"}
+    }
+
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.image_selector.detect_gpu",
+        lambda: (GPUVendor.AMD, "gfx942"),
+    )
+    assert selector.select_image("vllm") == "example/vllm:latest"
+    assert selector.get_runner_type() == "mi300x"
+
+
+@pytest.mark.parametrize(
+    ("arch", "runner"),
+    [
+        ("gfx942", "mi300x"),
+        ("gfx950", "mi355x"),
+        ("gfx1100", "mi325x"),
+        ("sm_80", "a100"),
+        ("sm_90", "h100"),
+        ("sm_90a", "h200"),
+        ("sm_100", "b200"),
+    ],
+)
+def test_image_selector_runner_mapping(tmp_path, arch, runner):
+    selector = ImageSelector(str(tmp_path / "missing.yaml"))
+    assert selector.get_runner_type(arch) == runner
+
+
+def test_image_selector_reports_missing_framework_arch_and_bad_yaml(tmp_path):
+    missing = ImageSelector(str(tmp_path / "missing.yaml"))
+    assert missing.list_available_images() == {}
+    with pytest.raises(ValueError, match="No image mapping"):
+        missing.select_image("vllm", "gfx942")
+
+    config = tmp_path / "images.yaml"
+    config.write_text("vllm:\n  gfx942: image\n")
+    selector = ImageSelector(str(config))
+    with pytest.raises(ValueError, match="No image found"):
+        selector.select_image("vllm", "gfx950")
+    with pytest.raises(ValueError, match="No runner type"):
+        selector.get_runner_type("unknown")
+
+    config.write_text("not: [valid")
+    assert ImageSelector(str(config)).list_available_images() == {}
+
+
+def test_inferencex_default_resolution_prefers_environment(monkeypatch, tmp_path):
+    override = tmp_path / "explicit"
+    monkeypatch.setenv("MAGPIE_INFERENCEX_PATH", str(override))
+    assert _resolve_default_inferencex_dir() == str(override)
+
+
+def test_inferencex_manager_reuses_configured_and_default_paths(tmp_path):
+    configured = tmp_path / "configured"
+    configured.mkdir()
+    manager = InferenceXManager(default_dir=str(tmp_path / "default"))
+    assert manager.ensure_available(str(configured)) == str(configured)
+    assert manager._is_placeholder(None) is True
+    assert manager._is_placeholder("") is True
+    assert manager._is_placeholder("YOUR_INFERENCEX_PATH") is True
+    assert manager._is_placeholder(str(configured)) is False
+
+    default = Path(manager.default_dir)
+    default.mkdir()
+    assert manager.ensure_available() == str(default)
+    assert manager._validate_installation(str(default)) is False
+    (default / "benchmarks").mkdir()
+    assert manager._validate_installation(str(default)) is True
+    assert manager.ensure_available() == str(default)
+
+
+def test_inferencex_manager_clones_repository(tmp_path, monkeypatch):
+    target = tmp_path / "nested" / "InferenceX"
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok")
+
+    monkeypatch.setattr("Magpie.modes.benchmark.inferencex.subprocess.run", run)
+    manager = InferenceXManager(
+        repo_url="https://example/repo.git", default_dir=str(target)
+    )
+
+    assert manager.ensure_available() == str(target)
+    assert target.parent.exists()
+    assert calls[0][0] == [
+        "git",
+        "clone",
+        "https://example/repo.git",
+        str(target),
+    ]
+    assert calls[0][1]["timeout"] == 300
+
+
+@pytest.mark.parametrize(
+    ("failure", "message"),
+    [
+        (subprocess.TimeoutExpired("git", 300), "timed out"),
+        (FileNotFoundError(), "git is not installed"),
+        (OSError("read-only"), "Failed to setup"),
+    ],
+)
+def test_inferencex_manager_translates_clone_exceptions(
+    tmp_path, monkeypatch, failure, message
+):
+    def fail(*_args, **_kwargs):
+        raise failure
+
+    monkeypatch.setattr("Magpie.modes.benchmark.inferencex.subprocess.run", fail)
+    manager = InferenceXManager(default_dir=str(tmp_path / "InferenceX"))
+
+    with pytest.raises(RuntimeError, match=message):
+        manager.ensure_available()
+
+
+def test_inferencex_manager_reports_git_failure(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.inferencex.subprocess.run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 2, stderr="authentication failed"
+        ),
+    )
+    manager = InferenceXManager(default_dir=str(tmp_path / "InferenceX"))
+
+    with pytest.raises(RuntimeError, match="authentication failed"):
+        manager.ensure_available()
+
+
+def test_inferencex_module_level_helpers_delegate(monkeypatch, tmp_path):
+    import Magpie.modes.benchmark.inferencex as inferencex
+
+    inferencex._manager = None
+    first = get_manager()
+    assert get_manager() is first
+
+    class StubManager:
+        def ensure_available(self, configured_path):
+            return f"resolved:{configured_path}"
+
+    monkeypatch.setattr(inferencex, "_manager", StubManager())
+    assert ensure_inferencex_available("/configured") == "resolved:/configured"

--- a/tests/test_config_coverage.py
+++ b/tests/test_config_coverage.py
@@ -1,0 +1,297 @@
+from pathlib import Path
+
+import pytest
+
+from Magpie.config.correctness import (
+    CorrectnessBackend,
+    CorrectnessConfig,
+    CorrectnessMode,
+)
+from Magpie.config.kernel import KernelEvalConfig
+from Magpie.config.performance import (
+    MetrixConfig,
+    NcuConfig,
+    PerfBackend,
+    PerformanceConfig,
+    RocprofComputeConfig,
+)
+from Magpie.config.pipeline import CompilingConfig, KernelType, PipelineConfig
+
+
+def test_metrix_profile_args_include_all_optional_settings():
+    cfg = MetrixConfig(
+        profile="memory",
+        metrics=["memory.l2_hit_rate", "compute.total_flops"],
+        kernel_filter="gemm.*",
+        num_replays=3,
+        timeout_seconds=45,
+        extra_args=["--verbose"],
+    )
+
+    assert cfg.get_profile_args("metrics.json") == [
+        "--output",
+        "metrics.json",
+        "--num-replays",
+        "3",
+        "--timeout",
+        "45",
+        "--aggregate",
+        "--profile",
+        "memory",
+        "--metrics",
+        "memory.l2_hit_rate,compute.total_flops",
+        "--kernel",
+        "gemm.*",
+        "--verbose",
+    ]
+
+
+def test_metrix_profile_args_work_with_defaults():
+    assert MetrixConfig().get_profile_args("out.json") == [
+        "--output",
+        "out.json",
+        "--num-replays",
+        "1",
+        "--timeout",
+        "60",
+        "--aggregate",
+    ]
+
+
+def test_rocprof_profile_and_analyze_args_cover_filters_and_expansion(tmp_path):
+    cfg = RocprofComputeConfig(
+        workload_dir=str(tmp_path / "workloads"),
+        profile_args=["--no-roof", "--roof-only --quiet", 7],
+        analyze_args=["--dispatch 2", "--verbose"],
+        metric_blocks=["1", "10"],
+        kernel_filter="gemm",
+        dispatch_filter=[2, 4],
+    )
+
+    assert cfg.get_profile_args("case", "/override") == [
+        "-n",
+        "case",
+        "-p",
+        "/override",
+        "-b",
+        "1",
+        "10",
+        "-k",
+        "gemm",
+        "-d",
+        "2",
+        "4",
+        "--no-roof",
+        "--roof-only",
+        "--quiet",
+    ]
+    assert cfg.get_analyze_args("/workload", "/csv") == [
+        "-p",
+        "/workload",
+        "-b",
+        "1",
+        "10",
+        "--output-format",
+        "csv",
+        "--output-name",
+        "/csv",
+        "--dispatch",
+        "2",
+        "--verbose",
+    ]
+    assert cfg.get_workload_path("case") == tmp_path / "workloads" / "case"
+    assert cfg.get_workload_path("case", "/base") == Path("/base/case")
+
+
+def test_rocprof_args_cover_empty_blocks_and_non_csv_output():
+    cfg = RocprofComputeConfig(metric_blocks=[], output_format="json")
+
+    assert cfg.get_profile_args("case") == ["-n", "case", "-p", "./workloads"]
+    assert cfg.get_analyze_args("/workload", "/ignored") == ["-p", "/workload"]
+
+    cfg.output_format = "csv"
+    assert cfg.get_analyze_args("/workload") == [
+        "-p",
+        "/workload",
+        "--output-format",
+        "csv",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("kernel_type", "gpu_arch", "expected"),
+    [
+        (KernelType.HIP, None, PerfBackend.ROCPROF_COMPUTE),
+        (KernelType.CUDA, None, PerfBackend.NCU),
+        (KernelType.TRITON, "gfx942", PerfBackend.ROCPROF_COMPUTE),
+        (KernelType.TRITON, "sm_90", PerfBackend.NCU),
+        (KernelType.TRITON, "cpu", PerfBackend.NONE),
+        (KernelType.TRITON, None, PerfBackend.NONE),
+        (KernelType.PYTORCH, None, PerfBackend.NONE),
+    ],
+)
+def test_performance_config_selects_backend(kernel_type, gpu_arch, expected):
+    cfg = PerformanceConfig(kernel_type=kernel_type, gpu_arch=gpu_arch)
+
+    assert cfg.get_backend() is expected
+    assert isinstance(cfg.rocprof_config, RocprofComputeConfig)
+    assert isinstance(cfg.ncu_config, NcuConfig)
+    assert isinstance(cfg.metrix_config, MetrixConfig)
+
+
+def test_performance_config_preserves_explicit_backend_and_configs():
+    rocprof = RocprofComputeConfig(metric_blocks=[])
+    ncu = NcuConfig(args=["--set", "full"])
+    metrix = MetrixConfig(profile="quick")
+    cfg = PerformanceConfig(
+        backend=PerfBackend.METRIX,
+        kernel_type=KernelType.CUDA,
+        rocprof_config=rocprof,
+        ncu_config=ncu,
+        metrix_config=metrix,
+    )
+
+    assert cfg.get_backend() is PerfBackend.METRIX
+    assert cfg.rocprof_config is rocprof
+    assert cfg.ncu_config is ncu
+    assert cfg.metrix_config is metrix
+    assert PerformanceConfig().get_backend() is PerfBackend.NONE
+
+
+def test_correctness_config_from_empty_dict_and_testcase_detection():
+    cfg = CorrectnessConfig.from_dict({}, mode=CorrectnessMode.RESULT_COMPARISON)
+
+    assert cfg.mode is CorrectnessMode.RESULT_COMPARISON
+    assert cfg.backend is CorrectnessBackend.TESTCASE
+    assert cfg.has_testcase() is False
+    cfg.testcase_command = []
+    assert cfg.has_testcase() is False
+    cfg.testcase_command = ["pytest", "-q"]
+    assert cfg.has_testcase() is True
+
+
+def test_correctness_config_builds_complete_accordo_settings():
+    cfg = CorrectnessConfig.from_dict(
+        {
+            "backend": "accordo",
+            "workspace_path": "/workspace",
+            "accordo": {
+                "kernel_name": "gemm",
+                "reference_binary": "./reference",
+                "optimized_binary": "./optimized",
+                "atol": 0.01,
+                "rtol": 0.02,
+                "equal_nan": True,
+                "timeout_seconds": 12,
+                "kernel_args": [["x", "ptr"]],
+                "working_directory": "/work",
+            },
+        },
+        mode=CorrectnessMode.RESULT_COMPARISON,
+    )
+
+    assert cfg.backend is CorrectnessBackend.ACCORDO
+    assert cfg.mode is CorrectnessMode.RESULT_COMPARISON
+    assert cfg.accordo_config.kernel_name == "gemm"
+    assert cfg.accordo_config.reference_binary == "./reference"
+    assert cfg.accordo_config.optimized_binary == "./optimized"
+    assert cfg.accordo_config.atol == 0.01
+    assert cfg.accordo_config.rtol == 0.02
+    assert cfg.accordo_config.equal_nan is True
+    assert cfg.accordo_config.timeout_seconds == 12
+    assert cfg.accordo_config.kernel_args == [["x", "ptr"]]
+    assert cfg.accordo_config.working_directory == "/work"
+    assert cfg.accordo_config.workspace_path == "/workspace"
+
+
+def test_correctness_config_allows_accordo_settings_with_testcase_backend():
+    cfg = CorrectnessConfig.from_dict({"accordo": {"kernel_name": "gemm"}})
+
+    assert cfg.backend is CorrectnessBackend.TESTCASE
+    assert cfg.accordo_config.kernel_name == "gemm"
+
+
+def test_kernel_eval_config_command_helpers_and_round_trip():
+    cfg = KernelEvalConfig(
+        kernel_id="gemm",
+        kernel_type=KernelType.CUDA,
+        source_file_path="kernel.cu",
+        compiling_command=["make", "build"],
+        testcase_command=[["setup"], ["run"]],
+        prof_command=["ncu", "./run"],
+        input_shapes=[(16, 16)],
+        extra={"warmup": 2},
+    )
+
+    assert cfg.get_source_file_paths() == ["kernel.cu"]
+    assert cfg.has_compile_command() is True
+    assert cfg.has_testcase() is True
+    assert cfg.has_prof_command() is True
+    assert cfg.get_compile_commands() == [["make", "build"]]
+    assert cfg.get_testcase_commands() == [["setup"], ["run"]]
+    assert cfg.get_prof_commands() == [["ncu", "./run"]]
+
+    restored = KernelEvalConfig.from_dict(cfg.to_dict())
+    assert restored.kernel_id == "gemm"
+    assert restored.kernel_type is KernelType.CUDA
+    assert restored.input_shapes == [(16, 16)]
+    assert restored.extra == {"warmup": 2}
+
+
+def test_kernel_eval_config_empty_commands_and_enum_inputs():
+    cfg = KernelEvalConfig(source_file_path=["a.hip", "b.hip"])
+
+    assert cfg.get_source_file_paths() == ["a.hip", "b.hip"]
+    assert cfg.has_compile_command() is False
+    assert cfg.has_testcase() is False
+    assert cfg.has_prof_command() is False
+    assert cfg.get_compile_commands() == []
+    assert cfg.get_testcase_commands() == []
+    assert cfg.get_prof_commands() == []
+    assert (
+        KernelEvalConfig.from_dict({"kernel_type": KernelType.HIP}).kernel_type
+        is KernelType.HIP
+    )
+    assert (
+        KernelEvalConfig.from_dict({"kernel_type": KernelType.CUDA.value}).kernel_type
+        is KernelType.CUDA
+    )
+
+
+def test_pipeline_config_uses_explicit_arch_and_supplied_configs():
+    compiling = CompilingConfig(enable_default_compile=True)
+    correctness = CorrectnessConfig()
+    performance = PerformanceConfig(backend=PerfBackend.NCU)
+    cfg = PipelineConfig(
+        kernel_type=KernelType.TRITON,
+        gpu_arch="sm_90",
+        compiling_config=compiling,
+        correctness_config=correctness,
+        performance_config=performance,
+    )
+
+    assert cfg.compiling_config is compiling
+    assert cfg.correctness_config is correctness
+    assert cfg.performance_config is performance
+
+
+def test_pipeline_config_detects_gpu_and_builds_defaults(monkeypatch):
+    monkeypatch.setattr("Magpie.utils.detect_gpu", lambda: ("amd", "gfx942"))
+
+    cfg = PipelineConfig(kernel_type=KernelType.TRITON)
+
+    assert cfg.gpu_arch == "gfx942"
+    assert isinstance(cfg.compiling_config, CompilingConfig)
+    assert isinstance(cfg.correctness_config, CorrectnessConfig)
+    assert cfg.performance_config.get_backend() is PerfBackend.ROCPROF_COMPUTE
+
+
+@pytest.mark.parametrize(
+    "detector",
+    [lambda: ("amd", None), lambda: (_ for _ in ()).throw(OSError("missing tool"))],
+)
+def test_pipeline_config_reports_gpu_detection_failures(monkeypatch, detector):
+    monkeypatch.setattr("Magpie.utils.detect_gpu", detector)
+
+    with pytest.raises(RuntimeError, match="Please specify 'gpu_arch'"):
+        PipelineConfig(kernel_type=KernelType.HIP)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+
+import pytest
+
+from Magpie.config import KernelEvalConfig, KernelType
+from Magpie.core.task import ModeConfig, ModeType, Task
+
+
+@pytest.fixture
+def kernel_config():
+    return KernelEvalConfig(
+        kernel_id="unit-kernel",
+        kernel_type=KernelType.HIP,
+        source_file_path=["kernel.hip"],
+        testcase_command=["./test"],
+    )
+
+
+@pytest.fixture
+def task_factory(kernel_config):
+    def make(mode=ModeType.ANALYZE, **mode_overrides):
+        values = {"mode_type": mode, "gpu_arch": "gfx942"}
+        values.update(mode_overrides)
+        return Task(
+            task_id=f"task-{mode.value}",
+            kernel_configs=[] if mode is ModeType.BENCHMARK else [kernel_config],
+            mode_config=ModeConfig(**values),
+        )
+
+    return make
+
+
+@pytest.fixture
+def ray_config(tmp_path):
+    return SimpleNamespace(
+        cluster_address="auto",
+        install_magpie=False,
+        magpie_install_path=None,
+        pip_packages=[],
+        hf_cache_dir=str(tmp_path / "hf"),
+        multi_node=False,
+        total_num_gpus=1,
+        env_vars={},
+        entrypoint_num_cpus=2,
+        to_dict=lambda: {"cluster_address": "auto"},
+    )

--- a/tests/unit/core/test_core_execution.py
+++ b/tests/unit/core/test_core_execution.py
@@ -1,0 +1,552 @@
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import Future
+from types import SimpleNamespace
+
+import pytest
+
+from Magpie.config import KernelEvalConfig, KernelType
+from Magpie.core.executor import (
+    ContainerExecutor,
+    ExecutorConfig,
+    ExecutorType,
+    LocalExecutor,
+    _execute_task_worker,
+    _local_pool_worker_init,
+    create_executor,
+)
+from Magpie.core.job_store import JobRecord, JobStore
+from Magpie.core.ray_executor import RayJobExecutor
+from Magpie.core.task import ModeConfig, ModeType, Task, TaskResult, TaskStatus
+
+
+class Lock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class FakePool:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.future = Future()
+        self.shutdown_calls = []
+
+    def submit(self, function, payload):
+        self.submission = (function, payload)
+        return self.future
+
+    def shutdown(self, wait=True):
+        self.shutdown_calls.append(wait)
+
+
+def completed_payload(task_id="task-analyze"):
+    return {
+        "task_id": task_id,
+        "status": "completed",
+        "success": True,
+        "results": {"value": 1},
+        "errors": [],
+        "execution_time": 0.1,
+        "metadata": {"source": "unit"},
+    }
+
+
+def test_task_and_result_serialization(kernel_config):
+    task = Task(
+        task_id="task",
+        kernel_configs=[kernel_config, "invalid"],
+        mode_config={"mode_type": ModeType.COMPARE},
+        status="running",
+        metadata={"owner": "test"},
+    )
+    assert task.status is TaskStatus.RUNNING
+    assert task.mode_type is ModeType.COMPARE
+    payload = task.to_dict()
+    assert payload["kernel_configs"][0]["kernel_id"] == "unit-kernel"
+    assert payload["kernel_configs"][1] == "invalid"
+
+    value = SimpleNamespace(to_dict=lambda: {"score": 2})
+    list_result = TaskResult("task", results=[value, {"raw": True}])
+    assert list_result.success is True
+    assert list_result.to_dict()["results"] == [{"score": 2}, {"raw": True}]
+    assert TaskResult("task", results=value).to_dict()["results"] == {"score": 2}
+    assert TaskResult("task", results="raw").to_dict()["results"] == "raw"
+    failed = TaskResult("task", status="failed", errors=["boom"])
+    assert failed.success is False
+
+
+def test_job_store_crud_filters_and_invalid_metadata(tmp_path):
+    store = JobStore(str(tmp_path / "jobs" / "store.db"))
+    first = JobRecord(
+        ray_job_id="ray-1",
+        magpie_task_id="task-1",
+        mode_type="benchmark",
+        ray_cluster="auto",
+        config_path="config.json",
+        result_path="result.json",
+        submitted_at=1,
+        metadata={"model": "demo"},
+    )
+    second = JobRecord(
+        ray_job_id="ray-2",
+        magpie_task_id="task-2",
+        mode_type="analyze",
+        ray_cluster="auto",
+        config_path="two.json",
+        result_path="two-result.json",
+        submitted_at=2,
+        status="RUNNING",
+    )
+    store.add(first)
+    store.add(second)
+    assert store.get("missing") is None
+    assert store.get("ray-1").metadata == {"model": "demo"}
+    assert store.get_by_task_id("task-2").ray_job_id == "ray-2"
+    assert store.get_by_task_id("missing") is None
+    assert [r.ray_job_id for r in store.list_jobs()] == ["ray-2", "ray-1"]
+    assert [r.ray_job_id for r in store.list_jobs(status="RUNNING")] == ["ray-2"]
+    assert [r.ray_job_id for r in store.list_jobs(mode_type="benchmark")] == ["ray-1"]
+    store.update_status("ray-1", "SUCCEEDED")
+    assert store.get("ray-1").status == "SUCCEEDED"
+    store._conn.execute(
+        "UPDATE jobs SET metadata = ? WHERE ray_job_id = ?", ("{", "ray-1")
+    )
+    store._conn.commit()
+    assert store.get("ray-1").metadata == {}
+    store.delete("ray-1")
+    assert store.get("ray-1") is None
+    store.close()
+
+
+def test_local_worker_gpu_binding(monkeypatch):
+    counter = SimpleNamespace(value=1)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    _local_pool_worker_init(counter, Lock(), (3, 7))
+    assert counter.value == 2
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "7"
+    assert os.environ["HIP_VISIBLE_DEVICES"] == "7"
+    assert os.environ["ROCR_VISIBLE_DEVICES"] == "7"
+    _local_pool_worker_init(counter, Lock(), ())
+
+
+def test_local_executor_lifecycle_submit_wait_and_execute(task_factory, monkeypatch):
+    pools = []
+
+    def pool(**kwargs):
+        pools.append(FakePool(**kwargs))
+        return pools[-1]
+
+    monkeypatch.setattr("Magpie.core.executor.get_gpu_count", lambda: 2)
+    monkeypatch.setattr("Magpie.core.executor.ProcessPoolExecutor", pool)
+    monkeypatch.setattr(
+        "Magpie.core.executor.multiprocessing.Value",
+        lambda *_: SimpleNamespace(value=0),
+    )
+    monkeypatch.setattr("Magpie.core.executor.multiprocessing.Lock", Lock)
+    executor = LocalExecutor(
+        ExecutorConfig(max_workers=2, gpu_devices=[0], timeout_seconds=1)
+    )
+    assert executor.is_running() is False
+    assert executor.start() is True
+    assert executor.start() is True
+    assert executor._available_gpus == [0, 1]
+    task = task_factory()
+    assert executor.get_task_status(task.task_id) is None
+    assert executor.submit(task) == task.task_id
+    assert executor.get_task_status(task.task_id) is TaskStatus.RUNNING
+    pools[0].future.set_result(completed_payload(task.task_id))
+    result = executor.wait_for_task(task.task_id, timeout=1)
+    assert result.success is True
+    assert executor.wait_all()[0].success is True
+
+    monkeypatch.setattr(
+        "Magpie.core.executor._execute_task_worker",
+        lambda _: completed_payload(task.task_id),
+    )
+    assert executor.execute(task).success is True
+    executor.stop()
+    assert pools[0].shutdown_calls == [True]
+    assert executor.is_running() is False
+
+
+def test_local_executor_errors_and_gpu_validation(task_factory, monkeypatch):
+    executor = LocalExecutor(ExecutorConfig(gpu_devices=[]))
+    with pytest.raises(RuntimeError, match="not running"):
+        executor.submit(task_factory())
+    with pytest.raises(ValueError, match="not found"):
+        executor.wait_for_task("missing")
+
+    future = Future()
+    future.set_exception(ValueError("worker failed"))
+    executor._futures["bad"] = future
+    assert executor.wait_for_task("bad").status is TaskStatus.FAILED
+
+    monkeypatch.setattr(
+        "Magpie.core.executor._execute_task_worker",
+        lambda _: (_ for _ in ()).throw(ValueError("bad")),
+    )
+    assert executor.execute(task_factory()).status is TaskStatus.FAILED
+    monkeypatch.setattr("Magpie.core.executor.get_gpu_count", lambda: 0)
+    with pytest.raises(RuntimeError, match="No GPU"):
+        executor._check_gpu_availability()
+
+
+def test_local_executor_start_failure(monkeypatch):
+    monkeypatch.setattr("Magpie.core.executor.get_gpu_count", lambda: 1)
+    monkeypatch.setattr(
+        "Magpie.core.executor.ProcessPoolExecutor",
+        lambda **_: (_ for _ in ()).throw(OSError("no pool")),
+    )
+    assert LocalExecutor(ExecutorConfig()).start() is False
+
+
+def test_container_executor_lifecycle_and_commands(task_factory, monkeypatch):
+    with pytest.raises(ValueError, match="docker_image"):
+        ContainerExecutor(ExecutorConfig(executor_type="container"))
+    executor = ContainerExecutor(
+        ExecutorConfig(
+            executor_type="container", docker_image="image:tag", gpu_devices=[0, 2]
+        )
+    )
+    monkeypatch.setattr(executor, "_check_docker_availability", lambda: True)
+    monkeypatch.setattr(executor, "_pull_image", lambda: True)
+    assert executor.start() is True
+    assert executor.start() is True
+    task = task_factory()
+    assert executor.submit(task) == task.task_id
+
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok")
+
+    monkeypatch.setattr("Magpie.core.executor.subprocess.run", run)
+    assert executor.execute(task).success is True
+    assert '"device=0,2"' in calls[0][0]
+    executor._container_ids[task.task_id] = "container-id"
+    executor.stop()
+    assert calls[-2][0][:2] == ["docker", "stop"]
+    assert calls[-1][0][:2] == ["docker", "rm"]
+
+
+def test_container_executor_failure_timeout_and_helpers(task_factory, monkeypatch):
+    executor = ContainerExecutor(ExecutorConfig(docker_image="image", gpu_devices=[]))
+    with pytest.raises(RuntimeError, match="not running"):
+        executor.submit(task_factory())
+    assert executor._build_gpu_args() == []
+
+    monkeypatch.setattr(
+        "Magpie.core.executor.subprocess.run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 2, stderr="bad"),
+    )
+    assert executor._check_docker_availability() is False
+    assert executor._pull_image() is False
+    assert executor.execute(task_factory()).status is TaskStatus.FAILED
+
+    monkeypatch.setattr(
+        "Magpie.core.executor.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(subprocess.TimeoutExpired(a[0], 1)),
+    )
+    assert executor._check_docker_availability() is False
+    assert executor._pull_image() is False
+    assert executor.execute(task_factory()).errors == ["Container execution timed out"]
+
+    monkeypatch.setattr(
+        "Magpie.core.executor.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("docker gone")),
+    )
+    assert executor.execute(task_factory()).errors == ["docker gone"]
+
+
+def test_executor_factory(task_factory, ray_config):
+    assert isinstance(create_executor(ExecutorConfig()), LocalExecutor)
+    assert isinstance(
+        create_executor(ExecutorConfig("container", docker_image="image")),
+        ContainerExecutor,
+    )
+    with pytest.raises(ValueError, match="ray_config"):
+        create_executor(ExecutorConfig("ray"))
+    assert isinstance(
+        create_executor(ExecutorConfig("ray"), ray_config=ray_config), RayJobExecutor
+    )
+    cfg = ExecutorConfig()
+    cfg.executor_type = object()
+    with pytest.raises(ValueError, match="Unknown"):
+        create_executor(cfg)
+
+
+def test_worker_analyze_compare_benchmark_and_failure(monkeypatch, task_factory):
+    class Analyzer:
+        def __init__(self, config):
+            self.config = config
+
+        def analyze(self, kernel):
+            return {"kernel": kernel.kernel_id}
+
+    class Comparator:
+        def __init__(self, config):
+            self.config = config
+
+        def compare(self, kernels):
+            return {"count": len(kernels)}
+
+    class Benchmarker:
+        def __init__(self, config):
+            self.config = config
+
+        def run(self, task_id):
+            return SimpleNamespace(to_dict=lambda: {"task_id": task_id})
+
+    monkeypatch.setattr("Magpie.modes.AnalyzeMode", Analyzer)
+    monkeypatch.setattr("Magpie.modes.CompareMode", Comparator)
+    monkeypatch.setattr("Magpie.modes.benchmark.BenchmarkMode", Benchmarker)
+    assert _execute_task_worker(task_factory().to_dict())["status"] == "completed"
+    assert (
+        _execute_task_worker(task_factory(ModeType.COMPARE).to_dict())["status"]
+        == "completed"
+    )
+    bench = task_factory(
+        ModeType.BENCHMARK, benchmark_config={"framework": "vllm", "model": "demo"}
+    )
+    assert _execute_task_worker(bench.to_dict())["results"]["task_id"] == bench.task_id
+    payload = task_factory().to_dict()
+    payload["mode_config"]["mode_type"] = "invalid"
+    assert _execute_task_worker(payload)["status"] == "failed"
+
+
+class FakeRay:
+    class exceptions:
+        class TaskCancelledError(Exception):
+            pass
+
+    def __init__(self):
+        self.initialized = False
+        self.ready = True
+        self.result = {"status": "ok", "execution_time": 2}
+        self.cancelled = []
+
+    def is_initialized(self):
+        return self.initialized
+
+    def init(self, **kwargs):
+        self.initialized = True
+        self.init_kwargs = kwargs
+
+    def shutdown(self):
+        self.initialized = False
+
+    def wait(self, refs, **kwargs):
+        return (refs if self.ready else [], [])
+
+    def get(self, ref):
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+    def cancel(self, ref, force=False):
+        self.cancelled.append((ref, force))
+
+    def nodes(self):
+        return []
+
+
+def test_ray_executor_lifecycle_wait_status_and_cancel(
+    task_factory, ray_config, monkeypatch
+):
+    ray = FakeRay()
+    monkeypatch.setitem(sys.modules, "ray", ray)
+    executor = RayJobExecutor(ExecutorConfig("ray"), ray_config)
+    assert executor.start() is True
+    assert executor.start() is True
+    monkeypatch.setattr(executor, "_submit_ray_task", lambda task: "ref")
+    task = task_factory()
+    assert executor.submit(task) == task.task_id
+    assert executor.execute(task).success is True
+    assert executor.get_task_status_ray(task.task_id) == "SUCCEEDED"
+    assert executor.get_task_result(task.task_id)["status"] == "ok"
+    assert executor.cancel_task(task.task_id) is True
+    assert executor.cancel_task("missing") is False
+    assert executor.list_tasks()[task.task_id] == "SUCCEEDED"
+    executor.stop()
+    assert executor.is_running() is False
+
+
+def test_ray_executor_wait_variants(task_factory, ray_config, monkeypatch):
+    ray = FakeRay()
+    monkeypatch.setitem(sys.modules, "ray", ray)
+    executor = RayJobExecutor(ExecutorConfig("ray"), ray_config)
+    executor._is_running = True
+    task = task_factory()
+    executor._pending_tasks[task.task_id] = task
+    executor._obj_refs[task.task_id] = "ref"
+    with pytest.raises(ValueError, match="not found"):
+        executor.wait_for_task("missing")
+    ray.ready = False
+    assert executor.wait_for_task(task.task_id, 0).status is TaskStatus.FAILED
+    assert executor.get_task_status_ray(task.task_id) == "RUNNING"
+    ray.ready = True
+    ray.result = {"status": "failed", "error": "remote"}
+    assert executor.wait_for_task(task.task_id).errors == ["remote"]
+    executor._results_cache.clear()
+    assert executor.get_task_status_ray(task.task_id) == "FAILED"
+    ray.result = ValueError("ray get")
+    assert executor.wait_for_task(task.task_id).status is TaskStatus.FAILED
+    executor._results_cache.clear()
+    assert executor.get_task_status_ray(task.task_id) == "FAILED"
+    executor._obj_refs["unknown"] = None
+    assert executor.get_task_status_ray("absent") == "UNKNOWN"
+
+
+def test_ray_runtime_helpers(tmp_path, ray_config, monkeypatch):
+    root = tmp_path / "magpie"
+    root.mkdir()
+    (root / "requirements.txt").write_text("# comment\nPyYAML>=6\n\n")
+    ray_config.install_magpie = True
+    ray_config.magpie_install_path = str(root)
+    ray_config.pip_packages = ["pytest"]
+    ray_config.multi_node = True
+    ray_config.total_num_gpus = 8
+    ray_config.env_vars = {"CUSTOM": "1"}
+    executor = RayJobExecutor(ExecutorConfig("ray"), ray_config)
+    assert RayJobExecutor._collect_pip_packages(ray_config) == [
+        "pytest",
+        "PyYAML>=6",
+        str(root),
+    ]
+    env = executor._build_runtime_env()
+    assert env["env_vars"]["RAY_ADDRESS"] == "auto"
+    assert env["env_vars"]["MAGPIE_TOTAL_GPUS"] == "8"
+    assert env["env_vars"]["CUSTOM"] == "1"
+    assert env["pip"][-1] == str(root)
+
+    ray = FakeRay()
+    ray.nodes = lambda: [
+        {"Alive": False, "Resources": {"GPU": 1}, "NodeID": "dead"},
+        {
+            "Alive": True,
+            "Resources": {"GPU": 1, "node:__internal_head__": 1},
+            "NodeID": "head",
+        },
+        {"Alive": True, "Resources": {"GPU": 2}, "NodeID": "worker"},
+    ]
+    monkeypatch.setitem(sys.modules, "ray", ray)
+    assert RayJobExecutor._find_gpu_node() == "worker"
+    ray.nodes = lambda: [
+        {
+            "Alive": True,
+            "Resources": {"GPU": 1, "node:__internal_head__": 1},
+            "NodeID": "head",
+        }
+    ]
+    assert RayJobExecutor._find_gpu_node() == "head"
+
+
+def test_ray_executor_failure_and_cancelled_paths(
+    task_factory, ray_config, monkeypatch
+):
+    ray = FakeRay()
+    ray.init = lambda **kwargs: (_ for _ in ()).throw(RuntimeError("connect failed"))
+    monkeypatch.setitem(sys.modules, "ray", ray)
+    executor = RayJobExecutor(ExecutorConfig("ray"), ray_config)
+    assert executor.start() is False
+    with pytest.raises(RuntimeError, match="not running"):
+        executor.submit(task_factory())
+
+    executor._is_running = True
+    task = task_factory()
+    executor._pending_tasks[task.task_id] = task
+    executor._obj_refs[task.task_id] = "ref"
+    ray.get = lambda ref: (_ for _ in ()).throw(FakeRay.exceptions.TaskCancelledError())
+    cancelled = executor.wait_for_task(task.task_id)
+    assert cancelled.status is TaskStatus.CANCELLED
+    assert task.status is TaskStatus.CANCELLED
+    assert executor.wait_all()[-1].status is TaskStatus.CANCELLED
+
+    ray.cancel = lambda *args, **kwargs: (_ for _ in ()).throw(
+        RuntimeError("cancel failed")
+    )
+    assert executor.cancel_task(task.task_id) is False
+
+
+def test_ray_executor_stop_and_runtime_env_minimal(ray_config, monkeypatch):
+    ray = FakeRay()
+    ray.initialized = True
+    monkeypatch.setitem(sys.modules, "ray", ray)
+    executor = RayJobExecutor(ExecutorConfig("ray"), ray_config)
+    executor._ray_inited = True
+    executor._is_running = True
+    executor._obj_refs["task"] = "ref"
+    executor._results_cache["task"] = {"ok": True}
+    executor.stop()
+    assert executor.is_running() is False
+    assert executor._obj_refs == {}
+    assert ray.initialized is False
+
+    ray_config.install_magpie = False
+    ray_config.pip_packages = []
+    ray_config.multi_node = False
+    runtime = executor._build_runtime_env()
+    assert "pip" not in runtime
+    assert "RAY_ADDRESS" not in runtime["env_vars"]
+
+
+def test_ray_executor_builds_and_submits_remote_payload(
+    task_factory, ray_config, monkeypatch
+):
+    captured = {}
+
+    class RemoteFunction:
+        def remote(self, payload):
+            captured["payload"] = payload
+            return "object-ref"
+
+    ray = FakeRay()
+
+    def remote(**options):
+        captured["options"] = options
+
+        def decorate(function):
+            captured["function"] = function
+            return RemoteFunction()
+
+        return decorate
+
+    ray.remote = remote
+    monkeypatch.setitem(sys.modules, "ray", ray)
+
+    class NodeAffinitySchedulingStrategy:
+        def __init__(self, node_id, soft):
+            self.node_id = node_id
+            self.soft = soft
+
+    scheduling = SimpleNamespace(
+        NodeAffinitySchedulingStrategy=NodeAffinitySchedulingStrategy
+    )
+    monkeypatch.setitem(sys.modules, "ray.util", SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "ray.util.scheduling_strategies", scheduling)
+
+    ray_config.env_vars = {"CUSTOM": "yes"}
+    executor = RayJobExecutor(ExecutorConfig("ray"), ray_config)
+    monkeypatch.setattr(executor, "_find_gpu_node", lambda: "worker-node")
+    task = task_factory(
+        ModeType.BENCHMARK,
+        benchmark_config={
+            "framework": "vllm",
+            "ray_config": {"cluster_address": "ray://override"},
+        },
+    )
+    assert executor._submit_ray_task(task) == "object-ref"
+    assert captured["options"]["num_gpus"] == 0
+    assert captured["options"]["scheduling_strategy"].node_id == "worker-node"
+    assert captured["payload"]["task_id"] == task.task_id
+    assert captured["payload"]["ray_config"]["cluster_address"] == "ray://override"
+
+    monkeypatch.setattr(executor, "_find_gpu_node", lambda: None)
+    with pytest.raises(RuntimeError, match="No GPU node"):
+        executor._submit_ray_task(task)

--- a/tests/unit/core/test_scheduler.py
+++ b/tests/unit/core/test_scheduler.py
@@ -1,0 +1,240 @@
+from types import SimpleNamespace
+
+import pytest
+
+from Magpie.core.executor import ExecutorType
+from Magpie.core.scheduler import EnvironmentType, Scheduler, SchedulerConfig
+from Magpie.core.task import ModeType, TaskResult, TaskStatus
+
+
+class FakeExecutor:
+    def __init__(self, start=True):
+        self.start_result = start
+        self.tasks = {}
+        self.stopped = False
+
+    def start(self):
+        return self.start_result
+
+    def stop(self):
+        self.stopped = True
+
+    def submit(self, task):
+        task.status = TaskStatus.RUNNING
+        self.tasks[task.task_id] = task
+        return task.task_id
+
+    def execute(self, task):
+        return TaskResult(task.task_id, results={"mode": task.mode_type.value})
+
+    def wait_for_task(self, task_id, timeout=None):
+        return TaskResult(task_id, results={"timeout": timeout})
+
+    def wait_all(self, timeout=None):
+        return [TaskResult(task_id) for task_id in reversed(list(self.tasks))]
+
+    def get_task_status(self, task_id):
+        task = self.tasks.get(task_id)
+        return task.status if task else None
+
+
+def initialized_scheduler(config=None):
+    scheduler = Scheduler(config)
+    scheduler._executor = FakeExecutor()
+    scheduler._is_initialized = True
+    return scheduler
+
+
+@pytest.mark.parametrize(
+    ("environment", "executor_type"),
+    [
+        (EnvironmentType.LOCAL, ExecutorType.LOCAL),
+        (EnvironmentType.CONTAINER, ExecutorType.CONTAINER),
+        (EnvironmentType.RAY, ExecutorType.RAY),
+    ],
+)
+def test_scheduler_config_and_executor_mapping(environment, executor_type):
+    cfg = SchedulerConfig(environment_type=environment.value, max_workers=3)
+    scheduler = Scheduler(cfg)
+    executor_cfg = scheduler._create_executor_config()
+    assert cfg.environment_type is environment
+    assert executor_cfg.executor_type is executor_type
+    assert executor_cfg.max_workers == 3
+
+
+def test_scheduler_initialize_success_failure_and_repeat(monkeypatch):
+    created = []
+
+    def create(config, **kwargs):
+        created.append((config, kwargs))
+        return FakeExecutor()
+
+    monkeypatch.setattr("Magpie.core.scheduler.create_executor", create)
+    scheduler = Scheduler(SchedulerConfig(environment_type="ray"))
+    assert scheduler.initialize() is True
+    assert scheduler.initialize() is True
+    assert created[0][0].executor_type is ExecutorType.RAY
+    assert created[0][1]["ray_config"].cluster_address == "auto"
+
+    monkeypatch.setattr(
+        "Magpie.core.scheduler.create_executor", lambda *a, **k: FakeExecutor(False)
+    )
+    assert Scheduler().initialize() is False
+
+
+def test_scheduler_create_submit_execute_wait_and_hooks(kernel_config):
+    events = []
+
+    def bad_pre(_task):
+        raise ValueError("ignored")
+
+    def bad_post(_task, _result):
+        raise ValueError("ignored")
+
+    cfg = SchedulerConfig(
+        pre_hooks=[lambda task: events.append(("pre", task.task_id)), bad_pre],
+        post_hooks=[
+            lambda task, result: events.append(("post", result.task_id)),
+            bad_post,
+        ],
+    )
+    scheduler = initialized_scheduler(cfg)
+    task = scheduler.create_task(
+        [kernel_config],
+        mode_type=ModeType.COMPARE,
+        enable_default_compile=True,
+        check_performance=False,
+        gpu_arch="gfx942",
+        profiler_args=["--x"],
+        rocprof_config={"blocks": [1]},
+        ncu_config={"set": "full"},
+        metrix_config={"profile": "quick"},
+        correctness_config={"backend": "accordo"},
+        baseline_index=1,
+        compare_config={"winner_strategy": "correctness"},
+        priority=5,
+        metadata={"owner": "unit"},
+    )
+    assert task.mode_config.baseline_index == 1
+    assert task.priority == 5
+    assert scheduler.submit(task) == task.task_id
+    assert scheduler.get_task_status(task.task_id) is TaskStatus.RUNNING
+    waited = scheduler.wait_for_task(task.task_id, 7)
+    assert waited.results == {"timeout": 7}
+    assert scheduler.wait_for_task(task.task_id) is waited
+
+    direct = scheduler.create_task([kernel_config])
+    assert scheduler.execute(direct).success is True
+    assert scheduler.get_task_status(direct.task_id) is TaskStatus.COMPLETED
+    assert events[0][0] == "pre"
+    assert any(event[0] == "post" for event in events)
+
+
+def test_scheduler_requires_initialization(task_factory):
+    scheduler = Scheduler()
+    with pytest.raises(RuntimeError, match="initialize"):
+        scheduler.submit(task_factory())
+    with pytest.raises(RuntimeError, match="initialize"):
+        scheduler.execute(task_factory())
+    with pytest.raises(RuntimeError, match="initialize"):
+        scheduler.execute_batch([task_factory()])
+    with pytest.raises(ValueError, match="not found"):
+        scheduler.wait_for_task("missing")
+    assert scheduler.wait_all() == []
+
+
+def test_scheduler_batch_execution_and_order(kernel_config):
+    scheduler = initialized_scheduler()
+    tasks = [
+        scheduler.create_task([kernel_config], metadata={"index": index})
+        for index in range(3)
+    ]
+    results = scheduler.execute_batch(tasks)
+    assert [result.task_id for result in results] == [task.task_id for task in tasks]
+    assert scheduler.execute_batch([]) == []
+
+    scheduler.wait_all = lambda timeout=None: []
+    with pytest.raises(RuntimeError, match="Missing results"):
+        scheduler.execute_batch([scheduler.create_task([kernel_config])])
+
+
+def test_scheduler_convenience_methods(kernel_config, monkeypatch):
+    scheduler = initialized_scheduler()
+    seen = []
+
+    def execute(task):
+        seen.append(task)
+        return TaskResult(task.task_id)
+
+    monkeypatch.setattr(scheduler, "execute", execute)
+    assert scheduler.run_analyze([kernel_config]).success is True
+    assert seen[-1].mode_type is ModeType.ANALYZE
+    assert scheduler.run_compare([kernel_config], baseline_index=0).success is True
+    assert seen[-1].mode_type is ModeType.COMPARE
+    assert scheduler.run_benchmark({"framework": "vllm", "model": "demo"}).success
+    assert seen[-1].mode_type is ModeType.BENCHMARK
+
+    batch_modes = []
+
+    def execute_batch(tasks):
+        batch_modes.extend(task.mode_type for task in tasks)
+        return [TaskResult(task.task_id) for task in tasks]
+
+    monkeypatch.setattr(scheduler, "execute_batch", execute_batch)
+    assert len(scheduler.run_analyze_batch([[kernel_config], [kernel_config]])) == 2
+    assert batch_modes == [ModeType.ANALYZE, ModeType.ANALYZE]
+    batch_modes.clear()
+    assert len(scheduler.run_compare_batch([[kernel_config], [kernel_config]])) == 2
+    assert batch_modes == [ModeType.COMPARE, ModeType.COMPARE]
+
+
+def test_scheduler_ray_benchmark_success_and_failure(monkeypatch):
+    class Benchmarker:
+        success = True
+
+        def __init__(self, _config):
+            pass
+
+        def run(self, task_id):
+            return SimpleNamespace(
+                success=self.success,
+                errors=[] if self.success else ["failed"],
+                metadata={"ray": True},
+                to_dict=lambda: {"task_id": task_id},
+            )
+
+    monkeypatch.setattr("Magpie.modes.benchmark.BenchmarkMode", Benchmarker)
+    scheduler = Scheduler()
+    config = {"framework": "vllm", "model": "demo"}
+    result = scheduler.run_benchmark_ray(config, ray_cluster_address="ray://head")
+    assert result.success is True
+    assert config["run_mode"] == "ray"
+    assert config["ray_config"]["cluster_address"] == "ray://head"
+    Benchmarker.success = False
+    assert scheduler.run_benchmark_ray(config).status is TaskStatus.FAILED
+
+
+def test_scheduler_status_queue_clear_and_shutdown(task_factory):
+    scheduler = Scheduler()
+    pending = task_factory()
+    running = task_factory(ModeType.COMPARE)
+    running.task_id = "running"
+    running.status = TaskStatus.RUNNING
+    scheduler._task_queue = [pending, running]
+    assert scheduler.get_task_status(pending.task_id) is TaskStatus.PENDING
+    assert scheduler.get_pending_tasks() == [pending]
+    scheduler.clear_tasks()
+    assert scheduler._task_queue == [running]
+
+    result = TaskResult("done")
+    scheduler._completed_tasks["done"] = result
+    assert scheduler.get_completed_results() == {"done": result}
+    assert scheduler.get_task_status("done") is TaskStatus.COMPLETED
+    assert scheduler.get_task_status("missing") is None
+    executor = FakeExecutor()
+    scheduler._executor = executor
+    scheduler._is_initialized = True
+    assert scheduler.is_initialized() is True
+    scheduler.shutdown()
+    assert executor.stopped is True
+    assert scheduler.is_initialized() is False

--- a/tests/unit/eval/test_compiling_correctness.py
+++ b/tests/unit/eval/test_compiling_correctness.py
@@ -1,0 +1,475 @@
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from Magpie.config import (
+    AccordoConfig,
+    CompilingConfig,
+    CorrectnessBackend,
+    CorrectnessConfig,
+    EvalMode,
+    KernelEvalConfig,
+    KernelType,
+    PerformanceConfig,
+    PipelineConfig,
+)
+from Magpie.eval.compiling import Compiling
+from Magpie.eval.correctness import Correctness
+
+
+def pipeline(mode=EvalMode.ANALYZE, kernel_type=KernelType.HIP, correctness=None):
+    return PipelineConfig(
+        mode=mode,
+        kernel_type=kernel_type,
+        gpu_arch="gfx942" if kernel_type is not KernelType.CUDA else "sm_90",
+        compiling_config=CompilingConfig(),
+        correctness_config=correctness or CorrectnessConfig(),
+        performance_config=PerformanceConfig(enabled=False),
+    )
+
+
+def test_compiling_skips_jit_and_disabled_default():
+    compiler = Compiling(pipeline())
+    assert compiler.run(KernelEvalConfig(kernel_type=KernelType.PYTORCH)) is None
+    assert compiler.run(KernelEvalConfig(kernel_type=KernelType.TRITON)) is None
+    assert compiler.run(KernelEvalConfig(kernel_type=KernelType.HIP)) is None
+
+
+def test_compiling_custom_commands_success_failure_and_exception(monkeypatch):
+    compiler = Compiling(pipeline())
+    cfg = KernelEvalConfig(
+        compiling_command=[["prepare"], ["build"]], working_dir="/work"
+    )
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok")
+
+    monkeypatch.setattr("Magpie.eval.compiling.subprocess.run", run)
+    assert compiler.run(cfg).success is True
+    assert [call[0] for call in calls] == [["prepare"], ["build"]]
+    monkeypatch.setattr(
+        "Magpie.eval.compiling.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 2, stdout="failed"),
+    )
+    result = compiler.run(cfg)
+    assert result.success is False
+    assert "1/2 failed" in result.errors
+    monkeypatch.setattr(
+        "Magpie.eval.compiling.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("spawn")),
+    )
+    assert compiler.run(cfg).errors == "spawn"
+    with pytest.raises(ValueError, match="No compiling"):
+        compiler._compile_with_command(KernelEvalConfig())
+
+
+def test_default_hip_compilation_paths(monkeypatch):
+    cfg = pipeline()
+    cfg.compiling_config.enable_default_compile = True
+    compiler = Compiling(cfg)
+    kernel = KernelEvalConfig(kernel_type=KernelType.HIP, source_file_path=["a.hip"])
+    monkeypatch.setattr("Magpie.eval.compiling.shutil.which", lambda _: None)
+    assert "hipcc not found" in compiler.run(kernel).errors
+    monkeypatch.setattr("Magpie.eval.compiling.shutil.which", lambda _: "/bin/hipcc")
+    monkeypatch.setattr(
+        "Magpie.eval.compiling.compile_hip", lambda **kwargs: ("kernel.out", None, None)
+    )
+    result = compiler.run(kernel)
+    assert result.success is True
+    assert result.output_file_path == "kernel.out"
+    monkeypatch.setattr(
+        "Magpie.eval.compiling.compile_hip",
+        lambda **kwargs: (None, None, "compile error"),
+    )
+    assert compiler.run(kernel).errors == "compile error"
+    monkeypatch.setattr(
+        "Magpie.eval.compiling.compile_hip",
+        lambda **kwargs: (_ for _ in ()).throw(OSError("hip failure")),
+    )
+    assert compiler.run(kernel).errors == "hip failure"
+
+
+def test_default_cuda_compilation_paths(monkeypatch):
+    cfg = pipeline(kernel_type=KernelType.CUDA)
+    cfg.compiling_config.enable_default_compile = True
+    compiler = Compiling(cfg)
+    kernel = KernelEvalConfig(kernel_type=KernelType.CUDA, source_file_path=["a.cu"])
+    monkeypatch.setattr("Magpie.eval.compiling.shutil.which", lambda _: None)
+    assert "nvcc not found" in compiler.run(kernel).errors
+    monkeypatch.setattr("Magpie.eval.compiling.shutil.which", lambda _: "/bin/nvcc")
+    monkeypatch.setattr(
+        "Magpie.eval.compiling.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0),
+    )
+    result = compiler.run(kernel)
+    assert result.success is True
+    assert result.output_file_path.endswith("a.out")
+    monkeypatch.setattr(
+        "Magpie.eval.compiling.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 1, stderr="nvcc bad"),
+    )
+    assert compiler.run(kernel).errors == "nvcc bad"
+    monkeypatch.setattr(
+        "Magpie.eval.compiling.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("cuda failure")),
+    )
+    assert compiler.run(kernel).errors == "cuda failure"
+
+
+def test_correctness_analyze_and_testcase_paths(monkeypatch):
+    corr_cfg = CorrectnessConfig(iteration_count=2)
+    checker = Correctness(pipeline(correctness=corr_cfg))
+    assert "requires testcase" in checker.run(None, KernelEvalConfig()).errors
+    kernel = KernelEvalConfig(testcase_command=[["one"], ["two"]])
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="PASS"),
+    )
+    assert checker.run(None, kernel).success is True
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 2, stderr="bad"),
+    )
+    result = checker.run(None, kernel)
+    assert result.success is False
+    assert "1/2 failed" in result.errors
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("run failed")),
+    )
+    assert checker.run(None, kernel).errors == "run failed"
+
+
+def test_correctness_compare_dispatch(monkeypatch):
+    checker = Correctness(pipeline(mode=EvalMode.COMPARE))
+    hip = KernelEvalConfig(kernel_type=KernelType.HIP)
+    assert "requires testcase" in checker.run(None, hip).errors
+    triton = KernelEvalConfig(kernel_type=KernelType.TRITON, source_file_path=["x.py"])
+    monkeypatch.setattr(
+        checker,
+        "_run_triton_comparison",
+        lambda *args: SimpleNamespace(success=True),
+    )
+    assert checker.run(None, triton).success is True
+    pytorch = KernelEvalConfig(
+        kernel_type=KernelType.PYTORCH, source_file_path=["x.py"]
+    )
+    monkeypatch.setattr(
+        checker,
+        "_run_pytorch_comparison",
+        lambda *args: SimpleNamespace(success=True),
+    )
+    assert checker.run(None, pytorch).success is True
+    checker.pipeline_cfg.mode = object()
+    assert "Unknown evaluation mode" in checker.run(None, hip).errors
+    monkeypatch.setattr(
+        checker,
+        "_run_analyze_mode",
+        lambda *args: (_ for _ in ()).throw(ValueError("broken")),
+    )
+    checker.pipeline_cfg.mode = EvalMode.ANALYZE
+    assert checker.run(None, hip).errors == "broken"
+
+
+@pytest.mark.parametrize(
+    ("completed", "expected_success", "error"),
+    [
+        (subprocess.CompletedProcess([], 0, stdout="PASS"), True, None),
+        (
+            subprocess.CompletedProcess([], 0, stdout="error only"),
+            False,
+            "reported failure",
+        ),
+        (subprocess.CompletedProcess([], 1, stderr="crash"), False, "kernel failed"),
+    ],
+)
+def test_triton_comparison_results(
+    tmp_path, monkeypatch, completed, expected_success, error
+):
+    source = tmp_path / "kernel.py"
+    source.write_text("print('PASS')")
+    checker = Correctness(
+        pipeline(mode=EvalMode.COMPARE, kernel_type=KernelType.TRITON)
+    )
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.subprocess.run", lambda *a, **k: completed
+    )
+    result = checker._run_triton_comparison(
+        None,
+        KernelEvalConfig(kernel_type=KernelType.TRITON, source_file_path=[str(source)]),
+    )
+    assert result.success is expected_success
+    if error:
+        assert error in result.errors.lower()
+    assert (
+        "No source"
+        in checker._run_triton_comparison(
+            None, KernelEvalConfig(kernel_type=KernelType.TRITON)
+        ).errors
+    )
+
+
+def test_triton_comparison_timeout_and_exception(tmp_path, monkeypatch):
+    source = tmp_path / "kernel.py"
+    source.touch()
+    checker = Correctness(
+        pipeline(mode=EvalMode.COMPARE, kernel_type=KernelType.TRITON)
+    )
+    kernel = KernelEvalConfig(
+        kernel_type=KernelType.TRITON, source_file_path=[str(source)]
+    )
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(subprocess.TimeoutExpired("python", 120)),
+    )
+    assert "timed out" in checker._run_triton_comparison(None, kernel).errors
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("spawn")),
+    )
+    assert checker._run_triton_comparison(None, kernel).errors == "spawn"
+
+
+def accordo_checker(config):
+    corr = CorrectnessConfig(backend=CorrectnessBackend.ACCORDO, accordo_config=config)
+    return Correctness(pipeline(correctness=corr))
+
+
+def test_accordo_validation_config_and_success(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.shutil.which", lambda _: "/bin/accordo"
+    )
+    checker = accordo_checker(
+        AccordoConfig(
+            kernel_name="gemm",
+            reference_binary="ref",
+            optimized_binary="opt",
+            equal_nan=True,
+            kernel_args=[("x", "ptr")],
+            workspace_path=str(tmp_path),
+        )
+    )
+    output = {"is_valid": True, "num_arrays_validated": 2, "matched_arrays": {"x": {}}}
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="log\n" + json.dumps(output))
+
+    monkeypatch.setattr("Magpie.eval.correctness.subprocess.run", run)
+    result = checker.run(None, KernelEvalConfig())
+    assert result.success is True
+    assert len(result.metrics) == 2
+    assert "--equal-nan" in calls[0][0]
+    assert "--kernel-args" in calls[0][0]
+
+
+def test_accordo_validation_failures(tmp_path, monkeypatch):
+    monkeypatch.setattr("Magpie.eval.correctness.shutil.which", lambda _: None)
+    assert (
+        "not found"
+        in accordo_checker(AccordoConfig()).run(None, KernelEvalConfig()).errors
+    )
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.shutil.which", lambda _: "/bin/accordo"
+    )
+    assert (
+        "kernel_name"
+        in accordo_checker(AccordoConfig()).run(None, KernelEvalConfig()).errors
+    )
+    cfg = AccordoConfig(kernel_name="gemm")
+    assert "both" in accordo_checker(cfg).run(None, KernelEvalConfig()).errors
+    cfg.reference_binary = "ref"
+    cfg.optimized_binary = "opt"
+    checker = accordo_checker(cfg)
+
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.subprocess.run",
+        lambda *a, **k: subprocess.CompletedProcess(
+            [], 2, stdout='{"error":"invalid"}'
+        ),
+    )
+    assert "invalid" in checker.run(None, KernelEvalConfig()).errors
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.subprocess.run",
+        lambda *a, **k: subprocess.CompletedProcess([], 0, stdout="not-json"),
+    )
+    assert "invalid JSON" in checker.run(None, KernelEvalConfig()).errors
+    mismatch = {
+        "is_valid": False,
+        "num_mismatches": 1,
+        "error_message": "different",
+        "mismatches": [
+            {"arg_name": "x", "dispatch_index": 2, "max_difference": 1.0},
+            {"arg_name": "y", "max_difference": 2.0},
+        ],
+    }
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.subprocess.run",
+        lambda *a, **k: subprocess.CompletedProcess([], 0, stdout=json.dumps(mismatch)),
+    )
+    result = checker.run(None, KernelEvalConfig())
+    assert result.success is False
+    assert len(result.metrics) == 3
+
+
+def test_accordo_timeout_and_missing_binary(monkeypatch):
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.shutil.which", lambda _: "/bin/accordo"
+    )
+    cfg = AccordoConfig(
+        kernel_name="gemm", reference_binary="ref", optimized_binary="opt"
+    )
+    checker = accordo_checker(cfg)
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(subprocess.TimeoutExpired("accordo", 1)),
+    )
+    assert "timed out" in checker.run(None, KernelEvalConfig()).errors
+    monkeypatch.setattr(
+        "Magpie.eval.correctness.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    assert "not found" in checker.run(None, KernelEvalConfig()).errors
+
+
+def test_dynamic_module_loading(tmp_path):
+    checker = Correctness(pipeline())
+    module_file = tmp_path / "demo.py"
+    module_file.write_text("VALUE = 42\n")
+    assert checker._load_module(str(module_file)).VALUE == 42
+    with pytest.raises(FileNotFoundError):
+        checker._load_module(str(tmp_path / "missing.py"))
+
+
+class FakeTensor:
+    def __init__(self, value=1):
+        self.value = value
+        self.on_cuda = False
+
+    def cuda(self):
+        self.on_cuda = True
+        return self
+
+
+class FakeBool:
+    def __init__(self, value):
+        self.value = value
+
+    def any(self):
+        return self.value
+
+
+class NoGrad:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class FakeTorch:
+    Tensor = FakeTensor
+
+    def __init__(self, nan=False, inf=False, cuda=False):
+        self.nan = nan
+        self.inf = inf
+        self.cuda = SimpleNamespace(is_available=lambda: cuda)
+        self.seeds = []
+
+    def manual_seed(self, seed):
+        self.seeds.append(seed)
+
+    def no_grad(self):
+        return NoGrad()
+
+    def isnan(self, _value):
+        return FakeBool(self.nan)
+
+    def isinf(self, _value):
+        return FakeBool(self.inf)
+
+
+class FakeModel:
+    def __init__(self, *init_inputs):
+        self.init_inputs = init_inputs
+        self.on_cuda = False
+
+    def cuda(self):
+        self.on_cuda = True
+        return self
+
+    def eval(self):
+        return self
+
+    def __call__(self, *_inputs):
+        return FakeTensor()
+
+
+def setup_fake_torch(monkeypatch, fake):
+    monkeypatch.setattr("Magpie.eval.correctness.HAS_TORCH", True)
+    monkeypatch.setattr("Magpie.eval.correctness.torch", fake)
+    monkeypatch.setattr("Magpie.eval.correctness._ensure_torch", lambda: None)
+
+
+def test_pytorch_comparison_success_nan_and_inf(monkeypatch):
+    checker = Correctness(
+        pipeline(mode=EvalMode.COMPARE, kernel_type=KernelType.PYTORCH)
+    )
+    kernel = KernelEvalConfig(
+        kernel_type=KernelType.PYTORCH, source_file_path=["model.py"]
+    )
+    module = SimpleNamespace(
+        get_inputs=lambda: FakeTensor(),
+        get_init_inputs=lambda: [4],
+        Model=FakeModel,
+    )
+    monkeypatch.setattr(checker, "_load_module", lambda _: module)
+    fake = FakeTorch(cuda=True)
+    setup_fake_torch(monkeypatch, fake)
+    assert checker._run_pytorch_comparison(None, kernel).success is True
+    assert fake.seeds
+
+    fake.nan = True
+    result = checker._run_pytorch_comparison(None, kernel)
+    assert result.success is False
+    assert "NaN" in result.errors
+    fake.nan = False
+    fake.inf = True
+    result = checker._run_pytorch_comparison(None, kernel)
+    assert result.success is False
+    assert "Inf" in result.errors
+
+
+def test_pytorch_comparison_validation_and_exception(monkeypatch):
+    checker = Correctness(
+        pipeline(mode=EvalMode.COMPARE, kernel_type=KernelType.PYTORCH)
+    )
+    kernel = KernelEvalConfig(kernel_type=KernelType.PYTORCH)
+    monkeypatch.setattr("Magpie.eval.correctness.HAS_TORCH", False)
+    monkeypatch.setattr("Magpie.eval.correctness.torch", None)
+    monkeypatch.setattr("Magpie.eval.correctness._ensure_torch", lambda: None)
+    assert "not available" in checker._run_pytorch_comparison(None, kernel).errors
+    setup_fake_torch(monkeypatch, FakeTorch())
+    assert "No source" in checker._run_pytorch_comparison(None, kernel).errors
+    kernel.source_file_path = ["model.py"]
+    monkeypatch.setattr(
+        checker, "_load_module", lambda _: SimpleNamespace(Model=FakeModel)
+    )
+    assert "get_inputs" in checker._run_pytorch_comparison(None, kernel).errors
+    monkeypatch.setattr(
+        checker,
+        "_load_module",
+        lambda _: SimpleNamespace(get_inputs=lambda: [], Model=None),
+    )
+    assert "Model class" in checker._run_pytorch_comparison(None, kernel).errors
+    monkeypatch.setattr(
+        checker,
+        "_load_module",
+        lambda _: (_ for _ in ()).throw(OSError("load failed")),
+    )
+    assert checker._run_pytorch_comparison(None, kernel).errors == "load failed"

--- a/tests/unit/eval/test_performance_evaluator_remote.py
+++ b/tests/unit/eval/test_performance_evaluator_remote.py
@@ -1,0 +1,471 @@
+import json
+import os
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from Magpie.config import (
+    KernelEvalConfig,
+    KernelType,
+    MetrixConfig,
+    NcuConfig,
+    PerfBackend,
+    PerformanceConfig,
+    PipelineConfig,
+    RocprofComputeConfig,
+)
+from Magpie.eval.compiling import CompilingResult
+from Magpie.eval.correctness import CorrectnessResult
+from Magpie.eval.evaluator import BaseKind, EvaluationState, Evaluator
+from Magpie.eval.performance import (
+    KernelMetrics,
+    MetricResult,
+    Performance,
+    PerformanceResult,
+)
+from Magpie.remote import tasks as remote_tasks
+
+
+def performance(backend=PerfBackend.NONE, **kwargs):
+    perf = PerformanceConfig(backend=backend, **kwargs)
+    cfg = PipelineConfig(
+        kernel_type=KernelType.HIP,
+        gpu_arch="gfx942",
+        performance_config=perf,
+    )
+    return Performance(cfg)
+
+
+def test_performance_result_models_and_summaries():
+    metric = MetricResult("FLOPS", 12, "TF/s", peak=20, pct_of_peak=60)
+    kernels = [
+        KernelMetrics("gemm", 0, duration_ns=10),
+        KernelMetrics("gemm", 1, duration_ns=20),
+        KernelMetrics("other", 2, duration_ns=5),
+        KernelMetrics("__amd_rocclr_internal", 3, duration_ns=100),
+        KernelMetrics("no-duration", 4),
+    ]
+    result = PerformanceResult(True, metrics=[metric], kernel_metrics=kernels)
+    assert metric.to_dict() == {
+        "name": "FLOPS",
+        "value": 12,
+        "unit": "TF/s",
+        "peak": 20,
+        "pct_of_peak": 60,
+    }
+    assert kernels[0].to_dict()["kernel_name"] == "gemm"
+    data = result.to_dict()
+    assert data["summary"]["FLOPS"]["peak"] == 20
+    assert data["kernels"][0]["kernel_name"] == "gemm"
+    assert data["kernels"][0]["dispatch_count"] == 2
+
+
+def test_performance_run_dispatch_and_disabled(kernel_config, monkeypatch):
+    runner = performance(PerfBackend.NCU)
+    runner.perf_cfg.enabled = False
+    assert runner.run(None, kernel_config) is None
+    runner.perf_cfg.enabled = True
+    no_commands = KernelEvalConfig()
+    assert runner.run(None, no_commands) is None
+    custom = KernelEvalConfig(prof_command=["profile"])
+    monkeypatch.setattr(runner, "_run_custom_profiler", lambda _: "custom")
+    assert runner.run(None, custom) == "custom"
+    for backend, method, marker in [
+        (PerfBackend.NCU, "_run_ncu_on_testcase", "ncu"),
+        (PerfBackend.ROCPROF_COMPUTE, "_run_rocprof_compute_on_testcase", "rocprof"),
+        (PerfBackend.METRIX, "_run_metrix_on_testcase", "metrix"),
+    ]:
+        runner.perf_cfg.backend = backend
+        monkeypatch.setattr(runner, method, lambda _, value=marker: value)
+        assert runner.run(None, kernel_config) == marker
+    runner.perf_cfg.backend = PerfBackend.NONE
+    assert runner.run(None, kernel_config) is None
+    runner.perf_cfg.backend = PerfBackend.NCU
+    monkeypatch.setattr(
+        runner,
+        "_run_ncu_on_testcase",
+        lambda _: (_ for _ in ()).throw(ValueError("bad")),
+    )
+    assert runner.run(None, kernel_config).errors == "bad"
+
+
+def test_custom_profiler_success_failure_timeout_exception(monkeypatch):
+    runner = performance()
+    kernel = KernelEvalConfig(prof_command=[["one"], ["two"]])
+    monkeypatch.setattr(
+        "Magpie.eval.performance.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="ok"),
+    )
+    assert runner._run_custom_profiler(kernel).success is True
+    monkeypatch.setattr(
+        "Magpie.eval.performance.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd, 2, stdout="", stderr="failed"
+        ),
+    )
+    assert "1/2 failed" in runner._run_custom_profiler(kernel).errors
+    monkeypatch.setattr(
+        "Magpie.eval.performance.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(subprocess.TimeoutExpired("x", 1)),
+    )
+    assert "timed out" in runner._run_custom_profiler(kernel).errors
+    monkeypatch.setattr(
+        "Magpie.eval.performance.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("spawn")),
+    )
+    assert runner._run_custom_profiler(kernel).errors == "spawn"
+
+
+def test_rocprof_csv_parsers(tmp_path):
+    runner = performance(PerfBackend.ROCPROF_COMPUTE)
+    pmc = tmp_path / "pmc_perf.csv"
+    pmc.write_text(
+        "Kernel_Name,Dispatch_ID,Start_Timestamp,End_Timestamp,SQ_INSTS,TEXT\n"
+        "gemm,2,10,30,44,nope\n"
+        "bad,bad,x,y,bad,nope\n"
+    )
+    kernels = runner._parse_pmc_perf_csv(pmc)
+    assert kernels[0].duration_ns == 20
+    assert kernels[0].metrics[0].value == 44
+    assert kernels[1].dispatch_id == 0
+
+    top = tmp_path / "pmc_kernel_top.csv"
+    top.write_text("KernelName,DispatchID,Duration,Counter,Text\n" "gemm,1,30,7,nope\n")
+    parsed = runner._parse_kernel_top_csv(top)
+    assert parsed[0].duration_ns == 30
+    assert any(metric.name == "Counter" for metric in parsed[0].metrics)
+
+    table = tmp_path / "2.1_Speed-of-Light.csv"
+    table.write_text(
+        "Metric,Avg,Unit,Peak,Pct of Peak\n"
+        "VALU Utilization,50,%,100,50\n"
+        "missing,,%,,\n"
+    )
+    metrics = runner._parse_metric_table_csv(table)
+    assert metrics[0].name == "VALU_Util"
+    assert metrics[0].peak == 100
+    assert metrics[0].pct_of_peak == 50
+    assert runner._parse_speed_of_light_csv(tmp_path)
+
+    instruction = tmp_path / "10.1_Overall_Instruction_Mix.csv"
+    instruction.write_text("Metric,Avg,Unit\nVALU,10,count\n")
+    memory = tmp_path / "12.2_LDS_Stats.csv"
+    memory.write_text("Metric,Avg,Unit\nLDS,20,count\n")
+    assert runner._parse_instruction_mix_csv(tmp_path)[0].name == "Inst_VALU"
+    assert runner._parse_memory_metrics_csv(tmp_path)[0].name == "Inst_LDS"
+    summary, workload_kernels = runner._parse_rocprof_workload(tmp_path)
+    assert summary
+    assert workload_kernels
+
+
+def test_ncu_profile_and_parser(monkeypatch, kernel_config):
+    runner = performance(
+        PerfBackend.NCU,
+        ncu_config=NcuConfig(
+            metrics=["sm__cycles"], kernel_filter="gemm", args=["--csv"]
+        ),
+    )
+    monkeypatch.setattr("Magpie.eval.performance.shutil.which", lambda _: None)
+    assert "not found" in runner._run_ncu_on_testcase(kernel_config).errors
+    monkeypatch.setattr("Magpie.eval.performance.shutil.which", lambda _: "/bin/ncu")
+    assert "No testcase" in runner._run_ncu_on_testcase(KernelEvalConfig()).errors
+    monkeypatch.setattr(
+        "Magpie.eval.performance.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd, 0, stdout="sm__cycles cycle 1,234\n"
+        ),
+    )
+    result = runner._run_ncu_on_testcase(kernel_config)
+    assert result.success is True
+    assert result.metrics[0].value == 1234
+    monkeypatch.setattr(
+        "Magpie.eval.performance.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd, 2, stdout="", stderr="ncu failed"
+        ),
+    )
+    assert "ncu failed" in runner._run_ncu_on_testcase(kernel_config).errors
+    assert runner._parse_ncu_output("not metrics")[0].name == "profiling_complete"
+
+
+def test_metrix_profile_and_json_parser(tmp_path, monkeypatch, kernel_config):
+    config = MetrixConfig(output_dir=str(tmp_path), profile="quick")
+    runner = performance(PerfBackend.METRIX, metrix_config=config)
+    monkeypatch.setattr("Magpie.eval.performance.shutil.which", lambda _: None)
+    assert "not found" in runner._run_metrix_on_testcase(kernel_config).errors
+    monkeypatch.setattr("Magpie.eval.performance.shutil.which", lambda _: "/bin/metrix")
+    assert "No testcase" in runner._run_metrix_on_testcase(KernelEvalConfig()).errors
+    monkeypatch.setattr(
+        "Magpie.eval.performance.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="profiled"),
+    )
+    assert runner._run_metrix_on_testcase(kernel_config).success is True
+
+    data = {
+        "gemm": {
+            "duration_us": {"avg": 2},
+            "metrics": {
+                "memory.l2_hit_rate": {"avg": 80},
+                "ignored": {"avg": None},
+            },
+        },
+        "gemm-2": {"metrics": {"memory.l2_hit_rate": {"avg": 100}}},
+    }
+    path = tmp_path / "metrix.json"
+    path.write_text(json.dumps(data))
+    metrics, kernels = runner._parse_metrix_json_output(path)
+    assert metrics[0].name == "L2_HitRate"
+    assert metrics[0].value == 90
+    assert kernels[0].duration_ns == 2000
+    missing_metrics, missing_kernels = runner._parse_metrix_json_output(
+        tmp_path / "missing"
+    )
+    assert missing_metrics == missing_kernels == []
+
+
+def test_rocprof_profile_success_and_failures(tmp_path, monkeypatch, kernel_config):
+    rocprof = RocprofComputeConfig(output_dir=str(tmp_path))
+    runner = performance(PerfBackend.ROCPROF_COMPUTE, rocprof_config=rocprof)
+    monkeypatch.setattr("Magpie.eval.performance.shutil.which", lambda _: None)
+    assert "not found" in runner._run_rocprof_compute_on_testcase(kernel_config).errors
+    monkeypatch.setattr(
+        "Magpie.eval.performance.shutil.which", lambda _: "/bin/rocprof"
+    )
+    assert (
+        "No testcase"
+        in runner._run_rocprof_compute_on_testcase(KernelEvalConfig()).errors
+    )
+    workload = tmp_path / "rocprof_compute_output"
+
+    def run(cmd, **kwargs):
+        workload.mkdir(exist_ok=True)
+        (workload / "pmc_perf.csv").write_text(
+            "Kernel_Name,Dispatch_ID,Start_Timestamp,End_Timestamp\n" "gemm,0,0,10\n"
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok")
+
+    monkeypatch.setattr("Magpie.eval.performance.subprocess.run", run)
+    result = runner._run_rocprof_compute_on_testcase(kernel_config)
+    assert result.success is True
+    assert result.kernel_metrics[0].kernel_name == "gemm"
+    monkeypatch.setattr(
+        "Magpie.eval.performance.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 2, stderr="profile bad"),
+    )
+    assert (
+        "profile failed"
+        in runner._run_rocprof_compute_on_testcase(kernel_config).errors
+    )
+
+
+def test_evaluation_state_and_pipeline(kernel_config, monkeypatch):
+    state = EvaluationState(
+        compiling_result=CompilingResult(True),
+        correctness_result=CorrectnessResult(True),
+        performance_result=PerformanceResult(True),
+        score=1,
+        extra={"x": 1},
+    )
+    restored = EvaluationState.from_dict(state.to_dict())
+    assert restored.score == 1
+    assert restored.compiling_result.success is True
+    assert restored.correctness_result.success is True
+    assert restored.performance_result.success is True
+
+    evaluator = Evaluator(PipelineConfig(kernel_type=KernelType.HIP, gpu_arch="gfx942"))
+    monkeypatch.setattr(evaluator.compiling, "run", lambda _: None)
+    monkeypatch.setattr(
+        evaluator.correctness, "run", lambda *a: CorrectnessResult(True)
+    )
+    monkeypatch.setattr(evaluator.performance, "run", lambda *a: None)
+    result = evaluator.evaluate(kernel_config)
+    assert result.score == 1
+    assert result.compiling_state is BaseKind.SKIPPED
+    assert result.performance_state is BaseKind.SKIPPED
+
+
+@pytest.mark.parametrize(
+    ("stage", "error_prefix"),
+    [
+        ("compiling", "Compilation error"),
+        ("correctness", "Correctness error"),
+        ("performance", "Performance error"),
+    ],
+)
+def test_evaluator_stage_exceptions(kernel_config, stage, error_prefix, monkeypatch):
+    evaluator = Evaluator(PipelineConfig(kernel_type=KernelType.HIP, gpu_arch="gfx942"))
+    monkeypatch.setattr(
+        getattr(evaluator, stage),
+        "run",
+        lambda *a: (_ for _ in ()).throw(ValueError("broken")),
+    )
+    state = EvaluationState()
+    method = {
+        "compiling": evaluator._compile,
+        "correctness": evaluator._check_correctness,
+        "performance": evaluator._check_performance,
+    }[stage]
+    assert error_prefix in method(state, kernel_config).errors[0]
+
+
+def test_evaluator_failed_results_and_scores(kernel_config, monkeypatch):
+    evaluator = Evaluator(PipelineConfig(kernel_type=KernelType.HIP, gpu_arch="gfx942"))
+    monkeypatch.setattr(
+        evaluator.compiling, "run", lambda _: CompilingResult(False, errors="compile")
+    )
+    assert evaluator.evaluate(kernel_config).score == 0
+    state = EvaluationState(compiling_state=BaseKind.SUCCESS)
+    monkeypatch.setattr(
+        evaluator.correctness,
+        "run",
+        lambda *a: CorrectnessResult(False, errors="wrong"),
+    )
+    assert (
+        evaluator._check_correctness(state, kernel_config).correctness_state
+        is BaseKind.FAILED
+    )
+    monkeypatch.setattr(
+        evaluator.performance, "run", lambda *a: PerformanceResult(False, errors="slow")
+    )
+    assert (
+        evaluator._check_performance(state, kernel_config).performance_state
+        is BaseKind.FAILED
+    )
+    state.compiling_state = BaseKind.FAILED
+    assert evaluator._calculate_score(state).score == 0
+
+
+def test_remote_task_helpers_and_dispatch(monkeypatch):
+    monkeypatch.delenv("HF_HOME", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_CACHE", raising=False)
+    remote_tasks._setup_env({"shared_storage_path": "/shared"})
+    assert os.environ["HF_HOME"] == "/shared/hf_cache"
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "")
+    remote_tasks._clear_hidden_gpus()
+    assert "HIP_VISIBLE_DEVICES" not in os.environ
+    envs = {}
+    remote_tasks._ensure_extra_arg(envs, "EXTRA", "--flag value")
+    remote_tasks._ensure_extra_arg(envs, "EXTRA", "--flag other")
+    assert envs["EXTRA"] == "--flag value"
+    assert remote_tasks._extra_args_key("vllm") == "EXTRA_VLLM_ARGS"
+    assert remote_tasks._extra_args_key("custom") == "EXTRA_CUSTOM_ARGS"
+
+    monkeypatch.setitem(
+        remote_tasks._MODE_RUNNERS,
+        "unit",
+        lambda mode, ray, task: {"task_id": task, "status": "completed"},
+    )
+    result = remote_tasks.run_task({"task_id": "t", "mode_type": "unit"})
+    assert result["status"] == "completed"
+    assert "execution_time" in result
+    assert "Unsupported" in remote_tasks.run_task({"mode_type": "missing"})["error"]
+
+
+@pytest.mark.parametrize(
+    ("framework", "tp", "local", "expected"),
+    [
+        ("vllm", 2, 8, "--distributed-executor-backend mp"),
+        ("vllm", 16, 8, "--distributed-executor-backend ray"),
+        ("sglang", 16, 8, "--use-ray --nnodes 2"),
+    ],
+)
+def test_remote_tp_isolation(framework, tp, local, expected, monkeypatch):
+    mode = {"benchmark_config": {"framework": framework, "envs": {"TP": tp}}}
+    monkeypatch.setattr(remote_tasks, "_get_local_gpu_count", lambda: local)
+    monkeypatch.setenv("RAY_ADDRESS", "auto")
+    remote_tasks._configure_tp_isolation(mode, {})
+    key = remote_tasks._extra_args_key(framework)
+    assert expected in mode["benchmark_config"]["envs"][key]
+
+
+def test_remote_gpu_count_and_dispatch_failure(monkeypatch):
+    ray = SimpleNamespace(
+        get_runtime_context=lambda: SimpleNamespace(get_node_id=lambda: "node"),
+        nodes=lambda: [{"NodeID": "node", "Alive": True, "Resources": {"GPU": 4}}],
+    )
+    monkeypatch.setitem(__import__("sys").modules, "ray", ray)
+    assert remote_tasks._get_local_gpu_count() == 4
+    ray.nodes = lambda: (_ for _ in ()).throw(RuntimeError("ray unavailable"))
+    assert remote_tasks._get_local_gpu_count() == 8
+
+    monkeypatch.setitem(
+        remote_tasks._MODE_RUNNERS,
+        "broken",
+        lambda *args: (_ for _ in ()).throw(ValueError("worker broke")),
+    )
+    result = remote_tasks.run_task({"task_id": "broken", "mode_type": "broken"})
+    assert result["status"] == "failed"
+    assert result["error"] == "worker broke"
+
+
+@pytest.mark.parametrize("framework", ["atom", "unknown"])
+def test_remote_tp_isolation_skips_unsupported_multinode(framework, monkeypatch):
+    mode = {"benchmark_config": {"framework": framework, "envs": {"TP": 16}}}
+    monkeypatch.setattr(remote_tasks, "_get_local_gpu_count", lambda: 8)
+    remote_tasks._configure_tp_isolation(mode, {})
+    assert (
+        remote_tasks._extra_args_key(framework) not in mode["benchmark_config"]["envs"]
+    )
+
+
+def test_remote_benchmark_runner_sets_shared_paths(monkeypatch):
+    class Benchmarker:
+        def __init__(self, config, output_dir):
+            self.config = config
+            self.output_dir = output_dir
+
+        def run(self, task_id):
+            return SimpleNamespace(
+                to_dict=lambda: {
+                    "task_id": task_id,
+                    "run_mode": self.config.run_mode,
+                    "inferencex": self.config.inferencex_path,
+                    "cache": self.config.hf_cache_path,
+                    "output_dir": self.output_dir,
+                }
+            )
+
+    monkeypatch.setattr("Magpie.modes.benchmark.BenchmarkMode", Benchmarker)
+    mode = {
+        "benchmark_config": {
+            "framework": "vllm",
+            "model": "demo",
+            "run_mode": "ray",
+        }
+    }
+    result = remote_tasks._run_benchmark(
+        mode, {"shared_storage_path": "/shared"}, "task"
+    )
+    assert result["run_mode"] == "local"
+    assert result["inferencex"] == "/shared/InferenceX"
+    assert result["cache"] == "/shared/hf_cache"
+    assert result["output_dir"] == "/shared/results/task"
+
+
+def test_remote_analyze_and_compare_runners(monkeypatch, kernel_config):
+    class Analyzer:
+        def __init__(self, config):
+            self.config = config
+
+        def analyze(self, kernel):
+            return SimpleNamespace(to_dict=lambda: {"kernel": kernel.kernel_id})
+
+    class Comparator:
+        def __init__(self, config):
+            self.config = config
+
+        def compare(self, kernels):
+            return SimpleNamespace(to_dict=lambda: {"count": len(kernels)})
+
+    monkeypatch.setattr("Magpie.modes.AnalyzeMode", Analyzer)
+    monkeypatch.setattr("Magpie.modes.CompareMode", Comparator)
+    mode = {
+        "kernel_configs": [kernel_config.to_dict(), "ignored"],
+        "gpu_arch": "gfx942",
+        "compare_config": {"winner_strategy": "correctness"},
+    }
+    analyzed = remote_tasks._run_analyze(mode, {}, "analyze")
+    compared = remote_tasks._run_compare(mode, {}, "compare")
+    assert analyzed["results"] == [{"kernel": "unit-kernel"}]
+    assert compared["results"] == {"count": 1}

--- a/tests/unit/mcp/test_mcp_main.py
+++ b/tests/unit/mcp/test_mcp_main.py
@@ -1,0 +1,30 @@
+import sys
+
+from Magpie.mcp import __main__ as entrypoint
+from Magpie.mcp import server
+
+
+def test_mcp_main_stdio_and_http(monkeypatch):
+    calls = []
+    monkeypatch.setattr(server.mcp, "run", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(sys, "argv", ["magpie-mcp"])
+    entrypoint.main()
+    assert calls[-1] == {"transport": "stdio"}
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "magpie-mcp",
+            "--transport",
+            "streamable-http",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "9000",
+        ],
+    )
+    entrypoint.main()
+    assert calls[-1] == {"transport": "streamable-http"}
+    assert entrypoint.os.environ["MAGPIE_HOST"] == "127.0.0.1"
+    assert entrypoint.os.environ["MAGPIE_PORT"] == "9000"

--- a/tests/unit/mcp/test_server_tools.py
+++ b/tests/unit/mcp/test_server_tools.py
@@ -1,0 +1,659 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from Magpie.config import KernelEvalConfig, KernelType
+from Magpie.eval import BaseKind, EvaluationState
+from Magpie.mcp import server
+
+
+def decoded(value):
+    return json.loads(value)
+
+
+def test_health_and_framework_config(monkeypatch, tmp_path):
+    response = asyncio.run(server.health_check(None))
+    assert response.status_code == 200
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "scheduler:\n  max_workers: 3\nperformance:\n  timeout_seconds: 12\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    assert server._load_framework_config()["scheduler"]["max_workers"] == 3
+    scheduler = server._get_scheduler_config_from_yaml("local")
+    assert scheduler.max_workers == 3
+    assert server._get_perf_settings_from_yaml()["timeout_seconds"] == 12
+    assert "accordo" in server._get_correctness_settings_from_yaml()
+
+
+def test_hardware_spec_single_all_and_error(monkeypatch):
+    info = SimpleNamespace(to_dict=lambda: {"name": "gpu"})
+
+    class Controller:
+        def __init__(self, device_id=0):
+            self.device_id = device_id
+
+        def get_hardware_info(self):
+            return info
+
+    class Multi:
+        def get_all_hardware_info(self):
+            return {0: info, 1: info}
+
+    monkeypatch.setattr("Magpie.utils.GPUController", Controller)
+    monkeypatch.setattr("Magpie.utils.MultiGPUController", Multi)
+    monkeypatch.setattr("Magpie.utils.get_gpu_count", lambda: 2)
+    assert decoded(server.hardware_spec())["gpu_count"] == 2
+    assert len(decoded(server.hardware_spec(include_all=True))["gpus"]) == 2
+    monkeypatch.setattr(
+        Controller,
+        "get_hardware_info",
+        lambda self: (_ for _ in ()).throw(RuntimeError("offline")),
+    )
+    assert decoded(server.hardware_spec())["error"] == "offline"
+
+
+def test_format_analysis_dict_and_object():
+    config = KernelEvalConfig(kernel_id="demo", kernel_type=KernelType.HIP)
+    raw = {
+        "compiling_state": "SUCCESS",
+        "correctness_state": "SUCCESS",
+        "performance_state": "SUCCESS",
+        "score": 1,
+        "compiling_result": {"success": True, "compile_time_seconds": 1},
+        "correctness_result": {"success": True},
+        "performance_result": {"success": True, "summary": {"util": 90}},
+    }
+    formatted = server._format_analysis_result(raw, config, KernelType.HIP)
+    assert formatted["performance_result"]["summary"] == {"util": 90}
+
+    state = EvaluationState(
+        compiling_state=BaseKind.SUCCESS,
+        correctness_state=BaseKind.SUCCESS,
+        performance_state=BaseKind.SUCCESS,
+        score=2,
+    )
+    formatted = server._format_analysis_result(state, config, KernelType.HIP)
+    assert formatted["score"] == 2
+
+
+def test_result_formatters_cover_protocols():
+    serializable = SimpleNamespace(to_dict=lambda: {"serialized": True})
+    assert server._format_compiling_result(serializable) == {"serialized": True}
+    assert server._format_correctness_result(serializable) == {"serialized": True}
+    assert server._format_performance_result(serializable) == {"serialized": True}
+    plain = SimpleNamespace(success=True, errors="none", compile_time_seconds=2)
+    assert server._format_compiling_result(plain)["compile_time_seconds"] == 2
+    assert server._format_correctness_result(plain)["success"] is True
+
+    metrics = [
+        SimpleNamespace(name="util", value=80, unit="%", peak=100, pct_of_peak=80)
+    ]
+    perf = SimpleNamespace(
+        success=True, errors=None, workload_dir="work", metrics=metrics
+    )
+    formatted = server._format_performance_result(perf)
+    assert formatted["summary"]["util"]["pct_of_peak"] == 80
+    assert formatted["kernels"] == []
+
+
+def test_discover_kernels_success_and_error(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "discover_project_kernels",
+        lambda **kwargs: {"kernels": [kwargs["kernel_type"]]},
+    )
+    assert decoded(server.discover_kernels(".", "cuda"))["kernels"] == ["cuda"]
+    monkeypatch.setattr(
+        server,
+        "discover_project_kernels",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("scan failed")),
+    )
+    assert decoded(server.discover_kernels("."))["error"] == "scan failed"
+
+
+def test_suggest_optimizations_all_rules_and_errors():
+    unavailable = decoded(
+        server.suggest_optimizations(
+            json.dumps({"performance_state": "FAILED", "errors": ["bad"]})
+        )
+    )
+    assert unavailable["error"] == "Performance analysis not available"
+    data = {
+        "kernel_id": "demo",
+        "score": 0.4,
+        "performance_state": "SUCCESS",
+        "performance_result": {
+            "summary": {
+                "Active CUs": {"pct_of_peak": 20},
+                "MFMA_Util": {"value": 5},
+                "MFMA_FLOPs_F16": {"value": 1},
+                "VALU_Util": {"value": 80},
+                "VMEM_Util": {"value": 90},
+            },
+            "kernels": [
+                {"duration_ns": {"avg": 1000}},
+                {"duration_ns": {"avg": 2000}},
+                {"duration_ns": {"avg": 30000}},
+            ],
+        },
+    }
+    result = decoded(server.suggest_optimizations(json.dumps(data)))
+    assert result["summary"]["total_bottlenecks"] == 4
+    assert result["summary"]["high_impact_suggestions"] == 3
+    assert decoded(server.suggest_optimizations("{"))["error"] == "Invalid JSON input"
+
+
+def test_create_kernel_config_variants(monkeypatch):
+    result = decoded(
+        server.create_kernel_config(
+            "demo", "kernel.hip", "./test", working_dir="/work", compile_command="make"
+        )
+    )
+    assert "working_dir: /work" in result["config_content"]
+    assert "compile_command: make" in result["config_content"]
+    monkeypatch.setattr(
+        "yaml.dump", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("yaml failed"))
+    )
+    assert (
+        decoded(server.create_kernel_config("demo", "x", "test"))["error"]
+        == "yaml failed"
+    )
+
+
+class FakeScheduler:
+    initialized = True
+    response = None
+    instances = []
+
+    def __init__(self, config):
+        self.config = config
+        self.shutdown_called = False
+        self.__class__.instances.append(self)
+
+    def initialize(self):
+        return self.initialized
+
+    def run_analyze(self, **kwargs):
+        self.kwargs = kwargs
+        return self.response
+
+    def run_compare(self, **kwargs):
+        self.kwargs = kwargs
+        return self.response
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+
+def test_analyze_success_failure_and_initialization(monkeypatch):
+    monkeypatch.setattr("Magpie.core.Scheduler", FakeScheduler)
+    FakeScheduler.instances.clear()
+    FakeScheduler.initialized = True
+    FakeScheduler.response = SimpleNamespace(
+        success=True,
+        results=[
+            {
+                "compiling_state": "SUCCESS",
+                "correctness_state": "SUCCESS",
+                "performance_state": "SUCCESS",
+                "score": 1,
+            }
+        ],
+        errors=[],
+    )
+    result = decoded(
+        server.analyze(
+            "kernel.hip",
+            "./test --quick",
+            compile_command="make build",
+            performance_backend="metrix",
+            correctness_backend="accordo",
+            accordo_kernel_name="kernel",
+        )
+    )
+    assert result["score"] == 1
+    assert result["kernel_config"]["compile_command"] == "make build"
+    assert FakeScheduler.instances[-1].shutdown_called is True
+
+    FakeScheduler.response = SimpleNamespace(
+        success=False, results=[], errors=["failed"]
+    )
+    assert decoded(server.analyze("kernel.hip", "./test"))["error"] == "Analysis failed"
+    FakeScheduler.initialized = False
+    assert (
+        decoded(server.analyze("kernel.hip", "./test"))["error"]
+        == "Failed to initialize scheduler"
+    )
+
+
+def test_analyze_handles_scheduler_exception(monkeypatch):
+    class Broken:
+        def __init__(self, config):
+            raise RuntimeError("scheduler unavailable")
+
+    monkeypatch.setattr("Magpie.core.Scheduler", Broken)
+    result = decoded(server.analyze("kernel.hip", "./test"))
+    assert result["error"] == "scheduler unavailable"
+    assert result["kernel_config"]["kernel_path"] == "kernel.hip"
+
+
+def test_compare_success_shapes_failures_and_validation(monkeypatch):
+    monkeypatch.setattr("Magpie.core.Scheduler", FakeScheduler)
+    assert "at least 2" in decoded(server.compare(["one"], ["test"]))["error"]
+    assert "same length" in decoded(server.compare(["one", "two"], ["test"]))["error"]
+
+    FakeScheduler.initialized = True
+    FakeScheduler.response = SimpleNamespace(
+        success=True, results={"winner": 0}, errors=[]
+    )
+    result = decoded(
+        server.compare(
+            ["one.hip", "two.hip"],
+            ["./one", "./two"],
+            performance_backend="rocprof_compute",
+            correctness_backend="accordo",
+            accordo_kernel_name="kernel",
+        )
+    )
+    assert result["winner"] == 0
+    assert len(result["kernel_configs"]) == 2
+
+    FakeScheduler.response = SimpleNamespace(
+        success=True,
+        results=SimpleNamespace(to_dict=lambda: {"winner": 1}),
+        errors=[],
+    )
+    assert decoded(server.compare(["one", "two"], ["a", "b"]))["winner"] == 1
+    FakeScheduler.response = SimpleNamespace(success=True, results="plain", errors=[])
+    assert decoded(server.compare(["one", "two"], ["a", "b"]))["result"] == "plain"
+    FakeScheduler.response = SimpleNamespace(
+        success=False, results=None, errors=["bad"]
+    )
+    assert (
+        decoded(server.compare(["one", "two"], ["a", "b"]))["error"]
+        == "Comparison failed"
+    )
+    FakeScheduler.initialized = False
+    assert (
+        decoded(server.compare(["one", "two"], ["a", "b"]))["error"]
+        == "Failed to initialize scheduler"
+    )
+
+
+def test_configure_gpu_reset_config_and_validation(monkeypatch):
+    class Controller:
+        def __init__(self, device_ids=None):
+            self.device_ids = device_ids
+
+        def reset_all(self):
+            return {0: True}
+
+        def apply_config(self, config):
+            return {0: True, 1: False}
+
+    monkeypatch.setattr("Magpie.utils.MultiGPUController", Controller)
+    assert decoded(server.configure_gpu(reset=True))["action"] == "reset"
+    result = decoded(
+        server.configure_gpu(
+            [0, 1],
+            power_limit_watts=300,
+            gpu_clock_mhz=[1000, 1500],
+            mem_clock_mhz=[800, 1000],
+        )
+    )
+    assert result["action"] == "configure"
+    assert result["config"]["power_limit_watts"] == 300
+    assert "must be" in decoded(server.configure_gpu(gpu_clock_mhz=[1]))["error"]
+    assert "must be" in decoded(server.configure_gpu(mem_clock_mhz=[1]))["error"]
+
+
+def test_benchmark_tool_local_ray_and_error(monkeypatch, tmp_path):
+    created = []
+
+    class Benchmarker:
+        def __init__(self, config, output_dir):
+            self.config = config
+            self.output_dir = output_dir
+            created.append(self)
+
+        def run(self):
+            return SimpleNamespace(
+                to_dict=lambda: {"success": True},
+                get_summary=lambda: "complete",
+            )
+
+        def cleanup(self):
+            self.cleaned = True
+
+    monkeypatch.setattr("Magpie.modes.benchmark.BenchmarkMode", Benchmarker)
+    result = decoded(
+        asyncio.run(
+            server.benchmark(
+                "vllm",
+                "demo",
+                run_mode="ray",
+                tp=4,
+                extra_envs={"CUSTOM": "yes"},
+                ray_num_nodes=2,
+                ray_total_num_gpus=8,
+                output_dir=str(tmp_path),
+            )
+        )
+    )
+    assert result["success"] is True
+    assert result["summary_text"] == "complete"
+    assert created[-1].config.ray_config.gpus_per_node == 4
+    assert created[-1].cleaned is True
+
+    class Broken(Benchmarker):
+        def run(self):
+            raise RuntimeError("benchmark failed")
+
+    monkeypatch.setattr("Magpie.modes.benchmark.BenchmarkMode", Broken)
+    result = decoded(asyncio.run(server.benchmark("vllm", "demo")))
+    assert result["error"] == "benchmark failed"
+
+
+def test_gap_analysis_tool_success_empty_missing_and_error(monkeypatch, tmp_path):
+    traces = tmp_path / "run" / "torch_trace"
+    traces.mkdir(parents=True)
+
+    class Result:
+        rank_results = [{}, {}]
+        total_duration_us = 10
+        merged_kernels = ["kernel"]
+        errors = []
+
+        def to_dict(self):
+            return {"top_kernels": [{"name": "gemm"}]}
+
+        def to_csv(self, path):
+            path.write_text("csv")
+            return path
+
+        def to_rank_csv(self, directory):
+            return [directory / "rank0.csv"]
+
+    class Analyzer:
+        def __init__(self, config):
+            self.config = config
+
+        def analyze(self, path):
+            return Result()
+
+        def generate_clamped_traces(self, path, output_dir):
+            return [output_dir / "clamped.json"]
+
+    monkeypatch.setattr("Magpie.modes.benchmark.gap_analysis.GapAnalyzer", Analyzer)
+    result = decoded(
+        server.gap_analysis(str(tmp_path / "run"), generate_clamped_traces=True)
+    )
+    assert result["num_ranks"] == 2
+    assert result["top_kernels"][0]["name"] == "gemm"
+    assert result["rank_csv_files"]
+    assert result["clamped_trace_files"]
+    assert (
+        "not found" in decoded(server.gap_analysis(str(tmp_path / "missing")))["error"]
+    )
+
+    monkeypatch.setattr(
+        Analyzer,
+        "analyze",
+        lambda self, path: (_ for _ in ()).throw(RuntimeError("parse failed")),
+    )
+    assert decoded(server.gap_analysis(str(traces)))["error"] == "parse failed"
+
+
+def test_list_images_success_unknown_and_error(monkeypatch):
+    class Selector:
+        def list_available_images(self, framework=None):
+            return {"vllm": {"gfx942": "image", "odd": "other"}}
+
+        def get_runner_type(self, arch):
+            if arch == "odd":
+                raise ValueError("unknown")
+            return "mi300x"
+
+    monkeypatch.setattr("Magpie.modes.benchmark.ImageSelector", Selector)
+    result = decoded(server.list_benchmark_images("vllm"))
+    assert result["details"]["vllm"]["gfx942"]["runner_type"] == "mi300x"
+    assert result["details"]["vllm"]["odd"]["runner_type"] == "unknown"
+    monkeypatch.setattr(
+        Selector,
+        "list_available_images",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("missing config")),
+    )
+    assert decoded(server.list_benchmark_images())["error"] == "missing config"
+
+
+def test_list_and_get_benchmark_results(monkeypatch, tmp_path):
+    workspace = tmp_path / "benchmark_vllm_20260101"
+    (workspace / "torch_trace").mkdir(parents=True)
+    (workspace / "torch_trace" / "trace.json").write_text("{}")
+    (workspace / "tracelens_rank0_csvs").mkdir()
+    (workspace / "tracelens_rank0_csvs" / "summary.csv").write_text("csv")
+    (workspace / "config.yaml").write_text("model: demo\n")
+    report = {
+        "success": True,
+        "framework": "vllm",
+        "model": "demo",
+        "execution_time": 2,
+        "throughput": {"request_throughput": 3},
+        "latency": {"ttft_mean": 4},
+        "top_bottlenecks": ["a", "b"],
+        "kernel_summary": [{"name": "gemm"}],
+        "errors": [],
+    }
+    (workspace / "benchmark_report.json").write_text(json.dumps(report))
+    (workspace / "inferencex_result.json").write_text('{"raw": true}')
+    (workspace / "summary.txt").write_text("complete")
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.WorkspaceManager.list_workspaces",
+        lambda base_dir: [str(workspace)],
+    )
+    listed = decoded(server.list_benchmark_results(str(tmp_path)))
+    assert listed["runs"][0]["has_torch_trace"] is True
+    assert listed["runs"][0]["has_tracelens"] is True
+    detailed = decoded(
+        server.get_benchmark_result(
+            str(workspace), include_raw_result=True, include_tracelens_files=True
+        )
+    )
+    assert detailed["raw_inferencex_result"] == {"raw": True}
+    assert detailed["tracelens_files"]["rank0_csvs"]
+    assert detailed["torch_trace_files"]
+    assert (
+        "not found"
+        in decoded(server.get_benchmark_result(str(tmp_path / "missing")))["error"]
+    )
+
+
+def test_list_results_handles_invalid_and_outer_error(monkeypatch, tmp_path):
+    workspace = tmp_path / "benchmark_atom_date"
+    workspace.mkdir()
+    (workspace / "config.yaml").write_text("{")
+    (workspace / "benchmark_report.json").write_text("{")
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.WorkspaceManager.list_workspaces",
+        lambda base_dir: [str(workspace)],
+    )
+    entry = decoded(server.list_benchmark_results(str(tmp_path)))["runs"][0]
+    assert entry["config"] is None
+    assert entry["report_error"]
+    monkeypatch.setattr(
+        "Magpie.modes.benchmark.WorkspaceManager.list_workspaces",
+        lambda base_dir: (_ for _ in ()).throw(RuntimeError("scan failed")),
+    )
+    assert (
+        decoded(server.list_benchmark_results(str(tmp_path)))["error"] == "scan failed"
+    )
+
+
+def test_compare_benchmark_reports_success_validation_and_error(monkeypatch, tmp_path):
+    workspaces = []
+    for name in ("baseline", "optimized"):
+        workspace = tmp_path / name
+        (workspace / "tracelens_rank0_csvs").mkdir(parents=True)
+        (workspace / "benchmark_report.json").write_text(
+            json.dumps(
+                {"framework": "vllm", "model": name, "throughput": {}, "latency": {}}
+            )
+        )
+        workspaces.append(str(workspace))
+
+    class Analyzer:
+        def __init__(self, config):
+            self.config = config
+
+        def compare_reports(self, **kwargs):
+            return {"files": ["comparison.csv"], "error": None}
+
+    monkeypatch.setattr("Magpie.modes.benchmark.tracelens.TraceLensAnalyzer", Analyzer)
+    result = decoded(
+        server.compare_benchmark_reports(
+            workspaces, ["before", "after"], str(tmp_path / "out")
+        )
+    )
+    assert result["success"] is True
+    assert len(result["run_summaries"]) == 2
+    assert (
+        "At least 2"
+        in decoded(server.compare_benchmark_reports(workspaces[:1]))["error"]
+    )
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert (
+        "No TraceLens"
+        in decoded(server.compare_benchmark_reports([workspaces[0], str(empty)]))[
+            "error"
+        ]
+    )
+    monkeypatch.setattr(
+        Analyzer,
+        "compare_reports",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("compare failed")),
+    )
+    assert (
+        decoded(server.compare_benchmark_reports(workspaces))["error"]
+        == "compare failed"
+    )
+
+
+class FakeRayExecutor:
+    def __init__(self):
+        self.running = True
+        self.stopped = False
+
+    def is_running(self):
+        return self.running
+
+    def stop(self):
+        self.stopped = True
+
+    def get_task_status_ray(self, task_id):
+        return "SUCCEEDED"
+
+    def get_task_result(self, task_id):
+        return {"success": True} if task_id == "done" else None
+
+    def cancel_task(self, task_id):
+        return task_id == "running"
+
+    def list_tasks(self):
+        return {"done": "SUCCEEDED", "running": "RUNNING"}
+
+
+def test_ray_task_tools_success_and_errors(monkeypatch):
+    executor = FakeRayExecutor()
+    monkeypatch.setattr(server, "_get_ray_executor", lambda *args: executor)
+    assert decoded(server.ray_task_status("done"))["status"] == "SUCCEEDED"
+    assert decoded(server.ray_task_result("done"))["_task_id"] == "done"
+    assert decoded(server.ray_task_result("waiting"))["status"] == "SUCCEEDED"
+    assert decoded(server.ray_task_cancel("running"))["cancelled"] is True
+    assert decoded(server.ray_task_cancel("done"))["cancelled"] is False
+    assert decoded(server.ray_task_list())["total"] == 2
+
+    monkeypatch.setattr(
+        server,
+        "_get_ray_executor",
+        lambda *args: (_ for _ in ()).throw(RuntimeError("ray down")),
+    )
+    assert decoded(server.ray_task_status("x"))["error"] == "ray down"
+    assert decoded(server.ray_task_result("x"))["error"] == "ray down"
+    assert decoded(server.ray_task_cancel("x"))["error"] == "ray down"
+    assert decoded(server.ray_task_list())["error"] == "ray down"
+
+
+def test_ray_executor_cache_and_replacement(monkeypatch):
+    current = FakeRayExecutor()
+    server._ray_executor_instance = current
+    server._ray_executor_key = ("auto", "/shared")
+    assert server._get_ray_executor("auto", "/shared") is current
+
+    created = []
+
+    class NewExecutor(FakeRayExecutor):
+        def __init__(self, config, ray_config):
+            super().__init__()
+            created.append((config, ray_config))
+
+        def start(self):
+            self.started = True
+
+    monkeypatch.setattr("Magpie.core.ray_executor.RayJobExecutor", NewExecutor)
+    replacement = server._get_ray_executor("ray://host", "/new")
+    assert current.stopped is True
+    assert replacement.started is True
+    assert created[-1][1].cluster_address == "ray://host"
+
+
+def test_benchmark_batch_parallel_sequential_empty_and_item_errors(monkeypatch):
+    class Mode:
+        calls = 0
+
+        def __init__(self, config, output_dir):
+            self.config = config
+
+        def submit_ray_benchmark(self, executor):
+            self.__class__.calls += 1
+            if self.config.model == "bad":
+                return SimpleNamespace(
+                    success=False, errors=["submit failed"], metadata={}
+                )
+            return SimpleNamespace(
+                success=True, errors=[], metadata={"task_id": "task-1"}
+            )
+
+        def run(self):
+            if self.config.model == "explode":
+                raise RuntimeError("run failed")
+            return SimpleNamespace(
+                metadata={"ray_job_id": "job-1"}, workspace_dir="/results"
+            )
+
+    monkeypatch.setattr("Magpie.modes.benchmark.BenchmarkMode", Mode)
+    monkeypatch.setattr(server, "_get_ray_executor", lambda *args: FakeRayExecutor())
+    assert (
+        decoded(asyncio.run(server.benchmark_batch([])))["error"]
+        == "configs list is empty"
+    )
+    configs = [
+        {"framework": "vllm", "model": "demo"},
+        {"framework": "vllm", "model": "bad"},
+    ]
+    parallel = decoded(asyncio.run(server.benchmark_batch(configs, parallel=True)))
+    assert parallel["submitted"] == 1
+    assert parallel["failed"] == 1
+    sequential = decoded(
+        asyncio.run(
+            server.benchmark_batch(
+                [configs[0], {"framework": "vllm", "model": "explode"}],
+                parallel=False,
+            )
+        )
+    )
+    assert sequential["submitted"] == 1
+    assert sequential["failed"] == 1

--- a/tests/unit/modes/test_analysis_compare_monitor.py
+++ b/tests/unit/modes/test_analysis_compare_monitor.py
@@ -1,0 +1,219 @@
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from Magpie.config import KernelEvalConfig, KernelType
+from Magpie.eval import BaseKind, EvaluationState
+from Magpie.eval.correctness import CorrectnessResult
+from Magpie.eval.performance import KernelMetrics, MetricResult, PerformanceResult
+from Magpie.modes.analyze_eval.analyzer import AnalyzeConfig, AnalyzeMode
+from Magpie.modes.compare_eval.comparator import CompareConfig, CompareMode
+from Magpie.utils.gpu_monitor import GPUMonitor, GPUMonitorStats, GPUSample
+
+
+def successful_state(metric=80, duration=10):
+    return EvaluationState(
+        correctness_state=BaseKind.SUCCESS,
+        correctness_result=CorrectnessResult(True),
+        performance_state=BaseKind.SUCCESS,
+        performance_result=PerformanceResult(
+            True,
+            metrics=[MetricResult("util", metric, "%", pct_of_peak=metric)],
+            kernel_metrics=[KernelMetrics("gemm", 0, duration_ns=duration)],
+        ),
+        score=1,
+    )
+
+
+def test_analyze_mode_validation_config_and_batch(monkeypatch, kernel_config):
+    monkeypatch.setattr("Magpie.utils.detect_gpu", lambda: ("amd", "gfx942"))
+    config = AnalyzeConfig(
+        gpu_arch=None,
+        rocprof_config={"metric_blocks": ["1"]},
+        ncu_config={"metrics": ["cycles"]},
+        metrix_config={"backend": "metrix", "profile": "quick"},
+        correctness_config={"backend": "testcase"},
+    )
+    assert config.gpu_arch == "gfx942"
+    mode = AnalyzeMode(config)
+    assert "requires testcase" in mode.analyze(KernelEvalConfig()).errors[0]
+    seen = []
+
+    class FakeEvaluator:
+        def __init__(self, pipeline):
+            seen.append(pipeline)
+
+        def evaluate(self, kernel):
+            return successful_state()
+
+    monkeypatch.setattr("Magpie.modes.analyze_eval.analyzer.Evaluator", FakeEvaluator)
+    result = mode.analyze(kernel_config)
+    assert result.score == 1
+    assert seen[0].performance_config.get_backend().name == "METRIX"
+    assert mode.analyze_batch([]) == []
+    assert len(mode.analyze_batch([kernel_config, kernel_config])) == 2
+
+
+def test_compare_mode_evaluation_scoring_and_summary(monkeypatch, kernel_config):
+    configs = [
+        kernel_config,
+        KernelEvalConfig(**{**kernel_config.__dict__, "kernel_id": "two"}),
+    ]
+    states = [successful_state(80, 10), successful_state(40, 20)]
+
+    class FakeEvaluator:
+        def __init__(self, _pipeline):
+            pass
+
+        def evaluate(self, _kernel):
+            return states.pop(0)
+
+    config = CompareConfig(
+        gpu_arch="gfx942",
+        perf_weights_rocprof={"util": 0.5, "duration_ns_total": 0.5},
+        rocprof_config={"metric_blocks": ["1"]},
+        ncu_config={"metrics": ["cycles"]},
+        metrix_config={"profile": "quick"},
+    )
+    mode = CompareMode(config)
+    monkeypatch.setattr("Magpie.modes.compare_eval.comparator.Evaluator", FakeEvaluator)
+    comparison = mode.compare(configs)
+    assert comparison.winner == 0
+    assert comparison.rankings[0][0] == 0
+    assert "Correctness: 2/2 passed" in comparison.summary
+    assert comparison.to_dict()["winner"] == 0
+    with pytest.raises(ValueError, match="at least 2"):
+        mode.compare([kernel_config])
+
+
+def test_compare_weights_values_and_fallbacks(kernel_config):
+    config = CompareConfig(
+        gpu_arch="sm_90",
+        perf_weights_ncu={"util": 1},
+        perf_weights_rocprof={"duration_ns_total": 1},
+        perf_weights_metrix={"L2": 1},
+        metrix_config={"backend": "metrix"},
+    )
+    mode = CompareMode(config)
+    assert mode._get_perf_weights(KernelType.HIP) == {"L2": 1}
+    config.metrix_config = {}
+    assert mode._get_perf_weights(KernelType.CUDA) == {"util": 1}
+    state = successful_state(75, 12)
+    assert mode._get_perf_value(state, "util") == 75
+    assert mode._get_perf_value(state, "duration_ns_total") == 12
+    assert mode._get_perf_value(state, "missing") is None
+    assert mode._get_perf_value(EvaluationState(), "util") is None
+
+    failed = EvaluationState(
+        correctness_state=BaseKind.FAILED,
+        correctness_result=CorrectnessResult(False),
+    )
+    scores = mode._compute_perf_scores([state, failed], [True, False], KernelType.CUDA)
+    assert scores == [1.0, None]
+    config.perf_weights_ncu = {}
+    config.perf_weights_rocprof = {}
+    assert mode._compute_perf_scores([state], [True], KernelType.HIP) == [None]
+
+
+def test_compare_correctness_first_fallback(kernel_config):
+    mode = CompareMode(
+        CompareConfig(gpu_arch="gfx942", winner_strategy="correctness_first")
+    )
+    states = [
+        EvaluationState(correctness_state=BaseKind.FAILED),
+        successful_state(),
+    ]
+    configs = [kernel_config, KernelEvalConfig(kernel_id="second")]
+    comparison = mode._build_comparison(states, configs)
+    assert comparison.winner == 1
+
+
+def test_gpu_monitor_vendor_detection_and_start(monkeypatch):
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[0] == "rocm-smi":
+            return subprocess.CompletedProcess(cmd, 0, stdout="GPU[0]")
+        return subprocess.CompletedProcess(cmd, 1, stdout="")
+
+    monkeypatch.setattr("Magpie.utils.gpu_monitor.subprocess.run", run)
+    monitor = GPUMonitor(interval_sec=0.1)
+    assert monitor.vendor == "amd"
+    assert monitor.interval == 0.5
+    monkeypatch.setattr(
+        "Magpie.utils.gpu_monitor.threading.Thread",
+        lambda **kwargs: SimpleNamespace(start=lambda: None, is_alive=lambda: False),
+    )
+    assert monitor.start() is True
+    assert monitor.start() is True
+    assert monitor.is_running is True
+    assert monitor.stop().sample_count == 0
+    assert GPUMonitor(vendor="unknown").start() is False
+
+
+def test_gpu_monitor_collects_amd_and_nvidia_samples(monkeypatch):
+    monitor = GPUMonitor(vendor="amd")
+    amd_output = (
+        "Temperature junction 55.5\n"
+        "sclk 1200 Mhz\n"
+        "mclk 900 Mhz\n"
+        "Current Graphics Power: 220.5\n"
+    )
+    monkeypatch.setattr(
+        "Magpie.utils.gpu_monitor.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=amd_output),
+    )
+    sample = monitor._collect_sample()
+    assert sample.temperature_c == 55.5
+    assert sample.gpu_clock_mhz == 1200
+    assert sample.mem_clock_mhz == 900
+    assert sample.power_watts == 220.5
+
+    monitor.vendor = "nvidia"
+    monkeypatch.setattr(
+        "Magpie.utils.gpu_monitor.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd, 0, stdout="60, 1500, 1000, 250\n"
+        ),
+    )
+    sample = monitor._collect_sample()
+    assert sample.temperature_c == 60
+    assert sample.power_watts == 250
+    monitor.vendor = "other"
+    assert monitor._collect_sample() is None
+
+
+@pytest.mark.parametrize("vendor", ["amd", "nvidia"])
+def test_gpu_monitor_command_failures(vendor, monkeypatch):
+    monitor = GPUMonitor(vendor=vendor)
+    monkeypatch.setattr(
+        "Magpie.utils.gpu_monitor.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 2, stdout=""),
+    )
+    assert monitor._collect_sample() is None
+    monkeypatch.setattr(
+        "Magpie.utils.gpu_monitor.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(subprocess.TimeoutExpired("gpu", 5)),
+    )
+    assert monitor._collect_sample() is None
+
+
+def test_gpu_monitor_statistics_and_properties():
+    monitor = GPUMonitor(vendor="amd")
+    monitor._start_time = 1
+    monitor._samples = [
+        GPUSample(2, 40, 1000, 800, 200),
+        GPUSample(3, 60, 1200, 1000, 240),
+    ]
+    stats = monitor._compute_stats()
+    assert stats.sample_count == 2
+    assert stats.duration_sec == 2
+    assert stats.temp_avg == 50
+    assert stats.gpu_clock_avg == 1100
+    assert stats.mem_clock_avg == 900
+    assert stats.power_avg == 220
+    assert stats.to_dict()["temperature_c"]["max"] == 60
+    assert monitor.sample_count == 2
+    assert GPUMonitorStats().to_dict()["sample_count"] == 0

--- a/tests/unit/modes/test_benchmarker.py
+++ b/tests/unit/modes/test_benchmarker.py
@@ -1,0 +1,922 @@
+import os
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from Magpie.modes.benchmark import benchmarker
+from Magpie.modes.benchmark.benchmarker import BenchmarkMode
+from Magpie.modes.benchmark.config import (
+    BenchmarkConfig,
+    GpuSelectionConfig,
+    ProfilerConfig,
+    GapAnalysisConfig,
+    RayConfig,
+    ServerLifecycleConfig,
+    TorchProfilerConfig,
+)
+from Magpie.modes.benchmark.result import (
+    BenchmarkResult,
+    KernelMetrics,
+    LatencyMetrics,
+    ThroughputMetrics,
+)
+from Magpie.utils.gpu import GPUVendor
+
+
+def make_config(tmp_path, **changes):
+    values = {
+        "framework": "vllm",
+        "model": "demo",
+        "run_mode": "local",
+        "runner_type": "mi300x",
+        "inferencex_path": str(tmp_path / "InferenceX"),
+        "profiler": ProfilerConfig(torch_profiler=TorchProfilerConfig(enabled=False)),
+    }
+    values.update(changes)
+    return BenchmarkConfig(**values)
+
+
+def successful_result():
+    return BenchmarkResult(
+        success=True,
+        throughput=ThroughputMetrics(request_throughput=2),
+        latency=LatencyMetrics(ttft_mean=3),
+    )
+
+
+def test_run_local_happy_path(monkeypatch, tmp_path):
+    config = make_config(tmp_path)
+    mode = BenchmarkMode(config, output_dir=str(tmp_path / "results"))
+    monkeypatch.setattr(benchmarker, "ensure_inferencex_available", lambda path: path)
+    monkeypatch.setattr(mode, "_apply_gpu_selection", lambda: None)
+    monkeypatch.setattr(mode, "_prepare_benchmark_scripts", lambda: None)
+    monkeypatch.setattr(
+        mode, "_get_benchmark_script", lambda runner: "benchmarks/run.sh"
+    )
+    monkeypatch.setattr(mode, "_cleanup_server_processes", lambda framework: None)
+
+    def execute(_cmd, _env, workspace):
+        (workspace / "inferencex_result.json").write_text("{}")
+        return successful_result(), "stdout", ""
+
+    monkeypatch.setattr(mode, "_execute_local_benchmark", execute)
+    monkeypatch.setattr(
+        benchmarker.ResultParser,
+        "parse_inferencex_result",
+        lambda *a, **k: successful_result(),
+    )
+    result = mode.run("local-task")
+    assert result.success is True
+    assert result.framework == "vllm"
+    assert result.workspace_dir
+    assert mode._task_id == "local-task"
+
+
+def test_run_docker_with_trace_analysis(monkeypatch, tmp_path):
+    profile = ProfilerConfig()
+    profile.tracelens.enabled = True
+    profile.tracelens.analysis_mode = "pytorch"
+    config = make_config(
+        tmp_path, run_mode="docker", docker_image="image:test", profiler=profile
+    )
+    mode = BenchmarkMode(config, output_dir=str(tmp_path / "results"))
+    monkeypatch.setattr(benchmarker, "ensure_inferencex_available", lambda path: path)
+    monkeypatch.setattr(mode, "_apply_gpu_selection", lambda: None)
+    monkeypatch.setattr(mode, "_prepare_benchmark_scripts", lambda: None)
+    monkeypatch.setattr(
+        mode, "_get_benchmark_script", lambda runner: "benchmarks/run.sh"
+    )
+    monkeypatch.setattr(mode, "_select_image", lambda: "image:test")
+    monkeypatch.setattr(mode, "_build_docker_command", lambda **kwargs: ["docker"])
+
+    def execute(_cmd, workspace):
+        (workspace / "inferencex_result.json").write_text("{}")
+        (workspace / "torch_trace" / "rank0.json.gz").write_text("trace")
+        return successful_result(), "", ""
+
+    monkeypatch.setattr(mode, "_execute_benchmark", execute)
+    monkeypatch.setattr(
+        benchmarker.ResultParser,
+        "parse_inferencex_result",
+        lambda *a, **k: successful_result(),
+    )
+    monkeypatch.setattr(
+        benchmarker.ResultParser,
+        "parse_torch_trace",
+        lambda path: [KernelMetrics("gemm", 1, 100, 1)],
+    )
+    monkeypatch.setattr(
+        mode, "_run_tracelens_analysis", lambda *args: {"enabled": True}
+    )
+    result = mode.run()
+    assert result.success is True
+    assert result.top_bottlenecks == ["gemm"]
+    assert result.tracelens_analysis == {"enabled": True}
+
+
+def inference_profile():
+    profile = ProfilerConfig()
+    profile.tracelens.enabled = True
+    profile.tracelens.analysis_mode = "inference"
+    profile.gpu_monitor.enabled = False
+    return profile
+
+
+def prepare_run_mode(monkeypatch, mode):
+    monkeypatch.setattr(benchmarker, "ensure_inferencex_available", lambda path: path)
+    monkeypatch.setattr(mode, "_apply_gpu_selection", lambda: None)
+    monkeypatch.setattr(mode, "_prepare_benchmark_scripts", lambda: None)
+    monkeypatch.setattr(
+        mode, "_get_benchmark_script", lambda runner: "benchmarks/run.sh"
+    )
+    monkeypatch.setattr(mode, "_select_image", lambda: "image:test")
+
+
+def test_run_tracelens_runtime_setup_failure(monkeypatch, tmp_path):
+    mode = BenchmarkMode(
+        make_config(
+            tmp_path,
+            run_mode="docker",
+            docker_image="image:test",
+            profiler=inference_profile(),
+        ),
+        output_dir=str(tmp_path / "results"),
+    )
+    prepare_run_mode(monkeypatch, mode)
+    monkeypatch.setattr(
+        benchmarker,
+        "prepare_tracelens_runtime_image",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("patch failed")),
+    )
+    result = mode.run()
+    assert result.success is False
+    assert "runtime image setup failed" in result.errors[0]
+    assert result.tracelens_analysis["runtime_error"] == "patch failed"
+
+
+def test_run_tracelens_preprocess_failure(monkeypatch, tmp_path):
+    mode = BenchmarkMode(
+        make_config(tmp_path, profiler=inference_profile()),
+        output_dir=str(tmp_path / "results"),
+    )
+    prepare_run_mode(monkeypatch, mode)
+
+    class Pipeline:
+        def __init__(self, config):
+            pass
+
+        def prepare(self, workspace, runtime=None):
+            raise RuntimeError("prepare failed")
+
+        def restore(self):
+            return {"warnings": ["restored partially"]}
+
+    monkeypatch.setattr(benchmarker, "TraceLensInferencePipeline", Pipeline)
+    result = mode.run()
+    assert result.success is False
+    assert "preprocess failed" in result.errors[0]
+    assert result.tracelens_analysis["restore"]["warnings"]
+
+
+def test_run_missing_result_collects_stderr_and_server_errors(monkeypatch, tmp_path):
+    mode = BenchmarkMode(make_config(tmp_path), output_dir=str(tmp_path / "results"))
+    prepare_run_mode(monkeypatch, mode)
+    monkeypatch.setattr(mode, "_cleanup_server_processes", lambda framework: None)
+
+    def execute(_cmd, _env, workspace):
+        (workspace / "server.log").write_text("ready\nRuntimeError: server crashed\n")
+        return successful_result(), "", "diagnostic"
+
+    monkeypatch.setattr(mode, "_execute_local_benchmark", execute)
+    result = mode.run()
+    assert result.success is False
+    assert any("not found" in error for error in result.errors)
+    assert any("diagnostic" in error for error in result.errors)
+    assert any("server.log errors" in error for error in result.errors)
+
+
+def test_run_inference_trace_gap_monitor_and_restore(monkeypatch, tmp_path):
+    profile = inference_profile()
+    profile.gpu_monitor.enabled = True
+    config = make_config(
+        tmp_path,
+        profiler=profile,
+        gap_analysis=GapAnalysisConfig(enabled=True),
+        envs={"HIP_VISIBLE_DEVICES": "3"},
+    )
+    mode = BenchmarkMode(config, output_dir=str(tmp_path / "results"))
+    prepare_run_mode(monkeypatch, mode)
+    monkeypatch.setattr(mode, "_cleanup_server_processes", lambda framework: None)
+
+    class Pipeline:
+        def __init__(self, config):
+            pass
+
+        def prepare(self, workspace, runtime=None):
+            return {"warnings": ["prepare warning"]}
+
+        def restore(self):
+            return {"warnings": ["restore warning"]}
+
+    class Monitor:
+        def __init__(self, **kwargs):
+            assert kwargs["device_id"] == 3
+
+        def start(self):
+            return True
+
+        def stop(self):
+            return SimpleNamespace(sample_count=2, to_dict=lambda: {"sample_count": 2})
+
+    monkeypatch.setattr(benchmarker, "TraceLensInferencePipeline", Pipeline)
+    monkeypatch.setattr(benchmarker, "GPUMonitor", Monitor)
+
+    def execute(_cmd, _env, workspace):
+        (workspace / "inferencex_result.json").write_text("{}")
+        (workspace / "torch_trace" / "rank0.json.gz").write_text("trace")
+        return successful_result(), "", ""
+
+    monkeypatch.setattr(mode, "_execute_local_benchmark", execute)
+    monkeypatch.setattr(
+        benchmarker.ResultParser,
+        "parse_inferencex_result",
+        lambda *a, **k: successful_result(),
+    )
+    monkeypatch.setattr(
+        benchmarker.ResultParser,
+        "parse_torch_trace",
+        lambda path: [KernelMetrics("gemm", 1, 100, 1)],
+    )
+    monkeypatch.setattr(
+        mode,
+        "_run_tracelens_inference_analysis",
+        lambda **kwargs: {"output_files": ["trace.csv"]},
+    )
+    monkeypatch.setattr(
+        mode, "_run_gap_analysis", lambda *args: {"top_kernels": [{"name": "gemm"}]}
+    )
+    result = mode.run()
+    assert result.success is True
+    assert result.gpu_monitor == {"sample_count": 2}
+    assert result.gap_analysis["top_kernels"] == [{"name": "gemm"}]
+    assert result.tracelens_analysis["preprocess"]["warnings"]
+    assert result.tracelens_analysis["restore"]["warnings"]
+
+
+@pytest.mark.parametrize("failure", ["inferencex", "gpu", "script"])
+def test_run_setup_failures(monkeypatch, tmp_path, failure):
+    mode = BenchmarkMode(make_config(tmp_path), output_dir=str(tmp_path / failure))
+    if failure == "inferencex":
+        monkeypatch.setattr(
+            benchmarker,
+            "ensure_inferencex_available",
+            lambda path: (_ for _ in ()).throw(RuntimeError("clone failed")),
+        )
+    else:
+        monkeypatch.setattr(
+            benchmarker, "ensure_inferencex_available", lambda path: path
+        )
+        if failure == "gpu":
+            monkeypatch.setattr(
+                mode,
+                "_apply_gpu_selection",
+                lambda: (_ for _ in ()).throw(RuntimeError("no gpu")),
+            )
+        else:
+            monkeypatch.setattr(mode, "_apply_gpu_selection", lambda: None)
+            monkeypatch.setattr(mode, "_prepare_benchmark_scripts", lambda: None)
+            monkeypatch.setattr(
+                mode,
+                "_get_benchmark_script",
+                lambda runner: (_ for _ in ()).throw(FileNotFoundError("missing")),
+            )
+    result = mode.run()
+    assert result.success is False
+    assert result.errors
+
+
+@pytest.mark.parametrize(
+    ("throughput", "latency", "expected"),
+    [
+        (ThroughputMetrics(request_throughput=1), None, True),
+        (ThroughputMetrics(output_throughput=1), None, True),
+        (ThroughputMetrics(completed_requests=1), None, True),
+        (None, LatencyMetrics(ttft_mean=1), True),
+        (None, LatencyMetrics(e2el_mean=1), True),
+        (ThroughputMetrics(), LatencyMetrics(), False),
+    ],
+)
+def test_validate_results(tmp_path, throughput, latency, expected):
+    mode = BenchmarkMode(make_config(tmp_path))
+    assert (
+        mode._validate_results(BenchmarkResult(throughput=throughput, latency=latency))
+        is expected
+    )
+
+
+def test_gpu_selection_amd_nvidia_and_skips(monkeypatch, tmp_path):
+    disabled = make_config(tmp_path, gpu_selection=GpuSelectionConfig(auto=False))
+    BenchmarkMode(disabled)._apply_gpu_selection()
+
+    manual = make_config(
+        tmp_path,
+        gpu_selection=GpuSelectionConfig(auto=True),
+        envs={"HIP_VISIBLE_DEVICES": "3"},
+    )
+    BenchmarkMode(manual)._apply_gpu_selection()
+    assert manual.envs == {"HIP_VISIBLE_DEVICES": "3"}
+
+    amd = make_config(
+        tmp_path, gpu_selection=GpuSelectionConfig(auto=True, count=2), envs={}
+    )
+    monkeypatch.setattr(benchmarker, "find_idle_gpus", lambda **kwargs: [2, 4])
+    monkeypatch.setattr(benchmarker, "detect_gpu", lambda: (GPUVendor.AMD, "gfx942"))
+    BenchmarkMode(amd)._apply_gpu_selection()
+    assert amd.envs["ROCR_VISIBLE_DEVICES"] == "2,4"
+    assert amd.envs["HIP_VISIBLE_DEVICES"] == "0,1"
+
+    nvidia = make_config(
+        tmp_path, gpu_selection=GpuSelectionConfig(auto=True), envs={"TP": "bad"}
+    )
+    monkeypatch.setattr(benchmarker, "find_idle_gpus", lambda **kwargs: [7])
+    monkeypatch.setattr(benchmarker, "detect_gpu", lambda: (GPUVendor.NVIDIA, "sm_90"))
+    BenchmarkMode(nvidia)._apply_gpu_selection()
+    assert nvidia.envs["CUDA_VISIBLE_DEVICES"] == "7"
+    assert nvidia.envs["CUDA_DEVICE_ORDER"] == "PCI_BUS_ID"
+
+
+def test_gpu_selection_errors(monkeypatch, tmp_path):
+    config = make_config(tmp_path, gpu_selection=GpuSelectionConfig(auto=True, count=2))
+    mode = BenchmarkMode(config)
+    monkeypatch.setattr(benchmarker, "find_idle_gpus", lambda **kwargs: [0])
+    with pytest.raises(RuntimeError, match="needed 2"):
+        mode._apply_gpu_selection()
+    monkeypatch.setattr(
+        benchmarker,
+        "find_idle_gpus",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("busy")),
+    )
+    with pytest.raises(RuntimeError, match="Free a GPU"):
+        mode._apply_gpu_selection()
+
+
+def test_build_commands_and_script_resolution(monkeypatch, tmp_path):
+    inferencex = tmp_path / "InferenceX"
+    benchmarks = inferencex / "benchmarks"
+    nested = benchmarks / "single_node"
+    nested.mkdir(parents=True)
+    native = nested / "gptoss_fp8_mi300x.sh"
+    native.write_text("#!/bin/bash")
+    config = make_config(tmp_path, inferencex_path=str(inferencex), envs={"TP": 2})
+    mode = BenchmarkMode(config)
+    mode._task_id = "task"
+    assert (
+        mode._get_benchmark_script("mi300x")
+        == "benchmarks/single_node/gptoss_fp8_mi300x.sh"
+    )
+    config.benchmark_script = native.name
+    assert mode._get_benchmark_script("mi300x").endswith(native.name)
+
+    monkeypatch.setattr(benchmarker, "detect_gpu", lambda: (GPUVendor.AMD, "gfx942"))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    docker = mode._build_docker_command("image:test", workspace, "mi300x")
+    assert "--device=/dev/kfd" in docker
+    assert docker[-1].startswith("cd /opt/InferenceX")
+
+    command, env = mode._build_local_command(
+        workspace, "mi300x", "server", workspace / "pid"
+    )
+    assert command[0] == "bash"
+    assert env["MAGPIE_RUN_PHASE"] == "server"
+    assert env["MAGPIE_SERVER_PID_FILE"].endswith("pid")
+
+
+def test_prepare_scripts_select_runner_and_docker_nvidia_mounts(monkeypatch, tmp_path):
+    inferencex = tmp_path / "InferenceX"
+    config = make_config(
+        tmp_path,
+        inferencex_path=str(inferencex),
+        docker_image="image:test",
+        hf_cache_path=str(tmp_path / "hf"),
+        model=str(tmp_path / "model"),
+        envs={"CUSTOM": "yes"},
+    )
+    (tmp_path / "hf").mkdir()
+    (tmp_path / "model").mkdir()
+    mode = BenchmarkMode(config)
+    mode._prepare_benchmark_scripts()
+    copied = list((inferencex / "benchmarks").glob("*.sh"))
+    assert copied
+    assert all(path.stat().st_mode & 0o111 for path in copied)
+    assert mode._get_runner_type() == "mi300x"
+    assert mode._select_image() == "image:test"
+
+    monkeypatch.setattr(benchmarker, "detect_gpu", lambda: (GPUVendor.NVIDIA, "sm_90"))
+    monkeypatch.setattr(
+        mode, "_get_benchmark_script", lambda runner: "benchmarks/run.sh"
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    command = mode._build_docker_command("image:test", workspace, "h100")
+    assert "--gpus" in command
+    assert any(str(tmp_path / "hf") in item for item in command)
+    assert any(str(tmp_path / "model") in item for item in command)
+    assert "-e" in command
+
+
+def test_fix_workspace_ownership_helper_and_error(monkeypatch, tmp_path):
+    mode = BenchmarkMode(make_config(tmp_path, docker_image="image:test"))
+    calls = []
+    monkeypatch.setattr(benchmarker.os, "getuid", lambda: 501)
+    monkeypatch.setattr(benchmarker.os, "getgid", lambda: 20)
+    monkeypatch.setattr(
+        benchmarker.subprocess, "run", lambda cmd, **kwargs: calls.append(cmd)
+    )
+    mode._fix_workspace_ownership(tmp_path)
+    assert calls[0][-2:] == ["501:20", "/workspace"]
+    monkeypatch.setattr(
+        benchmarker.subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("docker failed")),
+    )
+    mode._fix_workspace_ownership(tmp_path)
+
+
+def test_script_resolution_fallback_and_errors(tmp_path):
+    inferencex = tmp_path / "InferenceX"
+    benchmarks = inferencex / "benchmarks"
+    benchmarks.mkdir(parents=True)
+    generic = benchmarks / "vllm_mi300x.sh"
+    generic.write_text("#!/bin/bash")
+    config = make_config(tmp_path, inferencex_path=str(inferencex))
+    mode = BenchmarkMode(config)
+    assert mode._get_benchmark_script("mi300x") == "benchmarks/vllm_mi300x.sh"
+    generic.unlink()
+    with pytest.raises(FileNotFoundError, match="No benchmark script"):
+        mode._get_benchmark_script("mi300x")
+    config.benchmark_script = "missing.sh"
+    with pytest.raises(FileNotFoundError, match="Specified benchmark_script"):
+        mode._get_benchmark_script("mi300x")
+
+
+@pytest.mark.parametrize("behavior", ["success", "failed", "timeout", "exception"])
+def test_execute_benchmark_paths(monkeypatch, tmp_path, behavior):
+    mode = BenchmarkMode(make_config(tmp_path, docker_image="image:test"))
+    mode._task_id = "task"
+    monkeypatch.setattr(mode, "_fix_workspace_ownership", lambda workspace: None)
+    if behavior == "success":
+        runner = lambda *a, **k: subprocess.CompletedProcess(a[0], 0, "out", "")
+    elif behavior == "failed":
+        runner = lambda *a, **k: subprocess.CompletedProcess(a[0], 2, "", "bad")
+    elif behavior == "timeout":
+        runner = lambda *a, **k: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(a[0], 1, output=b"partial", stderr=b"late")
+        )
+    else:
+        runner = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
+    monkeypatch.setattr(benchmarker.subprocess, "run", runner)
+    result, stdout, stderr = mode._execute_benchmark(["docker"], tmp_path)
+    assert result.success is (behavior == "success")
+    if behavior != "success":
+        assert result.errors
+
+
+def test_logs_cleanup_and_symlink_helpers(monkeypatch, tmp_path):
+    mode = BenchmarkMode(make_config(tmp_path))
+    mode._save_logs(tmp_path, "out", "err")
+    assert (tmp_path / "benchmark_stdout.log").read_text() == "out"
+    assert (tmp_path / "benchmark_stderr.log").read_text() == "err"
+    assert mode._create_workspace_symlink(tmp_path) is None
+    BenchmarkMode._remove_workspace_symlink(None)
+    link = tmp_path / "link"
+    link.symlink_to(tmp_path / "target")
+    BenchmarkMode._remove_workspace_symlink(link)
+    assert not link.exists()
+
+    monkeypatch.setattr(benchmarker.os, "getuid", lambda: 0)
+    mode._fix_workspace_ownership(tmp_path)
+
+
+def lifecycle_mode(tmp_path, **lifecycle_changes):
+    lifecycle = ServerLifecycleConfig(
+        enabled=True,
+        pid_dir=str(tmp_path / "pids"),
+        **lifecycle_changes,
+    )
+    config = make_config(
+        tmp_path,
+        envs={"PORT": "9000", "TP": 2, "EXTRA_VLLM_ARGS": "--fast"},
+        server_lifecycle=lifecycle,
+    )
+    return BenchmarkMode(config)
+
+
+def test_reuse_metadata_ports_paths_and_health(monkeypatch, tmp_path):
+    mode = lifecycle_mode(tmp_path)
+    assert mode._reuse_benchmark_port() == 9000
+    mode.config.envs["PORT"] = "invalid"
+    assert mode._reuse_benchmark_port() == 8888
+    desired = mode._desired_reuse_server_meta(8888)
+    assert desired["framework"] == "vllm"
+    assert desired["tp"] == "2"
+    assert mode._reuse_meta_mismatch(None, desired)
+    assert mode._reuse_meta_mismatch(desired, desired) is None
+    changed = dict(desired, model="other")
+    assert "model" in mode._reuse_meta_mismatch(changed, desired)
+
+    directory, pid_file, meta_file = mode._reuse_server_paths(8888)
+    assert directory.is_dir()
+    assert pid_file.name == "vllm_8888.pid"
+    mode._reuse_write_meta(meta_file, desired)
+    assert mode._reuse_read_meta(meta_file) == desired
+    meta_file.write_text("[]")
+    assert mode._reuse_read_meta(meta_file) is None
+    meta_file.write_text("{")
+    assert mode._reuse_read_meta(meta_file) is None
+
+    class Response:
+        status = 204
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+    response = Response()
+    monkeypatch.setattr(benchmarker.urllib.request, "urlopen", lambda *a, **k: response)
+    assert mode._reuse_http_healthy(9000) is True
+    monkeypatch.setattr(
+        benchmarker.urllib.request,
+        "urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(
+            benchmarker.urllib.error.URLError("down")
+        ),
+    )
+    assert mode._reuse_http_healthy(9000) is False
+
+
+def test_reuse_attach_decisions_and_wait(monkeypatch, tmp_path):
+    mode = lifecycle_mode(tmp_path)
+    desired = mode._desired_reuse_server_meta(9000)
+    _, _, meta_file = mode._reuse_server_paths(9000)
+    mode._reuse_write_meta(meta_file, desired)
+    monkeypatch.setattr(mode, "_reuse_http_healthy", lambda port: True)
+    assert mode._reuse_will_attach_to_existing_server() is True
+    mode.config.server_lifecycle.force_reuse = True
+    meta_file.write_text("{")
+    assert mode._reuse_will_attach_to_existing_server() is True
+    monkeypatch.setattr(mode, "_reuse_http_healthy", lambda port: False)
+    assert mode._reuse_will_attach_to_existing_server() is False
+
+    times = iter([0, 1])
+    monkeypatch.setattr(benchmarker.time, "time", lambda: next(times))
+    monkeypatch.setattr(mode, "_reuse_http_healthy", lambda port: True)
+    assert mode._reuse_wait_health(9000, 2) is True
+
+
+def test_reuse_existing_server_client_and_cleanup(monkeypatch, tmp_path):
+    mode = lifecycle_mode(tmp_path, cleanup=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(
+        mode, "_get_benchmark_script", lambda runner: "benchmarks/vllm_mi300x.sh"
+    )
+    monkeypatch.setattr(mode, "_reuse_http_healthy", lambda port: True)
+    monkeypatch.setattr(mode, "_reuse_meta_mismatch", lambda stored, desired: None)
+    _, pid_file, meta_file = mode._reuse_server_paths(9000)
+    pid_file.write_text("123")
+    mode._reuse_write_meta(meta_file, {"server_pid": 123})
+    monkeypatch.setattr(
+        mode, "_build_local_command", lambda **kwargs: ([kwargs["phase"]], {})
+    )
+    monkeypatch.setattr(
+        mode,
+        "_execute_local_benchmark",
+        lambda *a, **k: (successful_result(), "client out", "client err"),
+    )
+    terminated = []
+    monkeypatch.setattr(
+        mode, "_reuse_terminate_persistent_server", lambda pid: terminated.append(pid)
+    )
+    monkeypatch.setattr(mode, "_cleanup_server_processes", lambda framework: None)
+    result, stdout, stderr = mode._execute_local_benchmark_with_reuse(
+        workspace, "mi300x"
+    )
+    assert result.success is True
+    assert "Using existing" in stdout
+    assert "client err" in stderr
+    assert terminated == [123]
+    assert not pid_file.exists()
+    assert not meta_file.exists()
+
+
+def test_reuse_existing_server_mismatch_and_non_builtin(monkeypatch, tmp_path):
+    mode = lifecycle_mode(tmp_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(
+        mode, "_get_benchmark_script", lambda runner: "benchmarks/custom.sh"
+    )
+    result, _, _ = mode._execute_local_benchmark_with_reuse(workspace, "mi300x")
+    assert "built-in" in result.errors[0]
+
+    monkeypatch.setattr(
+        mode, "_get_benchmark_script", lambda runner: "benchmarks/vllm_mi300x.sh"
+    )
+    monkeypatch.setattr(mode, "_reuse_http_healthy", lambda port: True)
+    monkeypatch.setattr(
+        mode, "_reuse_meta_mismatch", lambda stored, desired: "model differs"
+    )
+    result, _, _ = mode._execute_local_benchmark_with_reuse(workspace, "mi300x")
+    assert "metadata mismatch" in result.errors[0]
+
+
+def test_reuse_spawns_server_then_runs_client(monkeypatch, tmp_path):
+    mode = lifecycle_mode(tmp_path, cleanup=False)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(
+        mode, "_get_benchmark_script", lambda runner: "benchmarks/vllm_mi300x.sh"
+    )
+    monkeypatch.setattr(mode, "_reuse_http_healthy", lambda port: False)
+    monkeypatch.setattr(mode, "_reuse_clear_stale_artifacts", lambda *args: None)
+
+    def build(**kwargs):
+        if kwargs["phase"] == "server":
+            kwargs["server_pid_file"].write_text("321")
+        return [kwargs["phase"]], {}
+
+    monkeypatch.setattr(mode, "_build_local_command", build)
+    monkeypatch.setattr(
+        benchmarker.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 0, "server out", ""),
+    )
+    monkeypatch.setattr(mode, "_reuse_wait_health", lambda port, deadline: True)
+    monkeypatch.setattr(
+        mode,
+        "_execute_local_benchmark",
+        lambda *a, **k: (successful_result(), "client out", ""),
+    )
+    result, stdout, _ = mode._execute_local_benchmark_with_reuse(workspace, "mi300x")
+    assert result.success is True
+    assert "Spawned persistent server PID 321" in stdout
+    _, pid_file, meta_file = mode._reuse_server_paths(9000)
+    assert pid_file.read_text().strip() == "321"
+    assert mode._reuse_read_meta(meta_file)["server_pid"] == 321
+
+
+@pytest.mark.parametrize("behavior", ["success", "failure", "timeout", "exception"])
+def test_execute_local_benchmark_paths(monkeypatch, tmp_path, behavior):
+    mode = BenchmarkMode(make_config(tmp_path))
+    if behavior == "success":
+        runner = lambda *a, **k: subprocess.CompletedProcess(a[0], 0, "out", "")
+    elif behavior == "failure":
+        runner = lambda *a, **k: subprocess.CompletedProcess(a[0], 3, "", "bad")
+    elif behavior == "timeout":
+        runner = lambda *a, **k: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(a[0], 1, output=b"partial", stderr=b"late")
+        )
+    else:
+        runner = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
+    monkeypatch.setattr(benchmarker.subprocess, "run", runner)
+    result, stdout, stderr = mode._execute_local_benchmark(["run"], {}, tmp_path)
+    assert result.success is (behavior == "success")
+    if behavior != "success":
+        assert result.errors
+
+
+def test_clear_stale_artifacts(monkeypatch, tmp_path):
+    mode = lifecycle_mode(tmp_path)
+    _, pid_file, meta_file = mode._reuse_server_paths(9000)
+    pid_file.write_text("123 extra")
+    meta_file.write_text("{}")
+    terminated = []
+    monkeypatch.setattr(
+        mode, "_reuse_terminate_persistent_server", lambda pid: terminated.append(pid)
+    )
+    monkeypatch.setattr(mode, "_cleanup_server_processes", lambda framework: None)
+    mode._reuse_clear_stale_artifacts(pid_file, meta_file, 9000)
+    assert terminated == [123]
+    assert not pid_file.exists() and not meta_file.exists()
+
+
+def test_postprocessing_helpers_success_and_errors(monkeypatch, tmp_path):
+    config = make_config(
+        tmp_path,
+        envs={"TP": 2},
+        gap_analysis=GapAnalysisConfig(enabled=True),
+    )
+    mode = BenchmarkMode(config)
+
+    class TraceAnalyzer:
+        def __init__(self, config):
+            pass
+
+        def analyze(self, **kwargs):
+            return {"output_files": ["report.csv"], "errors": ["warning"]}
+
+    monkeypatch.setattr(benchmarker, "TraceLensAnalyzer", TraceAnalyzer)
+    assert mode._run_tracelens_analysis(tmp_path, tmp_path)["output_files"]
+    monkeypatch.setattr(
+        TraceAnalyzer,
+        "analyze",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("trace failed")),
+    )
+    assert mode._run_tracelens_analysis(tmp_path, tmp_path)["error"] == "trace failed"
+
+    pipeline = SimpleNamespace(
+        analyze=lambda **kwargs: {
+            "output_files": ["host.csv"],
+            "warnings": ["warn"],
+            "errors": [],
+        },
+        analyze_in_container=lambda **kwargs: {
+            "output_files": ["docker.csv"],
+            "warnings": [],
+            "errors": ["partial"],
+        },
+    )
+    assert mode._run_tracelens_inference_analysis(
+        tmp_path, tmp_path, "mi300x", pipeline
+    )["output_files"] == ["host.csv"]
+    mode.config.run_mode = "docker"
+    mode.config.docker_image = "image:test"
+    assert mode._run_tracelens_inference_analysis(
+        tmp_path, tmp_path, "mi300x", pipeline
+    )["output_files"] == ["docker.csv"]
+    pipeline.analyze_in_container = lambda **kwargs: (_ for _ in ()).throw(
+        RuntimeError("inference failed")
+    )
+    assert (
+        mode._run_tracelens_inference_analysis(tmp_path, tmp_path, "mi300x", pipeline)[
+            "error"
+        ]
+        == "inference failed"
+    )
+
+
+def test_gap_postprocessing_success_and_error(monkeypatch, tmp_path):
+    mode = BenchmarkMode(
+        make_config(tmp_path, gap_analysis=GapAnalysisConfig(enabled=True))
+    )
+
+    class Result:
+        rank_results = [{}, {}]
+        merged_kernels = ["gemm"]
+        errors = ["warning"]
+
+        def to_csv(self, path, **kwargs):
+            path.write_text("csv")
+
+        def to_rank_csv(self, directory):
+            return [directory / "rank0.csv"]
+
+        def to_dict(self):
+            return {"top_kernels": [{"name": "gemm"}]}
+
+    class Analyzer:
+        def __init__(self, config):
+            pass
+
+        def analyze(self, path):
+            return Result()
+
+    monkeypatch.setattr("Magpie.modes.benchmark.gap_analysis.GapAnalyzer", Analyzer)
+    result = mode._run_gap_analysis(tmp_path, tmp_path)
+    assert result["top_kernels"][0]["name"] == "gemm"
+    assert (tmp_path / "gap_analysis" / "gap_analysis.csv").exists()
+    monkeypatch.setattr(
+        Analyzer,
+        "analyze",
+        lambda self, path: (_ for _ in ()).throw(RuntimeError("gap failed")),
+    )
+    assert mode._run_gap_analysis(tmp_path, tmp_path)["error"] == "gap failed"
+
+
+def test_ray_task_build_submit_and_population(monkeypatch, tmp_path):
+    local = BenchmarkMode(make_config(tmp_path))
+    result = local.submit_ray_benchmark(SimpleNamespace())
+    assert result.success is False
+    assert "run_mode='ray'" in result.errors[0]
+
+    ray_config = make_config(
+        tmp_path,
+        run_mode="ray",
+        ray_config=RayConfig(
+            cluster_address="ray://host", shared_storage_path="/shared"
+        ),
+    )
+    mode = BenchmarkMode(ray_config)
+    task, error = mode._build_ray_benchmark_task()
+    assert error is None
+    assert task.task_id == mode._task_id
+    executor = SimpleNamespace(submit=lambda task: "task-remote")
+    submitted = mode.submit_ray_benchmark(executor)
+    assert submitted.success is True
+    assert submitted.metadata["task_id"] == "task-remote"
+    failed = mode.submit_ray_benchmark(
+        SimpleNamespace(
+            submit=lambda task: (_ for _ in ()).throw(RuntimeError("submit failed"))
+        )
+    )
+    assert failed.success is False
+
+    result = BenchmarkResult()
+    mode._populate_result_from_ray(
+        result,
+        {
+            "workspace_dir": "/results/run",
+            "throughput": {"request_throughput": 12},
+            "latency": {"ttft": {"mean_ms": 1, "p99_ms": 2}},
+            "kernel_summary": ["gemm"],
+            "top_bottlenecks": ["gemm"],
+            "gap_analysis": {"enabled": True},
+            "tracelens_analysis": {"enabled": True},
+            "errors": [],
+        },
+        ray_config.ray_config,
+    )
+    assert result.success is True
+    assert result.throughput.request_throughput == 12
+    assert result.latency.ttft_mean == 1
+    assert result.metadata["ray_cluster"] == "ray://host"
+
+
+def test_execute_ray_benchmark_success_start_failure_and_exception(
+    monkeypatch, tmp_path
+):
+    config = make_config(
+        tmp_path,
+        run_mode="ray",
+        ray_config=RayConfig(
+            cluster_address="ray://host", shared_storage_path="/shared"
+        ),
+    )
+    mode = BenchmarkMode(config)
+
+    class Executor:
+        start_value = True
+        execute_value = SimpleNamespace(
+            status=SimpleNamespace(value="completed"),
+            results={"throughput": {"request_throughput": 5}},
+            execution_time=2,
+            errors=[],
+        )
+
+        def __init__(self, config, ray_config):
+            self.stopped = False
+
+        def start(self):
+            return self.start_value
+
+        def execute(self, task):
+            return self.execute_value
+
+        def stop(self):
+            self.stopped = True
+
+    monkeypatch.setattr("Magpie.core.ray_executor.RayJobExecutor", Executor)
+    result = mode._execute_ray_benchmark()
+    assert result.success is True
+    assert result.throughput.request_throughput == 5
+
+    Executor.start_value = False
+    result = mode._execute_ray_benchmark()
+    assert "Failed to connect" in result.errors[0]
+    Executor.start_value = True
+    Executor.execute_value = SimpleNamespace(
+        status=SimpleNamespace(value="failed"),
+        results=None,
+        execution_time=1,
+        errors=["remote failed"],
+    )
+    assert mode._execute_ray_benchmark().errors == ["remote failed"]
+    monkeypatch.setattr(
+        "Magpie.core.ray_executor.RayJobExecutor",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("ray unavailable")),
+    )
+    assert "ray unavailable" in mode._execute_ray_benchmark().errors[0]
+
+
+def test_cleanup_local_and_docker(monkeypatch, tmp_path):
+    local = BenchmarkMode(make_config(tmp_path))
+    cleaned = []
+    monkeypatch.setattr(
+        local, "_cleanup_server_processes", lambda framework: cleaned.append(framework)
+    )
+    local.cleanup()
+    assert cleaned == ["vllm"]
+    docker = BenchmarkMode(
+        make_config(tmp_path, run_mode="docker", docker_image="image")
+    )
+    docker._task_id = "task"
+    calls = []
+    monkeypatch.setattr(
+        benchmarker.subprocess, "run", lambda cmd, **kwargs: calls.append(cmd)
+    )
+    docker.cleanup()
+    assert calls[0][-1] == "magpie-benchmark-task"

--- a/tests/unit/modes/test_gap_analysis.py
+++ b/tests/unit/modes/test_gap_analysis.py
@@ -1,0 +1,176 @@
+import gzip
+import json
+
+from Magpie.modes.benchmark.config import GapAnalysisConfig
+from Magpie.modes.benchmark.gap_analysis import (
+    GapAnalysisResult,
+    GapAnalyzer,
+    KernelStat,
+    RankResult,
+    _extract_rank,
+)
+
+
+def trace_events():
+    return [
+        {
+            "cat": "cpu_op",
+            "name": "aten::mm",
+            "ts": 0,
+            "dur": 5,
+            "args": {"External id": 1, "Input Dims": [[2, 3], [3, 4]]},
+        },
+        {
+            "cat": "kernel",
+            "name": "gemm",
+            "ts": 10,
+            "dur": 20,
+            "args": {"External id": 1},
+        },
+        {
+            "cat": "kernel",
+            "name": "gemm",
+            "ts": 35,
+            "dur": 10,
+            "args": {"External id": 1},
+        },
+        {"cat": "ignored", "name": "noise", "ts": 50, "dur": 5},
+        {"name": "metadata"},
+    ]
+
+
+def write_trace(path, events=None, compressed=True):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"traceEvents": events if events is not None else trace_events(), "meta": 1}
+    if compressed:
+        with gzip.open(path, "wt") as handle:
+            json.dump(data, handle)
+    else:
+        path.write_text(json.dumps(data))
+    return path
+
+
+def config(**kwargs):
+    values = {
+        "enabled": True,
+        "categories": ["kernel"],
+        "ignore_categories": ["ignored"],
+        "trace_start_pct": 0,
+        "trace_end_pct": 100,
+        "top_k": 10,
+    }
+    values.update(kwargs)
+    return GapAnalysisConfig(**values)
+
+
+def test_kernel_stats_and_result_serialization(tmp_path):
+    stat = KernelStat(
+        "gemm",
+        total_duration_us=30,
+        calls=2,
+        durations_us=[10, 20],
+        shapes=["x", "x", "y"],
+    )
+    assert stat.avg_us == 15
+    assert stat.min_us == 10
+    assert stat.max_us == 20
+    assert stat.std_us > 0
+    assert stat.unique_shapes == "x; y"
+    result = GapAnalysisResult(
+        config={"top_k": 10},
+        rank_results=[RankResult(0, "trace", 30, [stat])],
+        merged_kernels=[stat],
+        total_duration_us=30,
+        clamped_trace_paths=[tmp_path / "clamped.json.gz"],
+    )
+    assert result.to_dict()["top_kernels"][0]["pct_total"] == 100
+    csv_path = result.to_csv(tmp_path / "summary.csv")
+    assert "gemm" in csv_path.read_text()
+    rank_paths = result.to_rank_csv(tmp_path)
+    assert "gemm" in rank_paths[0].read_text()
+
+
+def test_gap_analyzer_end_to_end_and_clamping(tmp_path):
+    trace_dir = tmp_path / "traces"
+    first = write_trace(trace_dir / "trace-rank-0.pt.trace.json.gz")
+    second = write_trace(
+        trace_dir / "rank_1" / "trace.pt.trace.json.gz",
+        trace_events() + [{"cat": "kernel", "name": "other", "ts": 60, "dur": 40}],
+    )
+    analyzer = GapAnalyzer(
+        config(trace_start_pct=10, trace_end_pct=90, min_duration_us=5)
+    )
+    found = analyzer.detect_trace_files(trace_dir)
+    assert found == [(0, first), (1, second)]
+    result = analyzer.analyze(trace_dir)
+    assert len(result.rank_results) == 2
+    assert result.merged_kernels[0].name == "gemm"
+    assert result.total_duration_us > 0
+    paths = analyzer.generate_clamped_traces(trace_dir, tmp_path / "clamped")
+    assert len(paths) == 2
+    with gzip.open(paths[0], "rt") as handle:
+        clamped = json.load(handle)
+    assert clamped["traceEvents"]
+
+
+def test_gap_analyzer_missing_empty_and_bad_traces(tmp_path):
+    analyzer = GapAnalyzer(config())
+    assert "not found" in analyzer.analyze(tmp_path / "missing").errors[0]
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert "No trace" in analyzer.analyze(empty).errors[0]
+    bad = empty / "trace-rank-0.pt.trace.json"
+    bad.write_text("{")
+    result = analyzer.analyze(empty)
+    assert "Failed to analyze" in result.errors[0]
+    assert analyzer.generate_clamped_traces(empty) == []
+
+
+def test_gap_analysis_helpers_and_formats(tmp_path):
+    analyzer = GapAnalyzer(config(trace_start_pct=25, trace_end_pct=75))
+    events = trace_events()
+    shapes = analyzer._build_shape_map(events)
+    assert shapes == {1: "[2,3]x[3,4]"}
+    assert analyzer._format_input_dims([]) == ""
+    assert analyzer._format_input_dims([[], "bad"]) == ""
+    window = analyzer._apply_time_window(events)
+    assert len(window) < len(events)
+    assert analyzer._apply_time_window([{"name": "no timestamps"}]) == [
+        {"name": "no timestamps"}
+    ]
+    filtered = analyzer._filter_by_category(events, shapes)
+    assert [item[0] for item in filtered] == ["gemm", "gemm"]
+    assert filtered[0][2] == "[2,3]x[3,4]"
+    stats = analyzer._aggregate_stats(filtered)
+    assert stats[0].calls == 2
+    rank = analyzer._analyze_single_rank(0, tmp_path / "trace", events)
+    assert rank.kernels[0].name == "gemm"
+    merged = analyzer._merge_ranks([rank, rank])
+    assert merged[0].calls == rank.kernels[0].calls * 2
+
+
+def test_trace_loading_list_fallback_and_rank_extraction(tmp_path):
+    plain = tmp_path / "plain.json"
+    plain.write_text(json.dumps(trace_events()))
+    data, events = GapAnalyzer._load_trace_data(plain)
+    assert isinstance(data, list)
+    assert len(events) == len(trace_events())
+    odd = tmp_path / "odd.json"
+    odd.write_text("42")
+    assert GapAnalyzer._load_trace_data(odd)[1] == []
+    assert _extract_rank(tmp_path / "trace-rank-7.json") == 7
+    assert _extract_rank(tmp_path / "pp0_dp2_tp3" / "trace.json") == 3
+    assert _extract_rank(tmp_path / "trace.json") is None
+
+
+def test_generate_clamped_trace_no_timestamps_and_list_output(tmp_path):
+    analyzer = GapAnalyzer(config(trace_start_pct=0, trace_end_pct=50))
+    assert (
+        analyzer._generate_clamped_trace([], [{"name": "meta"}], tmp_path / "x.json")
+        is None
+    )
+    path = analyzer._generate_clamped_trace(
+        trace_events(), trace_events(), tmp_path / "flat.json", output_dir=tmp_path
+    )
+    with gzip.open(path, "rt") as handle:
+        assert isinstance(json.load(handle), list)

--- a/tests/unit/modes/test_tracelens.py
+++ b/tests/unit/modes/test_tracelens.py
@@ -1,0 +1,286 @@
+import builtins
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from Magpie.modes.benchmark.config import TraceLensConfig
+from Magpie.modes.benchmark import tracelens
+
+
+def config(**changes):
+    values = {
+        "enabled": True,
+        "analysis_mode": "pytorch",
+        "export_format": "csv",
+    }
+    values.update(changes)
+    return TraceLensConfig(**values)
+
+
+def completed(cmd, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
+@pytest.mark.parametrize(
+    "outcome", ["cli", "import", "installed", "failure", "timeout"]
+)
+def test_ensure_tracelens_installed(monkeypatch, outcome):
+    monkeypatch.setattr(
+        tracelens.shutil,
+        "which",
+        lambda _cmd: "/bin/tool" if outcome == "cli" else None,
+    )
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "TraceLens":
+            if outcome == "import":
+                return object()
+            raise ImportError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    if outcome == "timeout":
+        monkeypatch.setattr(
+            tracelens.subprocess,
+            "run",
+            lambda *a, **k: (_ for _ in ()).throw(subprocess.TimeoutExpired("pip", 1)),
+        )
+    else:
+        monkeypatch.setattr(
+            tracelens.subprocess,
+            "run",
+            lambda *a, **k: completed(
+                a[0], 0 if outcome == "installed" else 1, stderr="bad"
+            ),
+        )
+
+    assert tracelens.ensure_tracelens_installed() is (
+        outcome in {"cli", "import", "installed"}
+    )
+
+
+def test_availability_is_cached_and_checks_cli(monkeypatch):
+    analyzer = tracelens.TraceLensAnalyzer(config())
+    monkeypatch.setattr(tracelens, "ensure_tracelens_installed", lambda: False)
+    assert analyzer.is_available() is False
+    monkeypatch.setattr(tracelens, "ensure_tracelens_installed", lambda: True)
+    assert analyzer.is_available() is False
+
+    analyzer = tracelens.TraceLensAnalyzer(config())
+    monkeypatch.setattr(tracelens.shutil, "which", lambda _cmd: "/bin/tool")
+    assert analyzer.is_available() is True
+
+
+def test_analyze_disabled_unavailable_and_missing_traces(monkeypatch, tmp_path):
+    assert tracelens.TraceLensAnalyzer(config(enabled=False)).analyze(
+        tmp_path, tmp_path
+    ) == {"enabled": False}
+    analyzer = tracelens.TraceLensAnalyzer(config())
+    monkeypatch.setattr(analyzer, "is_available", lambda: False)
+    assert analyzer.analyze(tmp_path, tmp_path)["error"] == "TraceLens not installed"
+    monkeypatch.setattr(analyzer, "is_available", lambda: True)
+    assert "No trace files" in analyzer.analyze(tmp_path, tmp_path)["errors"][0]
+
+
+def test_analyze_runs_single_and_multi_reports(monkeypatch, tmp_path):
+    trace_dir = tmp_path / "traces"
+    output_dir = tmp_path / "out"
+    for rank in range(2):
+        rank_dir = trace_dir / f"rank_{rank}"
+        rank_dir.mkdir(parents=True)
+        (rank_dir / "trace.json.gz").write_text("trace")
+
+    analyzer = tracelens.TraceLensAnalyzer(config())
+    monkeypatch.setattr(analyzer, "is_available", lambda: True)
+    monkeypatch.setattr(
+        analyzer,
+        "_run_generate_report",
+        lambda **kwargs: {"files": ["single.csv"], "error": "single warning"},
+    )
+    monkeypatch.setattr(
+        analyzer,
+        "_run_multi_rank_collective",
+        lambda **kwargs: {"files": ["multi.csv"], "error": None},
+    )
+    result = analyzer.analyze(trace_dir, output_dir, num_ranks=2)
+    assert result["output_files"] == ["single.csv", "multi.csv"]
+    assert result["errors"] == ["single warning"]
+    assert (output_dir / "tracelens_rank0_csvs").is_dir()
+    assert (output_dir / "tracelens_collective_csvs").is_dir()
+
+
+def test_find_trace_files_filters_async_llm(tmp_path):
+    (tmp_path / "async_llm.json").write_text("trace")
+    (tmp_path / "worker.json").write_text("trace")
+    analyzer = tracelens.TraceLensAnalyzer(config())
+    assert [path.name for path in analyzer._find_trace_files(tmp_path)] == [
+        "worker.json"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("runner", "expected"),
+    [
+        (lambda cmd, **kwargs: completed(cmd, 1, stderr="bad"), "CLI failed"),
+        (
+            lambda cmd, **kwargs: (_ for _ in ()).throw(
+                subprocess.TimeoutExpired(cmd, 1)
+            ),
+            "timed out",
+        ),
+        (lambda cmd, **kwargs: (_ for _ in ()).throw(FileNotFoundError()), "not found"),
+        (lambda cmd, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")), "boom"),
+    ],
+)
+def test_generate_report_failures(monkeypatch, tmp_path, runner, expected):
+    analyzer = tracelens.TraceLensAnalyzer(config())
+    assert "At least one" in analyzer._run_generate_report(tmp_path / "trace")["error"]
+    monkeypatch.setattr(tracelens.subprocess, "run", runner)
+    result = analyzer._run_generate_report(tmp_path / "trace", tmp_path / "csv")
+    assert expected in result["error"]
+
+
+def test_generate_report_command_and_outputs(monkeypatch, tmp_path):
+    csv_dir = tmp_path / "csv"
+    csv_dir.mkdir()
+    (csv_dir / "summary.csv").write_text("ok")
+    workbook = tmp_path / "report.xlsx"
+    workbook.write_text("ok")
+    calls = []
+    monkeypatch.setattr(
+        tracelens.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd) or completed(cmd, stdout="done"),
+    )
+    analyzer = tracelens.TraceLensAnalyzer(config(gpu_arch_config="arch.json"))
+    result = analyzer._run_generate_report(tmp_path / "trace.json", csv_dir, workbook)
+    assert len(result["files"]) == 2
+    assert "--enable_kernel_summary" in calls[0]
+    assert calls[0][-2:] == ["--gpu_arch_json_path", "arch.json"]
+
+
+@pytest.mark.parametrize(
+    ("runner", "expected"),
+    [
+        (lambda cmd, **kwargs: completed(cmd, 1, stderr="bad"), "failed"),
+        (
+            lambda cmd, **kwargs: (_ for _ in ()).throw(
+                subprocess.TimeoutExpired(cmd, 1)
+            ),
+            "timed out",
+        ),
+        (lambda cmd, **kwargs: (_ for _ in ()).throw(FileNotFoundError()), "not found"),
+        (lambda cmd, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")), "boom"),
+    ],
+)
+def test_multi_rank_failures(monkeypatch, tmp_path, runner, expected):
+    trace_dir = tmp_path / "traces"
+    trace_dir.mkdir()
+    for rank in range(2):
+        (trace_dir / f"rank-{rank}.json").write_text("trace")
+    analyzer = tracelens.TraceLensAnalyzer(config())
+    monkeypatch.setattr(tracelens.subprocess, "run", runner)
+    result = analyzer._run_multi_rank_collective(
+        trace_dir, tmp_path / "csv", num_ranks=2
+    )
+    assert expected in result["error"]
+
+
+def test_multi_rank_validation_success_and_patterns(monkeypatch, tmp_path):
+    analyzer = tracelens.TraceLensAnalyzer(config())
+    assert "At least one" in analyzer._run_multi_rank_collective(tmp_path)["error"]
+    single_dir = tmp_path / "single"
+    single_dir.mkdir()
+    (single_dir / "only.json").write_text("trace")
+    assert (
+        "at least 2"
+        in analyzer._run_multi_rank_collective(
+            single_dir, tmp_path / "csv", num_ranks=8
+        )["error"]
+    )
+
+    (tmp_path / "rank-0.json").write_text("trace")
+    (tmp_path / "rank-1.json").write_text("trace")
+    csv_dir = tmp_path / "csv"
+    csv_dir.mkdir(exist_ok=True)
+    (csv_dir / "collective.csv").write_text("ok")
+    calls = []
+    monkeypatch.setattr(
+        tracelens.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd) or completed(cmd, stdout="done"),
+    )
+    result = analyzer._run_multi_rank_collective(tmp_path, csv_dir, num_ranks=2)
+    assert result["files"] == [str(csv_dir / "collective.csv")]
+    assert "--trace_pattern" in calls[0]
+    assert analyzer._detect_trace_pattern(tmp_path, []) is None
+    assert analyzer._detect_trace_pattern(
+        tmp_path, [Path("outside/gpu2.json")]
+    ).endswith("gpu*.json")
+    plain = tmp_path / "plain.json"
+    assert analyzer._detect_trace_pattern(tmp_path, [plain]) is None
+
+
+@pytest.mark.parametrize(
+    ("runner", "expected"),
+    [
+        (lambda cmd, **kwargs: completed(cmd, 1, stderr="bad"), "failed"),
+        (
+            lambda cmd, **kwargs: (_ for _ in ()).throw(
+                subprocess.TimeoutExpired(cmd, 1)
+            ),
+            "timed out",
+        ),
+        (lambda cmd, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")), "boom"),
+    ],
+)
+def test_compare_reports_validation_and_failures(
+    monkeypatch, tmp_path, runner, expected
+):
+    analyzer = tracelens.TraceLensAnalyzer(config())
+    assert "At least 2" in analyzer.compare_reports([tmp_path], tmp_path)["error"]
+    monkeypatch.setattr(analyzer, "is_available", lambda: False)
+    assert (
+        analyzer.compare_reports([tmp_path, tmp_path], tmp_path)["error"]
+        == "TraceLens not installed"
+    )
+    monkeypatch.setattr(analyzer, "is_available", lambda: True)
+    monkeypatch.setattr(tracelens.subprocess, "run", runner)
+    assert expected in analyzer.compare_reports([tmp_path, tmp_path], tmp_path)["error"]
+
+
+def test_compare_reports_success_and_convenience_functions(monkeypatch, tmp_path):
+    output = tmp_path / "output"
+    csv_dir = output / "tracelens_comparison_csvs"
+
+    def run(cmd, **kwargs):
+        csv_dir.mkdir(parents=True, exist_ok=True)
+        (csv_dir / "comparison.csv").write_text("ok")
+        (output / "tracelens_comparison.xlsx").write_text("ok")
+        return completed(cmd)
+
+    monkeypatch.setattr(tracelens.subprocess, "run", run)
+    analyzer = tracelens.TraceLensAnalyzer(config(export_format="excel"))
+    monkeypatch.setattr(analyzer, "is_available", lambda: True)
+    result = analyzer.compare_reports(
+        [tmp_path / "one", tmp_path / "two"], output, ["one", "two"]
+    )
+    assert len(result["files"]) == 2
+
+    monkeypatch.setattr(
+        tracelens.TraceLensAnalyzer, "analyze", lambda self, *args: {"ran": args}
+    )
+    assert (
+        tracelens.run_tracelens_analysis(config(), tmp_path, output, 2)["ran"][-1] == 2
+    )
+    monkeypatch.setattr(
+        tracelens.TraceLensAnalyzer,
+        "compare_reports",
+        lambda self, *args: {"compared": args},
+    )
+    assert tracelens.compare_tracelens_reports(
+        config(), [tmp_path, output], output, ["a", "b"]
+    )["compared"][-1] == ["a", "b"]

--- a/tests/unit/modes/test_tracelens_inference_unit.py
+++ b/tests/unit/modes/test_tracelens_inference_unit.py
@@ -1,0 +1,156 @@
+from types import SimpleNamespace
+
+from Magpie.modes.benchmark import tracelens_inference as module
+from Magpie.modes.benchmark.config import BenchmarkConfig
+from Magpie.modes.benchmark.tracelens_inference import (
+    InferencePhasePick,
+    TraceLensInferencePipeline,
+)
+
+
+def make_pipeline(framework="vllm", stages=None):
+    config = BenchmarkConfig.from_dict(
+        {
+            "framework": framework,
+            "model": "demo",
+            "run_mode": "local",
+            "profiler": {
+                "tracelens": {
+                    "enabled": True,
+                    "analysis_mode": "inference",
+                    "analysis_stages": stages or ["decode"],
+                }
+            },
+        }
+    )
+    return TraceLensInferencePipeline(config)
+
+
+def test_analyze_validation_failures(monkeypatch, tmp_path):
+    pipeline = make_pipeline()
+    monkeypatch.setattr(module, "ensure_tracelens_installed", lambda: False)
+    assert pipeline.analyze(tmp_path, tmp_path)["errors"] == [
+        "TraceLens is not installed"
+    ]
+
+    monkeypatch.setattr(module, "ensure_tracelens_installed", lambda: True)
+    monkeypatch.setattr(module.shutil, "which", lambda name: None)
+    result = pipeline.analyze(tmp_path, tmp_path)
+    assert "Required TraceLens" in result["errors"][0]
+
+
+def test_analyze_missing_rank_split_and_execution_csv(monkeypatch, tmp_path):
+    pipeline = make_pipeline(framework="vllm")
+    monkeypatch.setattr(module, "ensure_tracelens_installed", lambda: True)
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/bin/tool")
+    monkeypatch.setattr(
+        pipeline,
+        "_select_gpu_arch_platform",
+        lambda *args: ("mi300x", None, "platform warning"),
+    )
+    monkeypatch.setattr(pipeline, "_locate_rank0_trace", lambda path: None)
+    result = pipeline.analyze(tmp_path, tmp_path)
+    assert "Could not locate" in result["errors"][0]
+    assert "platform warning" in result["warnings"]
+
+    trace = tmp_path / "rank0.json"
+    trace.write_text("{}")
+    monkeypatch.setattr(pipeline, "_locate_rank0_trace", lambda path: trace)
+    monkeypatch.setattr(pipeline, "_capture_folder", lambda *args: tmp_path)
+    monkeypatch.setattr(pipeline, "_run_splitter", lambda *args: "split failed")
+    assert pipeline.analyze(tmp_path, tmp_path)["errors"][-1] == "split failed"
+
+    monkeypatch.setattr(pipeline, "_run_splitter", lambda *args: None)
+    monkeypatch.setattr(
+        pipeline, "_validate_trace_layout", lambda *args: ["layout warning"]
+    )
+    result = pipeline.analyze(tmp_path, tmp_path / "out")
+    assert "Missing TraceLens split CSV" in result["errors"][-1]
+    assert "layout warning" in result["warnings"]
+
+
+def test_analyze_stage_reports_and_skips(monkeypatch, tmp_path):
+    pipeline = make_pipeline(stages=["decode", "prefill"])
+    monkeypatch.setattr(module, "ensure_tracelens_installed", lambda: True)
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/bin/tool")
+    monkeypatch.setattr(
+        pipeline, "_select_gpu_arch_platform", lambda *args: ("mi300x", "mi300x", None)
+    )
+    trace = tmp_path / "rank0.json"
+    trace.write_text("{}")
+    monkeypatch.setattr(pipeline, "_locate_rank0_trace", lambda path: trace)
+    monkeypatch.setattr(pipeline, "_capture_folder", lambda *args: tmp_path)
+
+    def split(_trace, split_dir):
+        split_dir.mkdir(parents=True)
+        (split_dir / "execution_details.csv").write_text("stage,output_path\n")
+        return None
+
+    monkeypatch.setattr(pipeline, "_run_splitter", split)
+    monkeypatch.setattr(pipeline, "_validate_trace_layout", lambda *args: [])
+    pick = InferencePhasePick(
+        stage="decode",
+        csv_kind="execution",
+        batch_size=8,
+        trace_path=trace,
+        output_label="decode_bs8",
+    )
+    monkeypatch.setattr(
+        pipeline, "_pick_largest_batch_traces", lambda path: {"decode": pick}
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_run_perf_report",
+        lambda **kwargs: {"files": ["decode.csv"], "error": "partial"},
+    )
+    result = pipeline.analyze(tmp_path, tmp_path / "out")
+    assert result["output_files"] == ["decode.csv"]
+    assert result["errors"] == ["partial"]
+    assert any("prefill: no candidate" in warning for warning in result["warnings"])
+
+
+def test_sglang_fallback_creates_execution_csv(monkeypatch, tmp_path):
+    pipeline = make_pipeline(framework="sglang")
+    monkeypatch.setattr(module, "ensure_tracelens_installed", lambda: True)
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/bin/tool")
+    monkeypatch.setattr(
+        pipeline, "_select_gpu_arch_platform", lambda *args: (None, None, None)
+    )
+    trace = tmp_path / "rank0.json"
+    trace.write_text("{}")
+    monkeypatch.setattr(pipeline, "_locate_rank0_trace", lambda path: trace)
+    monkeypatch.setattr(pipeline, "_capture_folder", lambda *args: tmp_path)
+    monkeypatch.setattr(pipeline, "_run_splitter", lambda *args: None)
+    monkeypatch.setattr(pipeline, "_validate_trace_layout", lambda *args: [])
+
+    def fallback(_trace, split_dir):
+        split_dir.mkdir(parents=True, exist_ok=True)
+        (split_dir / "execution_details.csv").write_text("stage,output_path\n")
+        return ["fallback used"]
+
+    monkeypatch.setattr(pipeline, "_split_sglang_step_markers", fallback)
+    monkeypatch.setattr(pipeline, "_pick_largest_batch_traces", lambda path: {})
+    result = pipeline.analyze(tmp_path, tmp_path / "out")
+    assert any("fallback" in warning for warning in result["warnings"])
+
+
+def test_container_paths_rewrite_and_subprocess_environment(monkeypatch, tmp_path):
+    pipeline = make_pipeline()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    nested = workspace / "trace" / "rank0.json"
+    nested.parent.mkdir()
+    nested.write_text("{}")
+    assert pipeline._container_path(workspace, workspace) == "/workspace"
+    assert pipeline._container_path(nested, workspace) == "/workspace/trace/rank0.json"
+    try:
+        pipeline._container_path(tmp_path / "outside", workspace)
+    except ValueError as error:
+        assert "inside workspace" in str(error)
+
+    csv_file = workspace / "execution_details.csv"
+    csv_file.write_text("stage,output_path\ndecode,/workspace/trace/rank0.json\n")
+    pipeline._rewrite_container_split_paths(csv_file, workspace)
+    assert str(workspace / "trace" / "rank0.json") in csv_file.read_text()
+    pipeline.tl_extension = "extension.module"
+    assert pipeline._subprocess_env()["TL_EXTENSION"] == "extension.module"

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -1,0 +1,498 @@
+import argparse
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from Magpie import main
+from Magpie.config import KernelEvalConfig, KernelType
+from Magpie.core import EnvironmentType
+from Magpie.eval import BaseKind, EvaluationState
+
+
+def args(**changes):
+    values = {
+        "environment": None,
+        "workers": None,
+        "docker_image": None,
+    }
+    values.update(changes)
+    return argparse.Namespace(**values)
+
+
+def test_yaml_kernel_loading_and_environment_expansion(monkeypatch, tmp_path):
+    monkeypatch.setenv("MAGPIE_TEST_ROOT", str(tmp_path))
+    path = tmp_path / "kernels.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "kernel": {
+                    "id": "first",
+                    "type": "torch",
+                    "source_files": ["$MAGPIE_TEST_ROOT/kernel.py"],
+                    "working_dir": "$MAGPIE_TEST_ROOT",
+                    "env": {"ROOT": "$MAGPIE_TEST_ROOT"},
+                    "testcase_command": "python test.py",
+                    "compile_command": [["make", "clean"], ["make"]],
+                },
+                "kernels": [{"id": "second", "type": "hip"}],
+                "performance": {"backend": "$MAGPIE_BACKEND"},
+                "correctness": {"backend": "testcase"},
+                "ray_config": {"cluster_address": "ray://host"},
+            }
+        )
+    )
+    monkeypatch.setenv("MAGPIE_BACKEND", "metrix")
+    configs, perf, corr, sched = main.load_kernel_config(path)
+    assert [cfg.kernel_id for cfg in configs] == ["first", "second"]
+    assert configs[0].testcase_command == ["python", "test.py"]
+    assert configs[0].compiling_command == [["make", "clean"], ["make"]]
+    assert perf["backend"] == "metrix"
+    assert corr["backend"] == "testcase"
+    assert sched["environment"] == "ray"
+    assert main.load_yaml(tmp_path / "missing") == {}
+
+
+def test_setup_logging_uses_config_and_verbose(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        main.logging, "basicConfig", lambda **kwargs: calls.append(kwargs)
+    )
+    main.setup_logging({"logging": {"level": "warning"}})
+    assert calls[-1]["level"] == main.logging.WARNING
+    main.setup_logging({}, verbose=True)
+    assert calls[-1]["level"] == main.logging.DEBUG
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        (None, None),
+        ([], None),
+        ("make build", ["make", "build"]),
+        (["make", "build"], ["make", "build"]),
+        ([["make"], ["test"]], [["make"], ["test"]]),
+        (["make", 1], None),
+        ({"command": "make"}, None),
+    ],
+)
+def test_parse_command_list(entry, expected):
+    assert main._parse_command_list(entry) == expected
+
+
+def test_kernel_types_and_empty_entry():
+    assert main.parse_kernel_type("PY") is KernelType.PYTORCH
+    assert main.parse_kernel_type("triton") is KernelType.TRITON
+    with pytest.raises(ValueError, match="Unsupported kernel type"):
+        main.parse_kernel_type("metal")
+    assert main._parse_kernel_entry({}) is None
+
+
+def test_framework_settings_and_overrides():
+    config = {
+        "compiling": {"enable_default_compile": True},
+        "correctness": {"backend": "accordo", "accordo": {"atol": 0.1}},
+        "performance": {
+            "timeout_seconds": 12,
+            "backend": "metrix",
+            "rocprof_compute": {"roofline": False, "profile_args": "--foo"},
+            "metrix": {"profile": "quick", "num_replays": 2},
+            "ncu": {"args": ["--set", "full"], "metrics": ["cycles"]},
+        },
+        "compare": {"winner_strategy": "weighted"},
+    }
+    assert main._get_compiling_config(config)["enable_default_compile"] is True
+    correctness = main._get_correctness_config(config)
+    assert correctness["backend"] == "accordo"
+    assert correctness["accordo"]["atol"] == 0.1
+    correctness = main._apply_correctness_overrides(
+        correctness, {"backend": "testcase", "accordo": {"rtol": 0.2}}
+    )
+    assert correctness["backend"] == "testcase"
+    assert correctness["accordo"]["rtol"] == 0.2
+
+    hip = main._get_performance_config(config, KernelType.HIP)
+    assert hip["rocprof_config"]["profile_args"] == ["--foo", "--no-roof"]
+    cuda = main._get_performance_config(config, KernelType.CUDA)
+    assert cuda["profiler_args"] == ["--set", "full"]
+    triton = main._get_performance_config(config, KernelType.TRITON)
+    assert triton["rocprof_config"] and triton["ncu_config"]
+    assert main._get_compare_config(config)["winner_strategy"] == "weighted"
+
+    merged = main._apply_perf_overrides(
+        hip,
+        {
+            "backend": "metrix",
+            "timeout_seconds": "33",
+            "metrix": {"metrics": ["L2"]},
+            "rocprof_compute": {"roofline": True},
+            "ncu": {"metrics": ["dram"]},
+        },
+        KernelType.HIP,
+    )
+    assert merged["timeout_seconds"] == 33
+    assert merged["metrix_config"]["metrics"] == ["L2"]
+    assert "--no-roof" not in merged["rocprof_config"]["profile_args"]
+    non_metrix = main._apply_perf_overrides({}, {"backend": "ncu"}, KernelType.CUDA)
+    assert non_metrix["metrix_config"]["backend"] is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(True, True), (" YES ", True), ("off", False), (1, True), (0, False)],
+)
+def test_coerce_bool(value, expected):
+    assert main._coerce_bool(value) is expected
+
+
+def test_scheduler_config_precedence():
+    config = {
+        "scheduler": {
+            "environment": "docker",
+            "max_workers": 2,
+            "gpu_devices": [1],
+            "docker_image": "base",
+        }
+    }
+    scheduler = main._get_scheduler_config(
+        config,
+        args(environment="local", workers=4, docker_image="cli"),
+        {
+            "environment": "ray",
+            "ray_config": {
+                "cluster_address": "ray://host",
+                "shared_storage_path": "/shared",
+            },
+        },
+    )
+    assert scheduler.environment_type is EnvironmentType.LOCAL
+    assert scheduler.max_workers == 4
+    assert scheduler.docker_image == "cli"
+    assert scheduler.ray_cluster_address == "ray://host"
+
+
+def test_state_print_workspace_and_serialization(tmp_path, capsys):
+    state = main._dict_to_eval_state(
+        {
+            "compiling_state": "SUCCESS",
+            "correctness_state": "FAILED",
+            "performance_state": "SKIPPED",
+            "score": 0.5,
+            "errors": ["bad"],
+            "extra": {"key": "value"},
+        }
+    )
+    assert state.correctness_state is BaseKind.FAILED
+    config = KernelEvalConfig(kernel_id="demo", kernel_type=KernelType.HIP)
+    main._print_result(config, state)
+    main._print_result(config, {"score": 1.0, "errors": ["warning"]})
+    assert "Kernel: demo" in capsys.readouterr().out
+
+    workspace = main._create_workspace(tmp_path, "analyze", "unsafe label!")
+    main._save_config_snapshot(workspace, [config, "raw"], {"extra": True})
+    assert yaml.safe_load((workspace / "config.yaml").read_text())["extra"] is True
+    main._save_results([state, {"raw": True}, "plain"], workspace, "analyze")
+    report = next(workspace.glob("analyze_report.json"))
+    assert len(json.loads(report.read_text())["results"]) == 3
+
+    main._save_comparison(
+        {"winner": 0, "summary": "first", "rankings": [[0, 1.0]]}, workspace
+    )
+    assert (
+        json.loads((workspace / "compare_report.json").read_text())["results"]["winner"]
+        == 0
+    )
+
+
+class FakeScheduler:
+    initialized = True
+    response = None
+    instances = []
+
+    def __init__(self, config):
+        self.config = config
+        self.shutdown_called = False
+        self.__class__.instances.append(self)
+
+    def initialize(self):
+        return self.initialized
+
+    def run_analyze(self, **kwargs):
+        return self.response
+
+    def run_compare(self, **kwargs):
+        return self.response
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+
+def test_run_analyze_success_and_failures(monkeypatch, tmp_path):
+    source = tmp_path / "kernel.hip"
+    source.write_text("kernel")
+    cli = args(
+        kernel_config=None,
+        kernels=[source],
+        testcase="./test.sh",
+        compile_cmd=None,
+        type="hip",
+        output_dir=tmp_path / "out",
+        no_perf=False,
+    )
+    state = EvaluationState(
+        compiling_state=BaseKind.SUCCESS,
+        correctness_state=BaseKind.SUCCESS,
+        performance_state=BaseKind.SUCCESS,
+    )
+    FakeScheduler.instances.clear()
+    FakeScheduler.initialized = True
+    FakeScheduler.response = SimpleNamespace(success=True, results=[state], errors=[])
+    monkeypatch.setattr(main, "Scheduler", FakeScheduler)
+    assert main.run_analyze(cli, {}) == 0
+    assert FakeScheduler.instances[-1].shutdown_called is True
+
+    cli.testcase = None
+    assert main.run_analyze(cli, {}) == 1
+    cli.kernels = None
+    assert main.run_analyze(cli, {}) == 1
+
+
+def test_run_analyze_kernel_config_validation(tmp_path):
+    invalid = tmp_path / "invalid.yaml"
+    invalid.write_text("kernel:\n  id: broken\n  type: unsupported\n")
+    cli = args(
+        kernel_config=invalid,
+        kernels=None,
+        testcase=None,
+        compile_cmd=None,
+        type="hip",
+        output_dir=tmp_path / "out",
+        no_perf=False,
+    )
+    assert main.run_analyze(cli, {}) == 1
+
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("kernels: []\n")
+    cli.kernel_config = empty
+    assert main.run_analyze(cli, {}) == 1
+
+
+def test_run_compare_success_and_validation(monkeypatch, tmp_path):
+    sources = [tmp_path / "one.hip", tmp_path / "two.hip"]
+    for source in sources:
+        source.write_text("kernel")
+    cli = args(
+        kernel_config=None,
+        kernels=sources,
+        testcase="./test.sh",
+        type="hip",
+        output_dir=tmp_path / "out",
+        no_perf=False,
+        baseline=0,
+    )
+    FakeScheduler.instances.clear()
+    FakeScheduler.initialized = True
+    FakeScheduler.response = SimpleNamespace(
+        success=True,
+        results={"winner": 0, "summary": "winner", "rankings": []},
+        errors=[],
+    )
+    monkeypatch.setattr(main, "Scheduler", FakeScheduler)
+    assert main.run_compare(cli, {}) == 0
+    assert FakeScheduler.instances[-1].shutdown_called is True
+    cli.kernels = sources[:1]
+    assert main.run_compare(cli, {}) == 1
+
+
+def test_parser_and_load_benchmark_config(tmp_path):
+    parser = main.create_parser()
+    parsed = parser.parse_args(["analyze", "kernel.hip", "--testcase", "./test.sh"])
+    assert parsed.mode == "analyze"
+    path = tmp_path / "benchmark.yaml"
+    path.write_text("benchmark:\n  framework: vllm\n  model: demo\n")
+    config = main.load_benchmark_config(path)
+    assert config["framework"] == "vllm"
+
+
+def test_standalone_gap_analysis_success_empty_and_missing(
+    monkeypatch, tmp_path, capsys
+):
+    trace_dir = tmp_path / "run" / "torch_trace"
+    trace_dir.mkdir(parents=True)
+    kernel = SimpleNamespace(name="a" * 60, calls=2, total_duration_us=8, avg_us=4)
+
+    class Result:
+        errors = ["partial trace"]
+        merged_kernels = [kernel]
+        rank_results = [{}, {}]
+        total_duration_us = 10
+
+        def to_csv(self, path, **kwargs):
+            path.write_text("csv")
+
+        def to_rank_csv(self, path):
+            (path / "rank.csv").write_text("csv")
+
+    class Analyzer:
+        empty = False
+
+        def __init__(self, config):
+            self.config = config
+
+        def analyze(self, path):
+            result = Result()
+            if self.empty:
+                result.merged_kernels = []
+            return result
+
+    monkeypatch.setattr("Magpie.modes.benchmark.gap_analysis.GapAnalyzer", Analyzer)
+    cli = args(
+        trace_dir=tmp_path / "run",
+        start_pct=10,
+        end_pct=90,
+        top_k=5,
+        min_duration_us=1,
+        categories=["kernel"],
+        ignore_categories=["annotation"],
+        output_dir=tmp_path / "output",
+        find_kernel_sources=True,
+        kernel_source_repos=["repo"],
+        no_rank_csv=False,
+    )
+    assert main.run_gap_analysis_standalone(cli) == 0
+    output = capsys.readouterr().out
+    assert "Ranks analyzed: 2" in output
+    assert "partial trace" in output
+    assert (tmp_path / "output" / "gap_analysis" / "gap_analysis.csv").exists()
+    Analyzer.empty = True
+    assert main.run_gap_analysis_standalone(cli) == 1
+    cli.trace_dir = tmp_path / "missing"
+    assert main.run_gap_analysis_standalone(cli) == 1
+
+
+def benchmark_args(tmp_path, **changes):
+    values = {
+        "trace_dir": None,
+        "benchmark_config": None,
+        "framework": "vllm",
+        "model": "demo",
+        "precision": "fp8",
+        "tp": 2,
+        "concurrency": 4,
+        "input_len": 16,
+        "output_len": 8,
+        "torch_profiler": False,
+        "system_profiler": False,
+        "docker_image": "image:test",
+        "inferencex_path": "",
+        "benchmark_script": None,
+        "timeout": 30,
+        "run_mode": "local",
+        "output_dir": tmp_path,
+    }
+    values.update(changes)
+    return args(**values)
+
+
+def test_run_benchmark_cli_success_failure_and_validation(monkeypatch, tmp_path):
+    created = []
+
+    class Mode:
+        success = True
+        raises = False
+
+        def __init__(self, config, output_dir):
+            self.config = config
+            created.append(self)
+
+        def run(self):
+            if self.raises:
+                raise RuntimeError("runtime failed")
+            return SimpleNamespace(
+                success=self.success,
+                workspace_dir="/results/run",
+                errors=[] if self.success else ["failed"],
+                get_summary=lambda: "summary",
+            )
+
+    monkeypatch.setattr("Magpie.modes.benchmark.BenchmarkMode", Mode)
+    cli = benchmark_args(tmp_path)
+    assert main.run_benchmark(cli, {"benchmark": {"inferencex_path": "/default"}}) == 0
+    assert created[-1].config.inferencex_path == "/default"
+    Mode.success = False
+    assert main.run_benchmark(cli, {}) == 1
+    Mode.raises = True
+    assert main.run_benchmark(cli, {}) == 1
+    Mode.raises = False
+
+    cli.framework = None
+    assert main.run_benchmark(cli, {}) == 1
+    config_path = tmp_path / "invalid.yaml"
+    config_path.write_text("benchmark: {}\n")
+    cli.benchmark_config = config_path
+    assert main.run_benchmark(cli, {}) == 1
+
+
+def test_main_dispatch_gpu_info_help_and_modes(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(
+        main,
+        "get_gpu_info",
+        lambda: {
+            "vendor": "amd",
+            "architecture": "gfx942",
+            "detected": True,
+            "compiler": "hipcc",
+            "profiler": "rocprof",
+        },
+    )
+    monkeypatch.setattr(
+        main,
+        "create_parser",
+        lambda: SimpleNamespace(
+            parse_args=lambda: args(gpu_info=True), print_help=lambda: None
+        ),
+    )
+    assert main.main() == 0
+    assert "gfx942" in capsys.readouterr().out
+
+    monkeypatch.setattr(
+        main,
+        "create_parser",
+        lambda: SimpleNamespace(
+            parse_args=lambda: args(gpu_info=False, mode=None), print_help=lambda: None
+        ),
+    )
+    assert main.main() == 0
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("{}")
+    for mode_name, function_name, expected in [
+        ("analyze", "run_analyze", 2),
+        ("compare", "run_compare", 3),
+        ("benchmark", "run_benchmark", 4),
+    ]:
+        monkeypatch.setattr(main, function_name, lambda *a, value=expected, **k: value)
+        monkeypatch.setattr(
+            main,
+            "create_parser",
+            lambda m=mode_name: SimpleNamespace(
+                parse_args=lambda: args(
+                    gpu_info=False, mode=m, config=config_path, verbose=False
+                ),
+                print_help=lambda: None,
+            ),
+        )
+        assert main.main() == expected
+    monkeypatch.setattr(
+        main,
+        "create_parser",
+        lambda: SimpleNamespace(
+            parse_args=lambda: args(
+                gpu_info=False, mode="unknown", config=config_path, verbose=False
+            ),
+            print_help=lambda: None,
+        ),
+    )
+    assert main.main() == 1

--- a/tests/unit/utils/test_gpu.py
+++ b/tests/unit/utils/test_gpu.py
@@ -1,0 +1,382 @@
+import subprocess
+
+import pytest
+
+import Magpie.utils.gpu as gpu
+from Magpie.utils.gpu import (
+    GPUComputeSpec,
+    GPUConfig,
+    GPUController,
+    GPUHardwareInfo,
+    GPUVendor,
+    MultiGPUConfig,
+    MultiGPUController,
+)
+
+ROCMINFO = """
+***** Agent 1 *****
+  Device Type: GPU
+  Marketing Name: MI300X
+  Uuid: GPU-abc
+  Chip ID: 123(0x74a1)
+  Compute Unit: 304
+  SIMDs per CU: 4
+  Shader Engines: 8
+  Wavefront Size: 64
+  Workgroup Max Size: 1024
+  Max Waves Per CU: 32
+  Max Work-item Per CU: 2048
+  Cacheline Size: 64
+  Workgroup Max Size per Dimension:
+    x 1024 foo
+    y 1024 foo
+    z 1024
+  Grid Max Size: 4294967295
+  Grid Max Size per Dimension:
+    x 1 foo
+    y 2 foo
+    z 3
+  Cache Info:
+    L1: 32
+    L2: 16384
+    L3: 262144
+  Segment: GROUP
+    Size: 64
+  Name: amdgcn-amd-amdhsa--gfx942
+***** Agent 2 *****
+  Device Type: CPU
+"""
+
+
+def test_gpu_models_and_rocminfo_parser():
+    specs = gpu._parse_rocminfo_gpu_agents(ROCMINFO)
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec.compute_units == 304
+    assert spec.max_workgroup_size_xyz == [1024, 1024, 1024]
+    assert spec.grid_max_size_xyz == [1, 2, 3]
+    assert spec.l2_cache_kb == 16384
+    assert spec.lds_size_kb == 64
+    assert spec.isa_name.endswith("gfx942")
+    assert GPUComputeSpec(compute_units=1).to_dict() == {"compute_units": 1}
+    info = GPUHardwareInfo(GPUVendor.AMD, compute_spec=spec)
+    assert info.to_dict()["compute_spec"]["marketing_name"] == "MI300X"
+    restored = gpu._spec_from_cache_dict(spec.to_dict())
+    assert restored.compute_units == 304
+
+
+def test_compute_spec_disk_memory_and_live_caches(tmp_path, monkeypatch):
+    cache_dir = tmp_path / ".magpie"
+    cache_file = cache_dir / "specs.json"
+    monkeypatch.setattr(gpu, "_MAGPIE_CACHE_DIR", cache_dir)
+    monkeypatch.setattr(gpu, "_COMPUTE_SPEC_CACHE_FILE", cache_file)
+    monkeypatch.setattr(gpu, "_rocminfo_specs", None)
+    spec = GPUComputeSpec(compute_units=8)
+    gpu._save_compute_spec_cache([spec])
+    assert gpu._load_compute_spec_cache()["gpu_count"] == 1
+    assert gpu.get_amd_compute_specs()[0].compute_units == 8
+    monkeypatch.setattr(gpu, "_rocminfo_specs", None)
+    cache_file.unlink()
+    monkeypatch.setattr(
+        gpu.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 0, stdout=ROCMINFO),
+    )
+    assert gpu.get_amd_compute_specs(force_refresh=True)[0].marketing_name == "MI300X"
+
+
+def controller(vendor, monkeypatch, device_id=0):
+    monkeypatch.setattr(gpu, "detect_gpu", lambda: (vendor, "gfx942"))
+    return GPUController(device_id)
+
+
+def test_gpu_controller_hardware_info_amd(monkeypatch):
+    ctrl = controller(GPUVendor.AMD, monkeypatch)
+    monkeypatch.setattr(
+        gpu, "get_amd_compute_specs", lambda: [GPUComputeSpec(marketing_name="MI300X")]
+    )
+    outputs = {
+        "--showpower": "Average Power (W): 150.0",
+        "--showclocks": "sclk 1200\nmclk 900",
+        "--showtemp": "Temperature: 55.5",
+        "--showmeminfo": f"Total {16 * 1024**3}\nUsed {4 * 1024**3}",
+    }
+
+    def run(cmd, **kwargs):
+        key = next(key for key in outputs if key in cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout=outputs[key])
+
+    monkeypatch.setattr(gpu.subprocess, "run", run)
+    info = ctrl.get_hardware_info()
+    assert info.device_name == "MI300X"
+    assert info.power_current_watts == 150
+    assert info.gpu_clock_current == 1200
+    assert info.mem_clock_current == 900
+    assert info.temperature == 55.5
+    assert info.memory_total_gb == 16
+
+
+def test_gpu_controller_hardware_info_nvidia_and_unknown(monkeypatch):
+    ctrl = controller(GPUVendor.NVIDIA, monkeypatch)
+    values = "H100,100,700,800,1200,1800,900,1200,50,81920,1024"
+    monkeypatch.setattr(
+        gpu.subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=values),
+    )
+    info = ctrl.get_hardware_info()
+    assert info.device_name == "H100"
+    assert info.memory_total_gb == 80
+    ctrl.vendor = GPUVendor.UNKNOWN
+    assert ctrl.get_hardware_info().vendor is GPUVendor.UNKNOWN
+
+
+@pytest.mark.parametrize("vendor", [GPUVendor.AMD, GPUVendor.NVIDIA])
+def test_gpu_controller_apply_and_reset(vendor, monkeypatch):
+    ctrl = controller(vendor, monkeypatch)
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok")
+
+    monkeypatch.setattr(gpu.subprocess, "run", run)
+    config = GPUConfig(
+        power_limit_watts=300,
+        gpu_clock_mhz=(1000, 1200),
+        mem_clock_mhz=(800, 900),
+        gpu_clock_level=4,
+        mem_clock_level=2,
+    )
+    assert ctrl.apply_config(config) is True
+    assert ctrl.reset_config() is True
+    assert len(calls) >= 4 if vendor is GPUVendor.NVIDIA else len(calls) >= 4
+    monkeypatch.setattr(
+        gpu.subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("permission")),
+    )
+    assert ctrl.apply_config(config) is False
+    assert ctrl.reset_config() is False
+    ctrl.vendor = GPUVendor.UNKNOWN
+    assert ctrl.apply_config(config) is False
+    assert ctrl.reset_config() is False
+
+
+def test_gpu_detection_info_and_counts(monkeypatch):
+    monkeypatch.setattr(gpu, "_detect_amd_gpu", lambda: "gfx942")
+    assert gpu.detect_gpu() == (GPUVendor.AMD, "gfx942")
+    assert gpu.get_gpu_info()["compiler"] == "hipcc"
+    monkeypatch.setattr(gpu, "_detect_amd_gpu", lambda: None)
+    monkeypatch.setattr(gpu, "_detect_nvidia_gpu", lambda: "sm_90")
+    assert gpu.detect_gpu() == (GPUVendor.NVIDIA, "sm_90")
+    assert gpu.get_gpu_info()["compiler"] == "nvcc"
+    monkeypatch.setattr(gpu, "_detect_nvidia_gpu", lambda: None)
+    assert gpu.detect_gpu() == (GPUVendor.UNKNOWN, None)
+
+    responses = iter(
+        [
+            subprocess.CompletedProcess([], 0, stdout="1\n1\n"),
+            subprocess.CompletedProcess([], 1, stdout=""),
+            subprocess.CompletedProcess([], 0, stdout="GPU[0]\nGPU[1]\nGPU[1]"),
+        ]
+    )
+    monkeypatch.setattr(gpu.subprocess, "run", lambda *a, **k: next(responses))
+    assert gpu.get_gpu_count() == 2
+    assert gpu.get_gpu_count() == 2
+
+
+def test_low_level_detection_parsers(monkeypatch):
+    monkeypatch.setattr(
+        gpu.subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd, 0, stdout="Name: gfx950" if cmd[0] == "rocminfo" else "9.0\n"
+        ),
+    )
+    assert gpu._detect_amd_gpu() == "gfx950"
+    assert gpu._detect_nvidia_gpu() == "sm_90"
+
+
+def test_busy_and_memory_parsers(monkeypatch):
+    outputs = {
+        "--showpidgpus": "PID 10\n10 device(s): 0 2\n",
+        "--showmeminfo": f"device,total,used\nGPU[0],{8 * 1024**3},{2 * 1024**3}\n",
+        "--query-gpu=index,uuid": "0, GPU-a\n1, GPU-b\n",
+        "--query-compute-apps=gpu_uuid,pid": "GPU-b, 123\n",
+        "--query-gpu=index,memory.used,memory.total": "0, 1024, 8192\n",
+    }
+
+    def run(cmd, **kwargs):
+        key = next(key for key in outputs if key in " ".join(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout=outputs[key])
+
+    monkeypatch.setattr(gpu.subprocess, "run", run)
+    assert gpu._amd_busy_gpu_ids() == {0, 2}
+    assert gpu._amd_gpu_memory_usage()[0] == (2, 8)
+    assert gpu._nvidia_busy_gpu_ids() == {1}
+    assert gpu._nvidia_gpu_memory_usage()[0] == (1, 8)
+
+
+def test_find_idle_gpus_paths(monkeypatch):
+    monkeypatch.setattr(gpu, "detect_gpu", lambda: (GPUVendor.AMD, "gfx942"))
+    monkeypatch.setattr(gpu, "get_gpu_count", lambda: 3)
+    monkeypatch.setattr(gpu, "_amd_busy_gpu_ids", lambda: {1})
+    monkeypatch.setattr(
+        gpu,
+        "_amd_gpu_memory_usage",
+        lambda: {0: (2, 8), 1: (1, 8), 2: (7.5, 8)},
+    )
+    assert gpu.find_idle_gpus(1) == [0]
+    assert gpu.find_idle_gpus(0) == []
+    with pytest.raises(RuntimeError, match="no idle"):
+        gpu.find_idle_gpus(1, min_free_memory_gb=7)
+    monkeypatch.setattr(gpu, "get_gpu_count", lambda: 0)
+    with pytest.raises(RuntimeError, match="no GPUs"):
+        gpu.find_idle_gpus()
+
+
+def test_find_idle_gpus_nvidia_candidates_shortage_and_vendor(monkeypatch):
+    monkeypatch.setattr(gpu, "detect_gpu", lambda: (GPUVendor.NVIDIA, "sm_90"))
+    monkeypatch.setattr(gpu, "get_gpu_count", lambda: 4)
+    monkeypatch.setattr(gpu, "_nvidia_busy_gpu_ids", lambda: {1})
+    monkeypatch.setattr(
+        gpu,
+        "_nvidia_gpu_memory_usage",
+        lambda: {0: (7, 8), 1: (0, 8), 2: (2, 8), 3: (1, 8)},
+    )
+    assert gpu.find_idle_gpus(3, min_free_memory_gb=2, candidates=[-1, 0, 1, 2, 9]) == [
+        2
+    ]
+    monkeypatch.setattr(gpu, "detect_gpu", lambda: (GPUVendor.UNKNOWN, ""))
+    with pytest.raises(RuntimeError, match="unsupported"):
+        gpu.find_idle_gpus()
+
+
+@pytest.mark.parametrize(
+    "helper", ["amd_busy", "amd_memory", "nvidia_busy", "nvidia_memory"]
+)
+def test_gpu_process_memory_helpers_command_failures(monkeypatch, helper):
+    if helper == "nvidia_busy":
+        monkeypatch.setattr(
+            gpu.subprocess,
+            "run",
+            lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()),
+        )
+        assert gpu._nvidia_busy_gpu_ids() == set()
+    elif helper == "nvidia_memory":
+        monkeypatch.setattr(
+            gpu.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a[0], 1, stdout=""),
+        )
+        assert gpu._nvidia_gpu_memory_usage() == {}
+    elif helper == "amd_busy":
+        monkeypatch.setattr(
+            gpu.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                a[0], 0, stdout="No KFD PIDs currently running"
+            ),
+        )
+        assert gpu._amd_busy_gpu_ids() == set()
+    else:
+        monkeypatch.setattr(
+            gpu.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                a[0], 0, stdout="device,total,used\ninvalid\nGPU[x],1,1\nGPU[0],bad,1\n"
+            ),
+        )
+        assert gpu._amd_gpu_memory_usage() == {}
+
+
+class FakeController:
+    def __init__(self, device_id):
+        self.device_id = device_id
+
+    def get_hardware_info(self):
+        return GPUHardwareInfo(GPUVendor.AMD, device_id=self.device_id)
+
+    def apply_config(self, _config):
+        return True
+
+    def reset_config(self):
+        return True
+
+
+def test_multi_gpu_configuration_and_controller(monkeypatch, capsys):
+    monkeypatch.setattr(gpu, "get_gpu_count", lambda: 2)
+    monkeypatch.setattr(gpu, "GPUController", FakeController)
+    controller = MultiGPUController()
+    assert set(controller.get_all_hardware_info(parallel=False)) == {0, 1}
+    config = MultiGPUConfig(
+        default_config=GPUConfig(power_limit_watts=300), parallel=False
+    )
+    assert config.get_config_for_device(1).device_id == 1
+    assert controller.apply_config(config) == {0: True, 1: True}
+    assert controller.reset_all(parallel=False) == {0: True, 1: True}
+    controller.print_summary()
+    assert "GPU Summary" in capsys.readouterr().out
+
+
+def test_multi_gpu_parallel_paths_invalid_devices_and_errors(monkeypatch):
+    class SometimesBroken(FakeController):
+        def get_hardware_info(self):
+            if self.device_id == 1:
+                raise RuntimeError("query failed")
+            return super().get_hardware_info()
+
+        def apply_config(self, config):
+            return self.device_id == 0
+
+    monkeypatch.setattr(gpu, "get_gpu_count", lambda: 2)
+    monkeypatch.setattr(gpu, "GPUController", SometimesBroken)
+    controller = MultiGPUController(device_ids=[-1, 0, 1, 5])
+    infos = controller.get_all_hardware_info(parallel=True)
+    assert infos[1].vendor is GPUVendor.UNKNOWN
+    config = MultiGPUConfig(
+        default_config=GPUConfig(power_limit_watts=300),
+        device_ids=[0, 1, 5],
+        parallel=True,
+    )
+    assert controller.apply_config(config) == {0: True, 1: False, 5: False}
+    assert controller.reset_all(parallel=True) == {0: True, 1: True}
+    assert MultiGPUConfig().get_config_for_device(0) is None
+
+
+def test_list_gpus_empty_and_populated(monkeypatch):
+    monkeypatch.setattr(gpu, "get_gpu_count", lambda: 0)
+    assert gpu.list_gpus() == []
+    monkeypatch.setattr(gpu, "get_gpu_count", lambda: 2)
+    monkeypatch.setattr(gpu, "GPUController", FakeController)
+    assert [info.device_id for info in gpu.list_gpus()] == [0, 1]
+
+
+def test_load_gpu_config_and_reset_default(monkeypatch):
+    monkeypatch.setattr(gpu, "get_gpu_count", lambda: 2)
+    assert gpu.load_gpu_config_from_dict({}) == ([0, 1], None)
+    config = {
+        "gpu": {
+            "device_ids": [0, 1],
+            "parallel": False,
+            "hardware": {
+                "enabled": True,
+                "reset_after_benchmark": False,
+                "default": {
+                    "power": {"limit_watts": 300},
+                    "frequency": {
+                        "gpu_clock_mhz": [1000, 1200],
+                        "mem_clock_mhz": [800, 900],
+                    },
+                },
+                "per_gpu": {"1": {"power": {"limit_watts": 250}}},
+            },
+        }
+    }
+    devices, multi = gpu.load_gpu_config_from_dict(config)
+    assert devices == [0, 1]
+    assert multi.default_config.gpu_clock_mhz == (1000, 1200)
+    assert multi.gpu_configs[1].power_limit_watts == 250
+    assert gpu.get_reset_after_benchmark(config) is False
+    assert gpu.get_reset_after_benchmark({}) is True


### PR DESCRIPTION
## Summary

- raise whole-package unit test coverage to 90.04% without requiring GPU hardware
- organize tests by core, evaluation, MCP, benchmark modes, CLI, and GPU utilities
- add a reusable `make coverage` command with a strict 90% coverage gate
- add GitHub Actions jobs for Python 3.10 compatibility and Python 3.12 coverage
- constrain the MCP optional dependency to `mcp>=1.0.0,<2` because the current integration uses the MCP 1.x FastMCP import path

## Test coverage

- 378 tests pass
- 90.04% whole-package statement coverage
- 212 net new executable test cases compared with the initial 166-test baseline
- GPU, Docker, Ray, TraceLens CLI, and external process interactions are isolated with mocks/fakes, so CI does not require a GPU

## CI

- `Python 3.10 / tests`: runs the complete test suite on the minimum supported Python version
- `Python 3.12 / coverage`: runs the complete suite and enforces `--cov-fail-under=90`
- runs on pushes to `main` and `test/**`, pull requests targeting `main`, and manual dispatch

Latest validation: [GitHub Actions run 32337480865](https://github.com/AMD-AGI/Magpie/actions/runs/32337480865) — both jobs passed.
