### PR TITLE
Add e2e benchmark github action

### DIFF
--- a/.github/workflows/benchmark-e2e-cd.yml
+++ b/.github/workflows/benchmark-e2e-cd.yml
@@ -7,7 +7,7 @@ on:
       - "examples/benchmarks/**/*.yaml"
       - "examples/benchmarks/**/*.yml"
       - "scripts/ci/run_changed_benchmarks.py"
-      - ".github/workflows/benchmark-examples-cd.yml"
+      - ".github/workflows/benchmark-e2e-cd.yml"
   workflow_dispatch:
     inputs:
       config:

--- a/.github/workflows/benchmark-e2e-cd.yml
+++ b/.github/workflows/benchmark-e2e-cd.yml
@@ -84,9 +84,18 @@ jobs:
   benchmark:
     name: Run ${{ matrix.config }} on ${{ matrix.runner }}
     if: >-
-      github.event_name != 'pull_request' &&
-      needs.validate.outputs.has-benchmarks == 'true'
+      needs.validate.outputs.has-benchmarks == 'true' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          vars.MI355X_PR_BENCHMARK_ENABLED == 'true'
+        )
+      )
     needs: validate
+    environment:
+      name: mi355x-benchmark
     strategy:
       fail-fast: false
       max-parallel: 2

--- a/.github/workflows/benchmark-examples-cd.yml
+++ b/.github/workflows/benchmark-examples-cd.yml
@@ -1,4 +1,4 @@
-name: Benchmark examples end-to-end CD
+name: Benchmark E2E CD Pipeline
 
 on:
   pull_request:

--- a/.github/workflows/benchmark-examples-cd.yml
+++ b/.github/workflows/benchmark-examples-cd.yml
@@ -116,6 +116,9 @@ jobs:
           .benchmark-venv/bin/python -m pip install --upgrade pip
           .benchmark-venv/bin/python -m pip install -e .
 
+      - name: Prepare persistent Hugging Face cache
+        run: mkdir -p "$HOME/.cache/huggingface"
+
       - name: Run selected benchmark config
         env:
           CONFIG: ${{ matrix.config }}

--- a/.github/workflows/benchmark-examples-cd.yml
+++ b/.github/workflows/benchmark-examples-cd.yml
@@ -9,7 +9,7 @@ on:
       - "scripts/ci/run_changed_benchmarks.py"
       - ".github/workflows/benchmark-examples-cd.yml"
   push:
-    branches: [main]
+    branches: [main, e2e-cd]
     paths:
       - "examples/benchmarks/**/*.yaml"
       - "examples/benchmarks/**/*.yml"

