### PR TITLE
Bump IntelliKit pins to v0.1.1

### DIFF
--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -18,7 +18,7 @@ tested.
 - GPUs are verified using the bundled benchmark scripts in `Magpie/scripts/benchmark/`.
 - Python versions are declared in `pyproject.toml`; the minimum is 3.10.
 - MCP (`mcp`) is required only for the MCP server.
-- IntelliKit integrations are optional (pinned commit `3f45cd314d455b652a1246678511b40547fe521e`). 
+- IntelliKit integrations are optional (pinned commit `2f61453a779980b00504ea3b772ff4a1a1c3f4ad`). 
 
 ## Profilers and optional tools
 
@@ -27,8 +27,8 @@ The following profiling tools and optional packages extend Magpie's capabilities
 | Tool | Version | Notes |
 | --- | --- | --- |
 | `rocprof-compute` | >= 3.2.3 | AMD performance profiling. See the [install guide](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/install/core-install.html). |
-| IntelliKit Metrix | `3f45cd314d455b652a1246678511b40547fe521e` | Optional AMD profiling integration. Install with `.[metrix]` or `.[intellikit]`. |
-| IntelliKit Accordo | `3f45cd314d455b652a1246678511b40547fe521e` | Optional AMD correctness integration. Install with `.[accordo]` or `.[intellikit]`. |
+| IntelliKit Metrix | `2f61453a779980b00504ea3b772ff4a1a1c3f4ad` | Optional AMD profiling integration. Install with `.[metrix]` or `.[intellikit]`. |
+| IntelliKit Accordo | `2f61453a779980b00504ea3b772ff4a1a1c3f4ad` | Optional AMD correctness integration. Install with `.[accordo]` or `.[intellikit]`. |
 
 ```{note}
 The IntelliKit integrations (Accordo and Metrix) are optional/experimental. Magpie primarily relies on ROCm libraries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,14 +39,14 @@ mcp = [
 # IntelliKit components are pinned but optional because Accordo builds native
 # ROCm/HIP code and should not be required for a plain Magpie install.
 metrix = [
-    "metrix @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=metrix",
+    "metrix @ git+https://github.com/AMDResearch/intellikit.git@2f61453a779980b00504ea3b772ff4a1a1c3f4ad#subdirectory=metrix",
 ]
 accordo = [
-    "accordo @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=accordo",
+    "accordo @ git+https://github.com/AMDResearch/intellikit.git@2f61453a779980b00504ea3b772ff4a1a1c3f4ad#subdirectory=accordo",
 ]
 intellikit = [
-    "metrix @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=metrix",
-    "accordo @ git+https://github.com/AMDResearch/intellikit.git@3f45cd314d455b652a1246678511b40547fe521e#subdirectory=accordo",
+    "metrix @ git+https://github.com/AMDResearch/intellikit.git@2f61453a779980b00504ea3b772ff4a1a1c3f4ad#subdirectory=metrix",
+    "accordo @ git+https://github.com/AMDResearch/intellikit.git@2f61453a779980b00504ea3b772ff4a1a1c3f4ad#subdirectory=accordo",
 ]
 all = [
     "mcp>=1.0.0,<2",


### PR DESCRIPTION
Moves the pinned metrix and accordo commits to IntelliKit v0.1.1 (`2f61453a`), and updates the compatibility matrix to match.

Brings in ROCm 10 support and the test-coverage work.