### PR TITLE
Add DeepSeek V4 Pro SGLang benchmark for MI355X

### DIFF
--- a/examples/benchmarks/sglang_mi355x/benchmark_sglang_deepseek_v4_pro_mxfp4.yaml
+++ b/examples/benchmarks/sglang_mi355x/benchmark_sglang_deepseek_v4_pro_mxfp4.yaml
@@ -1,0 +1,71 @@
+# SGLang Benchmark Configuration for deepseek-ai/DeepSeek-V4-Pro
+# ================================================================
+#
+# Usage (Docker - default):
+#   python -m Magpie benchmark --benchmark-config examples/benchmarks/sglang_mi355x/benchmark_sglang_deepseek_v4_pro_mxfp4.yaml
+#
+# Usage (Local - run directly on host, e.g. inside a pod):
+#   python -m Magpie benchmark --benchmark-config examples/benchmarks/sglang_mi355x/benchmark_sglang_deepseek_v4_pro_mxfp4.yaml --run-mode local
+
+benchmark:
+  framework: sglang
+  model: deepseek-ai/DeepSeek-V4-Pro
+  precision: mxfp4
+  run_mode: docker
+  gpu_arch: gfx950
+
+  # Environment variables
+  envs:
+    TP: 8
+    CONC: 64
+    ISL: 1024
+    OSL: 1024
+    RANDOM_RANGE_RATIO: 1
+    SGLANG_USE_AITER: 1
+    SGLANG_DEFAULT_THINKING: 1
+    SGLANG_DSV4_REASONING_EFFORT: max
+    SGLANG_USE_ROCM700A: 0
+    SGLANG_HACK_FLASHMLA_BACKEND: unified_kv_triton
+    AITER_BF16_FP8_MOE_BOUND: 0
+    SGLANG_SHARED_EXPERT_TP1: 1
+    SGLANG_DP_SHARED_EXPERT_LOCAL: 1
+    SGLANG_DP_USE_GATHERV: 1
+    SGLANG_DP_USE_REDUCE_SCATTER: 1
+    GPU_MAX_HW_QUEUES: 5
+    EXTRA_SGLANG_ARGS: >-
+      --dp 8
+      --enable-dp-attention
+      --enable-prefill-delayer
+      --enable-two-batch-overlap
+      --attention-backend dsv4
+      --cuda-graph-max-bs 64
+      --max-running-requests 64
+      --mem-fraction-static 0.90
+      --swa-full-tokens-ratio 0.15
+      --page-size 256
+      --kv-cache-dtype fp8_e4m3
+      --context-length 8192
+      --chunked-prefill-size 8192
+      --disable-shared-experts-fusion
+      --tool-call-parser deepseekv4
+      --reasoning-parser deepseek-v4
+      --watchdog-timeout 1800
+
+  # Profiler configuration
+  profiler:
+    torch_profiler:
+      enabled: false
+    system_profiler:
+      enabled: false
+    tracelens:
+      enabled: false
+
+  docker_image: "lmsysorg/sglang-rocm:v0.5.16-rocm724-mi35x-20260805"
+  # hf_cache_path: ""
+  benchmark_script: "sglang_mi355x.sh"
+  timeout_seconds: 7200
+
+  gap_analysis:
+    enabled: false
+    top_k: 100
+    find_kernel_sources: false

--- a/examples/benchmarks/sglang_mi355x/benchmark_sglang_deepseek_v4_pro_mxfp4.yaml
+++ b/examples/benchmarks/sglang_mi355x/benchmark_sglang_deepseek_v4_pro_mxfp4.yaml
@@ -32,6 +32,8 @@ benchmark:
     SGLANG_DP_USE_GATHERV: 1
     SGLANG_DP_USE_REDUCE_SCATTER: 1
     GPU_MAX_HW_QUEUES: 5
+    # Keep the CUDA graph capture limit and active request limit aligned with
+    # the validated benchmark concurrency (CONC=64).
     EXTRA_SGLANG_ARGS: >-
       --dp 8
       --enable-dp-attention


### PR DESCRIPTION
## Summary

Add a Magpie SGLang benchmark configuration for `deepseek-ai/DeepSeek-V4-Pro` on MI355X.

## Configuration

- MXFP4, TP8 with DP attention
- AITER and the DSV4 attention backend
- FP8 E4M3 KV cache
- Common `sglang_mi355x.sh` launcher
- ISL/OSL 1024/1024 at concurrency 64

## Validation

The configuration successfully completed a benchmark run on 8x MI355X GPUs.