--- a/.github/workflows/benchmark-examples-cd.yml
+++ b/.github/workflows/benchmark-examples-cd.yml
@@ -1,0 +1,138 @@
+name: Benchmark examples end-to-end CD
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "examples/benchmarks/**/*.yaml"
+      - "examples/benchmarks/**/*.yml"
+      - "scripts/ci/run_changed_benchmarks.py"
+      - ".github/workflows/benchmark-examples-cd.yml"
+  push:
+    branches: [main]
+    paths:
+      - "examples/benchmarks/**/*.yaml"
+      - "examples/benchmarks/**/*.yml"
+  workflow_dispatch:
+    inputs:
+      config:
+        description: "Optional benchmark example YAML path; empty means changed files"
+        required: false
+        type: string
+      base:
+        description: "Base revision when config is empty"
+        required: false
+        default: "origin/main"
+        type: string
+
+concurrency:
+  group: benchmark-examples-cd-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Detect and validate changed configs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+      has-benchmarks: ${{ steps.select.outputs.has_benchmarks }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install YAML dependency
+        run: python -m pip install PyYAML
+
+      - name: Validate configs and select hardware runners
+        id: select
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CONFIG: ${{ inputs.config }}
+          BASE: ${{ inputs.base }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BASE: ${{ github.event.before }}
+          PUSH_HEAD: ${{ github.sha }}
+        run: |
+          case "$EVENT_NAME" in
+            pull_request)
+              ARGS=(--base "$PR_BASE" --head "$PR_HEAD")
+              ;;
+            push)
+              ARGS=(--base "$PUSH_BASE" --head "$PUSH_HEAD")
+              ;;
+            workflow_dispatch)
+              if [[ -n "$CONFIG" ]]; then
+                ARGS=("$CONFIG")
+              else
+                ARGS=(--base "$BASE" --head HEAD)
+              fi
+              ;;
+          esac
+          python scripts/ci/run_changed_benchmarks.py "${ARGS[@]}" \
+            --output-dir benchmark-ci-results \
+            --github-output "$GITHUB_OUTPUT" \
+            --dry-run
+
+      - name: Publish validation summary
+        if: always()
+        run: cat benchmark-ci-results/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+  benchmark:
+    name: Run ${{ matrix.config }} on ${{ matrix.runner }}
+    if: >-
+      github.event_name != 'pull_request' &&
+      needs.validate.outputs.has-benchmarks == 'true'
+    needs: validate
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.validate.outputs.matrix) }}
+    runs-on: [self-hosted, linux, "${{ matrix.runner }}"]
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Create isolated Python environment
+        run: |
+          python3 -m venv .benchmark-venv
+          .benchmark-venv/bin/python -m pip install --upgrade pip
+          .benchmark-venv/bin/python -m pip install -e .
+
+      - name: Run selected benchmark config
+        env:
+          CONFIG: ${{ matrix.config }}
+        run: >-
+          .benchmark-venv/bin/python scripts/ci/run_changed_benchmarks.py
+          "$CONFIG"
+          --output-dir benchmark-ci-results
+
+      - name: Publish benchmark summary
+        if: always()
+        run: cat benchmark-ci-results/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-example-results-${{ github.run_id }}-${{ matrix.id }}
+          path: benchmark-ci-results/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/benchmark-examples-cd.yml
+++ b/.github/workflows/benchmark-examples-cd.yml
@@ -99,7 +99,7 @@ jobs:
     needs: validate
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix: ${{ fromJSON(needs.validate.outputs.matrix) }}
     runs-on: [self-hosted, linux, "${{ matrix.runner }}"]
     timeout-minutes: 360

--- a/.github/workflows/benchmark-examples-cd.yml
+++ b/.github/workflows/benchmark-examples-cd.yml
@@ -8,11 +8,6 @@ on:
       - "examples/benchmarks/**/*.yml"
       - "scripts/ci/run_changed_benchmarks.py"
       - ".github/workflows/benchmark-examples-cd.yml"
-  push:
-    branches: [main, e2e-cd]
-    paths:
-      - "examples/benchmarks/**/*.yaml"
-      - "examples/benchmarks/**/*.yml"
   workflow_dispatch:
     inputs:
       config:
@@ -64,15 +59,10 @@ jobs:
           BASE: ${{ inputs.base }}
           PR_BASE: ${{ github.event.pull_request.base.sha }}
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
-          PUSH_BASE: ${{ github.event.before }}
-          PUSH_HEAD: ${{ github.sha }}
         run: |
           case "$EVENT_NAME" in
             pull_request)
               ARGS=(--base "$PR_BASE" --head "$PR_HEAD")
-              ;;
-            push)
-              ARGS=(--base "$PUSH_BASE" --head "$PUSH_HEAD")
               ;;
             workflow_dispatch)
               if [[ -n "$CONFIG" ]]; then

--- a/examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_dsr1_mxfp4.yaml
+++ b/examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_dsr1_mxfp4.yaml
@@ -25,6 +25,11 @@ benchmark:
     SGLANG_USE_AITER: 1
     EXTRA_SGLANG_ARGS: "--kv-cache-dtype fp8_e4m3"
 
+  # This benchmark intentionally consumes the complete 8-GPU MI355X node.
+  # Skip idle-GPU auto-selection so every device remains visible to Docker.
+  gpu_selection:
+    auto: false
+
   # Profiler configuration
   profiler:
     torch_profiler:

--- a/examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_dsr1_mxfp4.yaml
+++ b/examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_dsr1_mxfp4.yaml
@@ -6,6 +6,7 @@
 #
 # Usage (Local - run directly on host, e.g. inside a pod):
 #   python -m Magpie benchmark --benchmark-config examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_dsr1_mxfp4.yaml --run-mode local
