### PR TITLE
Add Qwen3-Coder SGLang benchmarks

### DIFF
--- a/Magpie/modes/benchmark/benchmarker.py
+++ b/Magpie/modes/benchmark/benchmarker.py
@@ -649,7 +649,6 @@ class BenchmarkMode:
                 "--cap-add=CAP_SYS_ADMIN",
                 "--device=/dev/kfd",
                 "--device=/dev/dri",
-                "--device=/dev/mem",
                 "--cap-add=SYS_PTRACE",
                 "--security-opt", "seccomp=unconfined",
             ])

--- a/examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_qwen3_coder_480b_a35b_mxfp4.yaml
+++ b/examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_qwen3_coder_480b_a35b_mxfp4.yaml
@@ -1,0 +1,44 @@
+# SGLang Benchmark Configuration for amd/Qwen3-Coder-480B-A35B-Instruct-MXFP4
+# ====================================================
+#
+# Usage (Docker - default):
+#   python -m Magpie benchmark --benchmark-config examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_qwen3_coder_480b_a35b_mxfp4.yaml
+#
+# Usage (Local - run directly on host, e.g. inside a pod):
+#   python -m Magpie benchmark --benchmark-config examples/benchmarks/sglang_mi355x/benchmark_sglang_amd_qwen3_coder_480b_a35b_mxfp4.yaml --run-mode local
+
+benchmark:
+  framework: sglang
+  model: amd/Qwen3-Coder-480B-A35B-Instruct-MXFP4
+  precision: mxfp4
+  run_mode: docker
+  gpu_arch: gfx950
+
+  # Environment variables
+  envs:
+    TP: 4
+    CONC: 32
+    ISL: 1024
+    OSL: 1024
+    RANDOM_RANGE_RATIO: 0.8
+    SGLANG_USE_AITER: 1
+    EXTRA_SGLANG_ARGS: "--kv-cache-dtype fp8_e4m3"
+
+  # Profiler configuration
+  profiler:
+    torch_profiler:
+      enabled: false
+    system_profiler:
+      enabled: false
+    tracelens:
+      enabled: false
+
+  docker_image: "lmsysorg/sglang:v0.5.14-rocm720-mi35x"
+  # hf_cache_path: ""
+  benchmark_script: "sglang_mi355x.sh"
+  timeout_seconds: 7200
+
+  gap_analysis:
+    enabled: false
+    top_k: 100
+    find_kernel_sources: false

--- a/examples/benchmarks/sglang_mi355x/benchmark_sglang_qwen3_coder_480b_a35b_fp8.yaml
+++ b/examples/benchmarks/sglang_mi355x/benchmark_sglang_qwen3_coder_480b_a35b_fp8.yaml
@@ -16,7 +16,7 @@ benchmark:
 
   # Environment variables
   envs:
-    TP: 8
+    TP: 4
     CONC: 32
     ISL: 1024
     OSL: 1024
@@ -33,7 +33,7 @@ benchmark:
     tracelens:
       enabled: false
 
-  docker_image: "lmsysorg/sglang:v0.5.14-rocm720-mi35x"
+  docker_image: "lmsysorg/sglang:v0.5.18-rocm720-mi35x"
   # hf_cache_path: ""
   benchmark_script: "sglang_mi355x.sh"
   timeout_seconds: 7200

--- a/examples/benchmarks/sglang_mi355x/benchmark_sglang_qwen3_coder_480b_a35b_fp8.yaml
+++ b/examples/benchmarks/sglang_mi355x/benchmark_sglang_qwen3_coder_480b_a35b_fp8.yaml
@@ -1,0 +1,44 @@
+# SGLang Benchmark Configuration for Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
+# ====================================================
+#
+# Usage (Docker - default):
+#   python -m Magpie benchmark --benchmark-config examples/benchmarks/sglang_mi355x/benchmark_sglang_qwen3_coder_480b_a35b_fp8.yaml
+#
+# Usage (Local - run directly on host, e.g. inside a pod):
+#   python -m Magpie benchmark --benchmark-config examples/benchmarks/sglang_mi355x/benchmark_sglang_qwen3_coder_480b_a35b_fp8.yaml --run-mode local
+
+benchmark:
+  framework: sglang
+  model: Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
+  precision: fp8
+  run_mode: docker
+  gpu_arch: gfx950
+
+  # Environment variables
+  envs:
+    TP: 8
+    CONC: 32
+    ISL: 1024
+    OSL: 1024
+    RANDOM_RANGE_RATIO: 0.8
+    SGLANG_USE_AITER: 1
+    EXTRA_SGLANG_ARGS: "--kv-cache-dtype fp8_e4m3 --page-size 32"
+
+  # Profiler configuration
+  profiler:
+    torch_profiler:
+      enabled: false
+    system_profiler:
+      enabled: false
+    tracelens:
+      enabled: false
+
+  docker_image: "lmsysorg/sglang:v0.5.14-rocm720-mi35x"
+  # hf_cache_path: ""
+  benchmark_script: "sglang_mi355x.sh"
+  timeout_seconds: 7200
+
+  gap_analysis:
+    enabled: false
+    top_k: 100
+    find_kernel_sources: false

--- a/tests/unit/modes/test_benchmarker.py
+++ b/tests/unit/modes/test_benchmarker.py
@@ -383,6 +383,8 @@ def test_build_commands_and_script_resolution(monkeypatch, tmp_path):
     workspace.mkdir()
     docker = mode._build_docker_command("image:test", workspace, "mi300x")
     assert "--device=/dev/kfd" in docker
+    assert "--device=/dev/dri" in docker
+    assert "--device=/dev/mem" not in docker
     assert docker[-1].startswith("cd /opt/InferenceX")
 
     command, env = mode._build_local_command(


### PR DESCRIPTION
## Title

Add Qwen3-Coder 480B SGLang benchmark configurations for MI355X

## Summary

Add single-node SGLang benchmark configurations for Qwen3-Coder 480B A35B on MI355X:

- `amd/Qwen3-Coder-480B-A35B-Instruct-MXFP4`
- `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8`

Both configurations use TP4 and AITER kernels. The FP8 configuration also uses FP8 KV cache with a page size of 32.

## Configuration

- GPU: 4× MI355X
- Tensor parallelism: TP4
- AITER: enabled
- Workload: ISL/OSL 1024/1024, concurrency 32
- Random range ratio: 0.8
- FP8 KV cache: `fp8_e4m3`

## Validation

Both configurations successfully completed 320/320 benchmark requests.

| Model precision | Request throughput | Output throughput | Mean TTFT | Mean TPOT | Mean E2E |
|---|---:|---:|---:|---:|---:|
| MXFP4 | 1.93 req/s | 1,783.72 tok/s | 179.10 ms | 17.35 ms | 16.21 s |
| FP8 | 1.48 req/s | 1,363.58 tok/s | 229.74 ms | 22.69 ms | 21.18 s |