+# CD smoke test: exercise changed-config detection on the e2e-cd branch.
 
 benchmark:
   framework: sglang

--- a/examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_dsr1_mxfp4.yaml
+++ b/examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_dsr1_mxfp4.yaml
@@ -6,8 +6,6 @@
 #
 # Usage (Local - run directly on host, e.g. inside a pod):
 #   python -m Magpie benchmark --benchmark-config examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_dsr1_mxfp4.yaml --run-mode local
-# CD smoke test: exercise changed-config detection on the e2e-cd branch.
-
 benchmark:
   framework: sglang
   model: amd/DeepSeek-R1-0528-MXFP4-v2

--- a/examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_dsr1_mxfp4.yaml
+++ b/examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_dsr1_mxfp4.yaml
@@ -6,6 +6,7 @@
 #
 # Usage (Local - run directly on host, e.g. inside a pod):
 #   python -m Magpie benchmark --benchmark-config examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_dsr1_mxfp4.yaml --run-mode local
+
 benchmark:
   framework: sglang
   model: amd/DeepSeek-R1-0528-MXFP4-v2
@@ -23,7 +24,6 @@ benchmark:
     SGLANG_USE_AITER: 1
     EXTRA_SGLANG_ARGS: "--kv-cache-dtype fp8_e4m3"
 
-  # This benchmark intentionally consumes the complete 8-GPU MI355X node.
   # Skip idle-GPU auto-selection so every device remains visible to Docker.
   gpu_selection:
     auto: false

--- a/scripts/ci/run_changed_benchmarks.py
+++ b/scripts/ci/run_changed_benchmarks.py
@@ -99,6 +99,25 @@ def _slug(path: Path) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]+", "-", path.with_suffix("").as_posix())
 
 
+def _run_and_tee(command: list[str], log_path: Path) -> int:
+    """Run a command while streaming combined output to stdout and a log file."""
+    with log_path.open("w", encoding="utf-8") as log:
+        with subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        ) as proc:
+            if proc.stdout is None:
+                raise RuntimeError("benchmark process stdout pipe was not created")
+            for line in proc.stdout:
+                print(line, end="", flush=True)
+                log.write(line)
+                log.flush()
+            return proc.wait()
+
+
 def _latest_report(output_dir: Path) -> Path | None:
     reports = sorted(
         output_dir.glob("benchmark_*/benchmark_report.json"),
@@ -205,10 +224,7 @@ def run_configs(
             "--output-dir",
             str(config_output),
         ]
-        with log_path.open("w", encoding="utf-8") as log:
-            proc = subprocess.run(
-                command, stdout=log, stderr=subprocess.STDOUT, text=True
-            )
+        returncode = _run_and_tee(command, log_path)
 
         report_path = _latest_report(config_output)
         if report_path:
@@ -217,10 +233,10 @@ def run_configs(
                 entry["report_path"] = str(report_path)
             except (OSError, json.JSONDecodeError) as exc:
                 entry["error"] = f"cannot read benchmark report: {exc}"
-        if proc.returncode == 0 and entry.get("report", {}).get("success") is True:
+        if returncode == 0 and entry.get("report", {}).get("success") is True:
             entry["status"] = "PASSED"
         else:
-            entry.setdefault("error", f"benchmark exited with code {proc.returncode}")
+            entry.setdefault("error", f"benchmark exited with code {returncode}")
         results.append(entry)
 
     (output_root / "results.json").write_text(

--- a/scripts/ci/run_changed_benchmarks.py
+++ b/scripts/ci/run_changed_benchmarks.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Run added or modified benchmark example YAML files and summarize results."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+BENCHMARK_ROOT = Path("examples/benchmarks")
+BENCHMARK_SUFFIXES = {".yaml", ".yml"}
+RUNNER_BY_GPU_ARCH = {"gfx950": "mi355x"}
+
+
+def _git_lines(*args: str) -> list[str]:
+    proc = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def is_benchmark_example(path: Path) -> bool:
+    try:
+        path.relative_to(BENCHMARK_ROOT)
+    except ValueError:
+        return False
+    return path.suffix.lower() in BENCHMARK_SUFFIXES
+
+
+def discover_configs(
+    base: str | None,
+    head: str = "HEAD",
+    include_untracked: bool = False,
+) -> list[Path]:
+    """Return added/modified benchmark examples between two revisions."""
+    paths: set[Path] = set()
+    if base:
+        for name in _git_lines(
+            "diff",
+            "--name-only",
+            "--diff-filter=AMR",
+            base,
+            head,
+            "--",
+            str(BENCHMARK_ROOT),
+        ):
+            path = Path(name)
+            if is_benchmark_example(path) and path.is_file():
+                paths.add(path)
+
+    if include_untracked:
+        for name in _git_lines(
+            "ls-files", "--others", "--exclude-standard", "--", str(BENCHMARK_ROOT)
+        ):
+            path = Path(name)
+            if is_benchmark_example(path) and path.is_file():
+                paths.add(path)
+
+    return sorted(paths)
+
+
+def validate_config(path: Path) -> dict[str, Any]:
+    """Load a benchmark example and validate the fields needed by the CLI."""
+    if not is_benchmark_example(path):
+        raise ValueError(f"config is outside {BENCHMARK_ROOT}: {path}")
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("benchmark"), dict):
+        raise ValueError("missing top-level 'benchmark' mapping")
+    benchmark = data["benchmark"]
+    missing = [key for key in ("framework", "model") if not benchmark.get(key)]
+    if missing:
+        raise ValueError(f"missing required benchmark field(s): {', '.join(missing)}")
+    return benchmark
+
+
+def select_runner(benchmark: dict[str, Any]) -> str:
+    """Map an explicit benchmark hardware target to a GitHub runner label."""
+    runner_type = str(benchmark.get("runner_type", "")).lower()
+    if runner_type:
+        return runner_type if runner_type == "mi355x" else ""
+
+    gpu_arch = str(benchmark.get("gpu_arch", "")).lower()
+    if gpu_arch:
+        return RUNNER_BY_GPU_ARCH.get(gpu_arch, "")
+
+    return "mi355x"
+
+
+def _slug(path: Path) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", path.with_suffix("").as_posix())
+
+
+def _latest_report(output_dir: Path) -> Path | None:
+    reports = sorted(
+        output_dir.glob("benchmark_*/benchmark_report.json"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    return reports[0] if reports else None
+
+
+def _metric(report: dict[str, Any], group: str, key: str) -> Any:
+    value = report.get(group) or {}
+    return value.get(key, "") if isinstance(value, dict) else ""
+
+
+def _summary_table(results: Iterable[dict[str, Any]]) -> str:
+    rows = list(results)
+    lines = [
+        "# Changed benchmark results",
+        "",
+        "| Config | Model | Runner | Status | Requests/s | Output tokens/s | Mean TTFT (ms) | Mean TPOT (ms) |",
+        "|---|---|---|---:|---:|---:|---:|---:|",
+    ]
+    if not rows:
+        lines.append(
+            "| _No added or modified benchmark example YAML files_ | | | Skipped | | | | |"
+        )
+    for result in rows:
+        report = result.get("report") or {}
+        lines.append(
+            "| {config} | {model} | {runner} | {status} | {request_tp} | {output_tp} | "
+            "{ttft} | {tpot} |".format(
+                config=result["config"],
+                model=result.get("model", ""),
+                runner=result.get("runner", "unsupported"),
+                status=result["status"],
+                request_tp=_metric(report, "throughput", "request_throughput"),
+                output_tp=_metric(report, "throughput", "output_throughput"),
+                ttft=_metric(report, "latency", "ttft_mean"),
+                tpot=_metric(report, "latency", "tpot_mean"),
+            )
+        )
+    lines.append("")
+    for result in rows:
+        if result.get("error"):
+            lines.extend(
+                [f"## {result['config']}", "", f"Error: `{result['error']}`", ""]
+            )
+    return "\n".join(lines)
+
+
+def _write_github_matrix(results: list[dict[str, Any]], output_path: Path) -> None:
+    include = [
+        {
+            "config": result["config"],
+            "runner": result["runner"],
+            "id": _slug(Path(result["config"])),
+        }
+        for result in results
+        if result["status"] == "VALID" and result.get("runner")
+    ]
+    with output_path.open("a", encoding="utf-8") as output:
+        output.write(
+            f"matrix={json.dumps({'include': include}, separators=(',', ':'))}\n"
+        )
+        output.write(f"has_benchmarks={'true' if include else 'false'}\n")
+
+
+def run_configs(
+    configs: list[Path],
+    output_root: Path,
+    dry_run: bool,
+    github_output: Path | None = None,
+) -> int:
+    output_root.mkdir(parents=True, exist_ok=True)
+    results: list[dict[str, Any]] = []
+
+    for config in configs:
+        entry: dict[str, Any] = {"config": config.as_posix(), "status": "FAILED"}
+        try:
+            benchmark = validate_config(config)
+            entry["model"] = benchmark["model"]
+            entry["gpu_arch"] = benchmark.get("gpu_arch", "")
+            entry["runner"] = select_runner(benchmark)
+        except Exception as exc:
+            entry["error"] = f"invalid config: {exc}"
+            results.append(entry)
+            continue
+
+        if dry_run:
+            entry["status"] = "VALID"
+            results.append(entry)
+            continue
+
+        config_output = output_root / _slug(config)
+        config_output.mkdir(parents=True, exist_ok=True)
+        log_path = config_output / "runner.log"
+        command = [
+            sys.executable,
+            "-m",
+            "Magpie",
+            "benchmark",
+            "--benchmark-config",
+            str(config),
+            "--output-dir",
+            str(config_output),
+        ]
+        with log_path.open("w", encoding="utf-8") as log:
+            proc = subprocess.run(
+                command, stdout=log, stderr=subprocess.STDOUT, text=True
+            )
+
+        report_path = _latest_report(config_output)
+        if report_path:
+            try:
+                entry["report"] = json.loads(report_path.read_text(encoding="utf-8"))
+                entry["report_path"] = str(report_path)
+            except (OSError, json.JSONDecodeError) as exc:
+                entry["error"] = f"cannot read benchmark report: {exc}"
+        if proc.returncode == 0 and entry.get("report", {}).get("success") is True:
+            entry["status"] = "PASSED"
+        else:
+            entry.setdefault("error", f"benchmark exited with code {proc.returncode}")
+        results.append(entry)
+
+    (output_root / "results.json").write_text(
+        json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (output_root / "summary.md").write_text(_summary_table(results), encoding="utf-8")
+    if github_output:
+        _write_github_matrix(results, github_output)
+    return 1 if any(row["status"] == "FAILED" for row in results) else 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("configs", nargs="*", type=Path)
+    parser.add_argument("--base", help="base Git revision used for change detection")
+    parser.add_argument("--head", default="HEAD", help="head Git revision")
+    parser.add_argument("--include-untracked", action="store_true")
+    parser.add_argument("--output-dir", type=Path, default=Path("benchmark-ci-results"))
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="write the selected runner matrix to a GitHub Actions output file",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="validate without GPU execution"
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    configs = list(args.configs)
+    if not configs:
+        configs = discover_configs(args.base, args.head, args.include_untracked)
+    invalid_paths = [path for path in configs if not is_benchmark_example(path)]
+    if invalid_paths:
+        print(
+            f"Refusing non-example config(s): {', '.join(map(str, invalid_paths))}",
+            file=sys.stderr,
+        )
+        return 2
+    print("Benchmark configs:", *(str(path) for path in configs), sep="\n  ")
+    return run_configs(
+        sorted(set(configs)), args.output_dir, args.dry_run, args.github_output
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_changed_benchmarks.py
+++ b/scripts/ci/run_changed_benchmarks.py
@@ -127,9 +127,22 @@ def _latest_report(output_dir: Path) -> Path | None:
     return reports[0] if reports else None
 
 
-def _metric(report: dict[str, Any], group: str, key: str) -> Any:
-    value = report.get(group) or {}
-    return value.get(key, "") if isinstance(value, dict) else ""
+def _metric(report: dict[str, Any], *path: str) -> Any:
+    """Read a metric from a nested benchmark report."""
+    value: Any = report
+    for key in path:
+        if not isinstance(value, dict):
+            return ""
+        value = value.get(key)
+    return "" if value is None else value
+
+
+def _mean_latency(report: dict[str, Any], metric: str) -> Any:
+    """Read current nested latency metrics, with legacy flat-report fallback."""
+    value = _metric(report, "latency", metric, "mean_ms")
+    if value != "":
+        return value
+    return _metric(report, "latency", f"{metric}_mean")
 
 
 def _summary_table(results: Iterable[dict[str, Any]]) -> str:
@@ -155,8 +168,8 @@ def _summary_table(results: Iterable[dict[str, Any]]) -> str:
                 status=result["status"],
                 request_tp=_metric(report, "throughput", "request_throughput"),
                 output_tp=_metric(report, "throughput", "output_throughput"),
-                ttft=_metric(report, "latency", "ttft_mean"),
-                tpot=_metric(report, "latency", "tpot_mean"),
+                ttft=_mean_latency(report, "ttft"),
+                tpot=_mean_latency(report, "tpot"),
             )
         )
     lines.append("")

--- a/tests/test_changed_benchmarks_ci.py
+++ b/tests/test_changed_benchmarks_ci.py
@@ -1,0 +1,145 @@
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "ci" / "run_changed_benchmarks.py"
+SPEC = importlib.util.spec_from_file_location("run_changed_benchmarks", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def _config(
+    path: Path, model: str = "org/model", gpu_arch: str | None = "gfx950"
+) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    contents = f"benchmark:\n  framework: sglang\n  model: {model}\n"
+    if gpu_arch is not None:
+        contents += f"  gpu_arch: {gpu_arch}\n"
+    path.write_text(contents)
+    return path
+
+
+def test_discover_configs_includes_only_added_modified_examples(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    changed = _config(tmp_path / "examples/benchmarks/changed.yaml")
+    untracked = _config(tmp_path / "examples/benchmarks/nested/new.yml")
+    ignored = _config(tmp_path / "elsewhere/not-an-example.yaml")
+
+    def fake_git(*args):
+        if args[0] == "diff":
+            return [
+                str(changed.relative_to(tmp_path)),
+                str(ignored.relative_to(tmp_path)),
+            ]
+        return [str(untracked.relative_to(tmp_path))]
+
+    monkeypatch.setattr(MODULE, "_git_lines", fake_git)
+    assert MODULE.discover_configs("base", include_untracked=True) == [
+        changed.relative_to(tmp_path),
+        untracked.relative_to(tmp_path),
+    ]
+
+
+def test_run_configs_dry_run_validates_and_writes_summary(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    config = _config(tmp_path / "examples/benchmarks/example.yaml")
+    output = tmp_path / "results"
+
+    assert MODULE.run_configs([config.relative_to(tmp_path)], output, dry_run=True) == 0
+    results = json.loads((output / "results.json").read_text())
+    assert results[0]["status"] == "VALID"
+    assert results[0]["runner"] == "mi355x"
+    assert "org/model" in (output / "summary.md").read_text()
+
+
+def test_run_configs_executes_benchmark_and_summarizes_report(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    config = _config(tmp_path / "examples/benchmarks/example.yaml")
+    output = tmp_path / "results"
+
+    def fake_run(command, **kwargs):
+        config_output = Path(command[command.index("--output-dir") + 1])
+        workspace = config_output / "benchmark_sglang_20260825_120000"
+        workspace.mkdir(parents=True)
+        (workspace / "benchmark_report.json").write_text(
+            json.dumps(
+                {
+                    "success": True,
+                    "throughput": {
+                        "request_throughput": 12.5,
+                        "output_throughput": 6400.0,
+                    },
+                    "latency": {"ttft_mean": 20.0, "tpot_mean": 4.0},
+                }
+            )
+        )
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(MODULE.subprocess, "run", fake_run)
+    assert (
+        MODULE.run_configs([config.relative_to(tmp_path)], output, dry_run=False) == 0
+    )
+    results = json.loads((output / "results.json").read_text())
+    assert results[0]["status"] == "PASSED"
+    assert "12.5" in (output / "summary.md").read_text()
+
+
+def test_github_matrix_only_schedules_supported_hardware(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    mi355x = _config(tmp_path / "examples/benchmarks/mi355x.yaml")
+    unsupported = _config(
+        tmp_path / "examples/benchmarks/mi300x.yaml", gpu_arch="gfx942"
+    )
+    output = tmp_path / "results"
+    github_output = tmp_path / "github-output"
+
+    assert (
+        MODULE.run_configs(
+            [mi355x.relative_to(tmp_path), unsupported.relative_to(tmp_path)],
+            output,
+            dry_run=True,
+            github_output=github_output,
+        )
+        == 0
+    )
+    lines = dict(line.split("=", 1) for line in github_output.read_text().splitlines())
+    matrix = json.loads(lines["matrix"])
+    assert lines["has_benchmarks"] == "true"
+    assert matrix["include"] == [
+        {
+            "config": "examples/benchmarks/mi355x.yaml",
+            "runner": "mi355x",
+            "id": "examples-benchmarks-mi355x",
+        }
+    ]
+
+
+def test_missing_hardware_target_defaults_to_mi355x(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    config = _config(
+        tmp_path / "examples/benchmarks/default.yaml", gpu_arch=None
+    ).relative_to(tmp_path)
+
+    assert MODULE.select_runner(MODULE.validate_config(config)) == "mi355x"
+
+
+@pytest.mark.parametrize(
+    "contents,error",
+    [
+        ("framework: sglang\n", "top-level 'benchmark'"),
+        ("benchmark:\n  framework: sglang\n", "model"),
+    ],
+)
+def test_validate_config_rejects_invalid_examples(
+    monkeypatch, tmp_path, contents, error
+):
+    monkeypatch.chdir(tmp_path)
+    config = tmp_path / "examples/benchmarks/invalid.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text(contents)
+    with pytest.raises(ValueError, match=error):
+        MODULE.validate_config(config.relative_to(tmp_path))

--- a/tests/test_changed_benchmarks_ci.py
+++ b/tests/test_changed_benchmarks_ci.py
@@ -113,7 +113,10 @@ def test_run_configs_executes_benchmark_and_summarizes_report(monkeypatch, tmp_p
                         "request_throughput": 12.5,
                         "output_throughput": 6400.0,
                     },
-                    "latency": {"ttft_mean": 20.0, "tpot_mean": 4.0},
+                    "latency": {
+                        "ttft": {"mean_ms": 20.0},
+                        "tpot": {"mean_ms": 4.0},
+                    },
                 }
             )
         )
@@ -125,7 +128,29 @@ def test_run_configs_executes_benchmark_and_summarizes_report(monkeypatch, tmp_p
     )
     results = json.loads((output / "results.json").read_text())
     assert results[0]["status"] == "PASSED"
-    assert "12.5" in (output / "summary.md").read_text()
+    summary = (output / "summary.md").read_text()
+    assert "12.5" in summary
+    assert "20.0" in summary
+    assert "4.0" in summary
+
+
+def test_summary_supports_legacy_flat_latency_metrics():
+    summary = MODULE._summary_table(
+        [
+            {
+                "config": "examples/benchmarks/example.yaml",
+                "model": "org/model",
+                "runner": "mi355x",
+                "status": "PASSED",
+                "report": {
+                    "latency": {"ttft_mean": 21.0, "tpot_mean": 5.0},
+                },
+            }
+        ]
+    )
+
+    assert "21.0" in summary
+    assert "5.0" in summary
 
 
 def test_github_matrix_only_schedules_supported_hardware(monkeypatch, tmp_path):

--- a/tests/test_changed_benchmarks_ci.py
+++ b/tests/test_changed_benchmarks_ci.py
@@ -5,10 +5,28 @@ from pathlib import Path
 import pytest
 
 SCRIPT = Path(__file__).parents[1] / "scripts" / "ci" / "run_changed_benchmarks.py"
+WORKFLOW = (
+    Path(__file__).parents[1]
+    / ".github"
+    / "workflows"
+    / "benchmark-e2e-cd.yml"
+)
 SPEC = importlib.util.spec_from_file_location("run_changed_benchmarks", SCRIPT)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
+
+
+def test_gpu_job_requires_manual_dispatch_or_internal_pr_approval():
+    workflow = WORKFLOW.read_text()
+
+    assert "github.event_name == 'workflow_dispatch'" in workflow
+    assert (
+        "github.event.pull_request.head.repo.full_name == github.repository"
+        in workflow
+    )
+    assert "vars.MI355X_PR_BENCHMARK_ENABLED == 'true'" in workflow
+    assert "environment:\n      name: mi355x-benchmark" in workflow
 
 
 def _config(

--- a/tests/test_changed_benchmarks_ci.py
+++ b/tests/test_changed_benchmarks_ci.py
@@ -1,7 +1,6 @@
 import importlib.util
 import json
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -56,15 +55,38 @@ def test_run_configs_dry_run_validates_and_writes_summary(monkeypatch, tmp_path)
     assert "org/model" in (output / "summary.md").read_text()
 
 
+def test_run_and_tee_streams_and_saves_output(tmp_path, capsys):
+    log_path = tmp_path / "runner.log"
+
+    returncode = MODULE._run_and_tee(
+        [
+            MODULE.sys.executable,
+            "-c",
+            (
+                "import sys; print('live benchmark log', flush=True); "
+                "print('live benchmark error', file=sys.stderr, flush=True); "
+                "raise SystemExit(7)"
+            ),
+        ],
+        log_path,
+    )
+
+    expected = "live benchmark log\nlive benchmark error\n"
+    assert returncode == 7
+    assert capsys.readouterr().out == expected
+    assert log_path.read_text() == expected
+
+
 def test_run_configs_executes_benchmark_and_summarizes_report(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     config = _config(tmp_path / "examples/benchmarks/example.yaml")
     output = tmp_path / "results"
 
-    def fake_run(command, **kwargs):
+    def fake_run_and_tee(command, log_path):
         config_output = Path(command[command.index("--output-dir") + 1])
         workspace = config_output / "benchmark_sglang_20260825_120000"
         workspace.mkdir(parents=True)
+        log_path.write_text("streamed benchmark output\n")
         (workspace / "benchmark_report.json").write_text(
             json.dumps(
                 {
@@ -77,9 +99,9 @@ def test_run_configs_executes_benchmark_and_summarizes_report(monkeypatch, tmp_p
                 }
             )
         )
-        return SimpleNamespace(returncode=0)
+        return 0
 
-    monkeypatch.setattr(MODULE.subprocess, "run", fake_run)
+    monkeypatch.setattr(MODULE, "_run_and_tee", fake_run_and_tee)
     assert (
         MODULE.run_configs([config.relative_to(tmp_path)], output, dry_run=False) == 0
     )


### PR DESCRIPTION
## Summary

Add a GitHub Actions E2E CD pipeline for validating and manually running benchmark example configurations on MI355X self-hosted runners.

### Workflow behavior

- Validate changed benchmark YAML files on pull requests targeting `main`.
- Do not run GPU benchmarks during pull requests.
- Allow maintainers to manually run:
  - A specific benchmark YAML.
  - All benchmark YAML files changed from a selected base revision.
- Run up to two benchmark jobs concurrently when matching runners are available.

#### Trigger matrix
| Event | Behavior |
|---|---|
| Pull request to `main` | Validate benchmark configurations only |
| Manual `workflow_dispatch` | Validate and execute selected GPU benchmarks |

### Runner selection

Benchmark configurations are routed using the following rules:

- `runner_type: mi355x` → `mi355x`
- `gpu_arch: gfx950` → `mi355x`
- No `runner_type` or `gpu_arch` → default to `mi355x`
- Explicit unsupported hardware → validate the configuration without scheduling an MI355X job

Jobs run on runners matching:

```yaml
runs-on: [self-hosted, linux, mi355x]