### PR TITLE
Fix eval concurrency argument compatibility

### DIFF
--- a/Magpie/scripts/benchmark/atom_mi300x.sh
+++ b/Magpie/scripts/benchmark/atom_mi300x.sh
@@ -144,7 +144,8 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
             echo "[atom_mi300x] RUN_EVAL=true with BENCHMARK_BASE_URL but magpie_run_eval_remote_direct shim not available; skipping eval (results gate will see accuracy=None)."
         fi
     else
-        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?
+        export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
+        run_eval --framework lm-eval --port "$PORT" || exit $?
         append_lm_eval_summary
     fi
 fi

--- a/Magpie/scripts/benchmark/atom_mi300x.sh
+++ b/Magpie/scripts/benchmark/atom_mi300x.sh
@@ -145,8 +145,12 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        run_eval --framework lm-eval --port "$PORT" || exit $?
-        append_lm_eval_summary
+        if declare -F magpie_run_eval_persisted &>/dev/null; then
+            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
+        else
+            run_eval --framework lm-eval --port "$PORT" || exit $?
+            append_lm_eval_summary
+        fi
     fi
 fi
 set +x

--- a/Magpie/scripts/benchmark/atom_mi300x.sh
+++ b/Magpie/scripts/benchmark/atom_mi300x.sh
@@ -22,7 +22,7 @@
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 # shellcheck source=magpie_bench_remote_compat.sh
-[[ -f "$(dirname "$0")/magpie_bench_remote_compat.sh" ]] && source "$(dirname "$0")/magpie_bench_remote_compat.sh"
+source "$(dirname "$0")/magpie_bench_remote_compat.sh"
 
 PHASE="${MAGPIE_RUN_PHASE:-all}"
 case "$PHASE" in
@@ -145,12 +145,7 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        if declare -F magpie_run_eval_persisted &>/dev/null; then
-            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
-        else
-            run_eval --framework lm-eval --port "$PORT" || exit $?
-            append_lm_eval_summary
-        fi
+        magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
     fi
 fi
 set +x

--- a/Magpie/scripts/benchmark/atom_mi355x.sh
+++ b/Magpie/scripts/benchmark/atom_mi355x.sh
@@ -18,7 +18,7 @@
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 # shellcheck source=magpie_bench_remote_compat.sh
-[[ -f "$(dirname "$0")/magpie_bench_remote_compat.sh" ]] && source "$(dirname "$0")/magpie_bench_remote_compat.sh"
+source "$(dirname "$0")/magpie_bench_remote_compat.sh"
 
 PHASE="${MAGPIE_RUN_PHASE:-all}"
 case "$PHASE" in
@@ -140,12 +140,7 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        if declare -F magpie_run_eval_persisted &>/dev/null; then
-            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
-        else
-            run_eval --framework lm-eval --port "$PORT" || exit $?
-            append_lm_eval_summary
-        fi
+        magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
     fi
 fi
 set +x

--- a/Magpie/scripts/benchmark/atom_mi355x.sh
+++ b/Magpie/scripts/benchmark/atom_mi355x.sh
@@ -140,8 +140,12 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        run_eval --framework lm-eval --port "$PORT" || exit $?
-        append_lm_eval_summary
+        if declare -F magpie_run_eval_persisted &>/dev/null; then
+            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
+        else
+            run_eval --framework lm-eval --port "$PORT" || exit $?
+            append_lm_eval_summary
+        fi
     fi
 fi
 set +x

--- a/Magpie/scripts/benchmark/atom_mi355x.sh
+++ b/Magpie/scripts/benchmark/atom_mi355x.sh
@@ -139,7 +139,8 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
             echo "[atom_mi355x] RUN_EVAL=true with BENCHMARK_BASE_URL but magpie_run_eval_remote_direct shim not available; skipping eval (results gate will see accuracy=None)."
         fi
     else
-        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?
+        export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
+        run_eval --framework lm-eval --port "$PORT" || exit $?
         append_lm_eval_summary
     fi
 fi

--- a/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
+++ b/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
@@ -167,8 +167,12 @@ magpie_run_eval_remote_direct() {
   if [[ $rc -ne 0 ]]; then
     echo "[magpie_bench_remote_compat] WARN lm_eval exited rc=$rc; accuracy gate will see no results" >&2
   fi
-  magpie_write_accuracy_result "$out_dir" "$rc" "$result_dir"
-  return $rc
+  local report_rc=0
+  magpie_write_accuracy_result "$out_dir" "$rc" "$result_dir" || report_rc=$?
+  if [[ $rc -ne 0 ]]; then
+    return "$rc"
+  fi
+  return "$report_rc"
 }
 
 ###############################################################################
@@ -316,12 +320,29 @@ magpie_run_eval_persisted() {
     echo "[magpie_bench_remote_compat] ERROR cannot prepare accuracy directories" >&2
     return 1
   }
+  raw_dir=$(cd "$raw_dir" && pwd -P) || return 1
 
   export EVAL_RESULT_DIR="$raw_dir"
+  local caller_dir="$PWD"
+  # InferenceX stages batched-concurrency results into PWD rather than
+  # EVAL_RESULT_DIR. Run from raw_dir so both single and batched evaluations
+  # have one source tree that can be copied without modifying the artifacts.
+  cd "$raw_dir" || return 1
   run_eval "$@" || eval_rc=$?
+  cd "$caller_dir" || return 1
 
-  _write_lm_eval_meta_json \
-    "$raw_dir/meta_env.json" "" "${CONC:-1}" || stage_rc=$?
+  if [[ -n "${EVAL_BATCHED_CONCS:-}" ]]; then
+    if declare -F append_lm_eval_summary &>/dev/null; then
+      (cd "$raw_dir" && append_lm_eval_summary) || stage_rc=$?
+    else
+      echo "[magpie_bench_remote_compat] ERROR append_lm_eval_summary is unavailable for batched eval" >&2
+      stage_rc=1
+    fi
+  else
+    _write_lm_eval_meta_json \
+      "$raw_dir/meta_env.json" "" \
+      "${EVAL_CONCURRENT_REQUESTS:-${CONC:-1}}" || stage_rc=$?
+  fi
 
   local source_file destination
   while IFS= read -r -d '' source_file; do

--- a/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
+++ b/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
@@ -167,7 +167,7 @@ magpie_run_eval_remote_direct() {
   if [[ $rc -ne 0 ]]; then
     echo "[magpie_bench_remote_compat] WARN lm_eval exited rc=$rc; accuracy gate will see no results" >&2
   fi
-  magpie_write_accuracy_result "$out_dir" "$rc"
+  magpie_write_accuracy_result "$out_dir" "$rc" "$result_dir"
   return $rc
 }
 
@@ -181,9 +181,10 @@ magpie_run_eval_remote_direct() {
 magpie_write_accuracy_result() {
   local eval_dir="$1"
   local eval_rc="${2:-0}"
+  local summary_dir="${3:-$eval_dir}"
   local py="${MAGPIE_EVAL_PYTHON:-python3}"
 
-  "$py" - "$eval_dir" "$eval_rc" <<'PY'
+  "$py" - "$eval_dir" "$eval_rc" "$summary_dir" <<'PY'
 import json
 import os
 import sys
@@ -192,7 +193,8 @@ from pathlib import Path
 
 root = Path(sys.argv[1])
 eval_rc = int(sys.argv[2])
-output = root / "accuracy_result.json"
+output_root = Path(sys.argv[3])
+output = output_root / "accuracy_result.json"
 priority = (
     "exact_match,strict-match",
     "exact_match,flexible-extract",
@@ -267,14 +269,19 @@ else:
             metric=metric,
             score=metrics.get(metric) if metric else None,
             samples=summary["tasks"][task]["samples"],
-            source_result=str(source.relative_to(root)),
+            source_result=None,
             error=None if eval_rc == 0 else f"lm-eval exited with code {eval_rc}",
         )
     else:
-        summary["source_result"] = str(source.relative_to(root))
+        summary["source_result"] = None
         summary["error"] = "lm-eval result contains no task metrics"
 
-root.mkdir(parents=True, exist_ok=True)
+    try:
+        summary["source_result"] = str(source.relative_to(output_root))
+    except ValueError:
+        summary["source_result"] = str(source)
+
+output_root.mkdir(parents=True, exist_ok=True)
 output.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 print(f"[magpie_bench_remote_compat] accuracy artifact: {output}", file=sys.stderr)
 PY
@@ -325,7 +332,7 @@ magpie_run_eval_persisted() {
     fi
   done < <(find "$raw_dir" -type f \( -name "*.json" -o -name "*.jsonl" \) -print0 2>/dev/null)
 
-  magpie_write_accuracy_result "$eval_dir" "$eval_rc" || stage_rc=$?
+  magpie_write_accuracy_result "$eval_dir" "$eval_rc" "$result_dir" || stage_rc=$?
   if [[ $eval_rc -ne 0 ]]; then
     return "$eval_rc"
   fi

--- a/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
+++ b/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
@@ -167,5 +167,156 @@ magpie_run_eval_remote_direct() {
   if [[ $rc -ne 0 ]]; then
     echo "[magpie_bench_remote_compat] WARN lm_eval exited rc=$rc; accuracy gate will see no results" >&2
   fi
+  magpie_write_accuracy_result "$out_dir" "$rc"
   return $rc
+}
+
+###############################################################################
+# magpie_write_accuracy_result
+#
+# Convert the newest standard lm-eval result into a small, stable Magpie
+# artifact. The raw lm-eval JSON remains alongside this file for consumers
+# that need the complete result schema.
+###############################################################################
+magpie_write_accuracy_result() {
+  local eval_dir="$1"
+  local eval_rc="${2:-0}"
+  local py="${MAGPIE_EVAL_PYTHON:-python3}"
+
+  "$py" - "$eval_dir" "$eval_rc" <<'PY'
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+root = Path(sys.argv[1])
+eval_rc = int(sys.argv[2])
+output = root / "accuracy_result.json"
+priority = (
+    "exact_match,strict-match",
+    "exact_match,flexible-extract",
+    "acc,none",
+    "acc",
+)
+
+candidates = []
+for path in root.rglob("*.json"):
+    if path == output:
+        continue
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        continue
+    if isinstance(payload, dict) and isinstance(payload.get("results"), dict):
+        candidates.append((path.stat().st_mtime, path, payload))
+
+summary = {
+    "schema_version": "1.0",
+    "provider": "lm-eval",
+    "status": "ERROR",
+    "task": None,
+    "metric": None,
+    "score": None,
+    "samples": None,
+    "source_result": None,
+    "tasks": {},
+    "error": None,
+    "created_at": datetime.now(timezone.utc).isoformat(),
+}
+
+if not candidates:
+    summary["error"] = (
+        f"lm-eval exited with code {eval_rc} and produced no result"
+        if eval_rc
+        else "lm-eval produced no result"
+    )
+else:
+    _, source, payload = max(candidates, key=lambda item: item[0])
+    sample_payload = payload.get("n-samples", {})
+    for task, task_result in payload["results"].items():
+        if not isinstance(task_result, dict):
+            continue
+        sample_info = sample_payload.get(task) if isinstance(sample_payload, dict) else None
+        if isinstance(sample_info, dict):
+            samples = sample_info.get("effective", sample_info.get("original"))
+        else:
+            samples = sample_info
+        metrics = {
+            key: value
+            for key, value in task_result.items()
+            if isinstance(value, (int, float)) and not isinstance(value, bool)
+        }
+        summary["tasks"][task] = {"metrics": metrics, "samples": samples}
+
+    if summary["tasks"]:
+        requested_tasks = [
+            item.strip()
+            for item in os.environ.get("MAGPIE_EVAL_TASKS", "").split(",")
+            if item.strip()
+        ]
+        task = next(
+            (item for item in requested_tasks if item in summary["tasks"]),
+            next(iter(summary["tasks"])),
+        )
+        metrics = summary["tasks"][task]["metrics"]
+        metric = next((item for item in priority if item in metrics), None)
+        summary.update(
+            status="COMPLETED" if eval_rc == 0 else "ERROR",
+            task=task,
+            metric=metric,
+            score=metrics.get(metric) if metric else None,
+            samples=summary["tasks"][task]["samples"],
+            source_result=str(source.relative_to(root)),
+            error=None if eval_rc == 0 else f"lm-eval exited with code {eval_rc}",
+        )
+    else:
+        summary["source_result"] = str(source.relative_to(root))
+        summary["error"] = "lm-eval result contains no task metrics"
+
+root.mkdir(parents=True, exist_ok=True)
+output.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(f"[magpie_bench_remote_compat] accuracy artifact: {output}", file=sys.stderr)
+PY
+}
+
+###############################################################################
+# magpie_run_eval_persisted
+#
+# Run InferenceX's local-server eval while forcing its temporary result path
+# onto Magpie's mounted workspace. InferenceX's append_lm_eval_summary then
+# stages the raw JSON and metadata under $RESULT_DIR/lm_eval instead of the
+# ephemeral container working directory.
+###############################################################################
+magpie_run_eval_persisted() {
+  if ! declare -F run_eval &>/dev/null; then
+    echo "[magpie_bench_remote_compat] ERROR run_eval is unavailable" >&2
+    return 1
+  fi
+
+  local result_dir="${RESULT_DIR:-${WORKSPACE_DIR:-/workspace}}"
+  local eval_dir="${result_dir%/}/lm_eval"
+  local raw_dir="${eval_dir}/.raw-$$"
+  local eval_rc=0
+  local stage_rc=0
+  mkdir -p "$raw_dir" || {
+    echo "[magpie_bench_remote_compat] ERROR cannot mkdir $raw_dir" >&2
+    return 1
+  }
+
+  export EVAL_RESULT_DIR="$raw_dir"
+  run_eval "$@" || eval_rc=$?
+
+  if declare -F append_lm_eval_summary &>/dev/null; then
+    (cd "$eval_dir" && append_lm_eval_summary) || stage_rc=$?
+  else
+    echo "[magpie_bench_remote_compat] WARN append_lm_eval_summary is unavailable; preserving raw results" >&2
+    eval_dir="$raw_dir"
+  fi
+
+  magpie_write_accuracy_result "$eval_dir" "$eval_rc" || stage_rc=$?
+  if [[ $eval_rc -ne 0 ]]; then
+    return "$eval_rc"
+  fi
+  return "$stage_rc"
 }

--- a/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
+++ b/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
@@ -194,7 +194,7 @@ from pathlib import Path
 root = Path(sys.argv[1])
 eval_rc = int(sys.argv[2])
 output_root = Path(sys.argv[3])
-output = output_root / "accuracy_result.json"
+output = output_root / "accuracy_report.json"
 priority = (
     "exact_match,strict-match",
     "exact_match,flexible-extract",

--- a/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
+++ b/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
@@ -283,10 +283,9 @@ PY
 ###############################################################################
 # magpie_run_eval_persisted
 #
-# Run InferenceX's local-server eval while forcing its temporary result path
-# onto Magpie's mounted workspace. InferenceX's append_lm_eval_summary then
-# stages the raw JSON and metadata under $RESULT_DIR/lm_eval instead of the
-# ephemeral container working directory.
+# Run InferenceX's local-server eval and copy its result artifacts into
+# Magpie's mounted workspace. The source lm-eval directory is left untouched;
+# Magpie owns only the copies under $RESULT_DIR/lm_eval.
 ###############################################################################
 magpie_run_eval_persisted() {
   if ! declare -F run_eval &>/dev/null; then
@@ -296,23 +295,35 @@ magpie_run_eval_persisted() {
 
   local result_dir="${RESULT_DIR:-${WORKSPACE_DIR:-/workspace}}"
   local eval_dir="${result_dir%/}/lm_eval"
-  local raw_dir="${eval_dir}/.raw-$$"
+  local raw_dir="${EVAL_RESULT_DIR:-}"
   local eval_rc=0
   local stage_rc=0
-  mkdir -p "$raw_dir" || {
-    echo "[magpie_bench_remote_compat] ERROR cannot mkdir $raw_dir" >&2
+
+  if [[ -z "$raw_dir" ]]; then
+    raw_dir=$(mktemp -d /tmp/eval_out-magpie-XXXXXX) || {
+      echo "[magpie_bench_remote_compat] ERROR cannot create eval result directory" >&2
+      return 1
+    }
+  fi
+  mkdir -p "$raw_dir" "$eval_dir" || {
+    echo "[magpie_bench_remote_compat] ERROR cannot prepare accuracy directories" >&2
     return 1
   }
 
   export EVAL_RESULT_DIR="$raw_dir"
   run_eval "$@" || eval_rc=$?
 
-  if declare -F append_lm_eval_summary &>/dev/null; then
-    (cd "$eval_dir" && append_lm_eval_summary) || stage_rc=$?
-  else
-    echo "[magpie_bench_remote_compat] WARN append_lm_eval_summary is unavailable; preserving raw results" >&2
-    eval_dir="$raw_dir"
-  fi
+  _write_lm_eval_meta_json \
+    "$raw_dir/meta_env.json" "" "${CONC:-1}" || stage_rc=$?
+
+  local source_file destination
+  while IFS= read -r -d '' source_file; do
+    destination="$eval_dir/$(basename "$source_file")"
+    if ! cp -p "$source_file" "$destination"; then
+      echo "[magpie_bench_remote_compat] WARN failed to copy $source_file" >&2
+      stage_rc=1
+    fi
+  done < <(find "$raw_dir" -type f \( -name "*.json" -o -name "*.jsonl" \) -print0 2>/dev/null)
 
   magpie_write_accuracy_result "$eval_dir" "$eval_rc" || stage_rc=$?
   if [[ $eval_rc -ne 0 ]]; then

--- a/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
+++ b/Magpie/scripts/benchmark/magpie_bench_remote_compat.sh
@@ -102,10 +102,12 @@ magpie_run_benchmark_serving_remote_direct() {
 # Inputs (env, must already be set by the calling mi*x.sh):
 #   MODEL                 model id passed to lm-eval
 #   BENCHMARK_BASE_URL    e.g. http://<head_pod_ip>:8888
-#   CONC                  concurrency cap (passed to local-completions)
+#   CONC                  performance concurrency (fallback for accuracy)
 #   RESULT_DIR            workspace dir; results land at $RESULT_DIR/lm_eval/
 #
 # Inputs (env, optional):
+#   MAGPIE_EVAL_CONCURRENCY independent accuracy concurrency; falls back to
+#                         EVAL_CONCURRENT_REQUESTS, then CONC, then 8
 #   MAGPIE_EVAL_TASKS     comma-separated lm-eval task names (default: gsm8k)
 #   MAGPIE_EVAL_LIMIT     int; cap samples for smoke runs (default: empty = full)
 #   MAGPIE_EVAL_BATCH_SIZE size for lm-eval (default: auto)
@@ -130,7 +132,7 @@ magpie_run_eval_remote_direct() {
 
   local tasks="${MAGPIE_EVAL_TASKS:-gsm8k}"
   local batch_size="${MAGPIE_EVAL_BATCH_SIZE:-auto}"
-  local conc="${CONC:-8}"
+  local conc="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-${CONC:-8}}}"
 
   # local-completions hits an OpenAI-compatible /v1/completions endpoint.
   # base_url ends in /v1/completions; tokenizer_backend=huggingface uses

--- a/Magpie/scripts/benchmark/sglang_mi300x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi300x.sh
@@ -143,9 +143,9 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
             echo "[sglang_mi300x] RUN_EVAL=true with BENCHMARK_BASE_URL but magpie_run_eval_remote_direct shim not available; skipping eval (results gate will see accuracy=None)."
         fi
     else
-        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?
+        export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
+        run_eval --framework lm-eval --port "$PORT" || exit $?
         append_lm_eval_summary
     fi
 fi
 set +x
-

--- a/Magpie/scripts/benchmark/sglang_mi300x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi300x.sh
@@ -144,8 +144,12 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        run_eval --framework lm-eval --port "$PORT" || exit $?
-        append_lm_eval_summary
+        if declare -F magpie_run_eval_persisted &>/dev/null; then
+            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
+        else
+            run_eval --framework lm-eval --port "$PORT" || exit $?
+            append_lm_eval_summary
+        fi
     fi
 fi
 set +x

--- a/Magpie/scripts/benchmark/sglang_mi300x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi300x.sh
@@ -16,7 +16,7 @@
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 # shellcheck source=magpie_bench_remote_compat.sh
-[[ -f "$(dirname "$0")/magpie_bench_remote_compat.sh" ]] && source "$(dirname "$0")/magpie_bench_remote_compat.sh"
+source "$(dirname "$0")/magpie_bench_remote_compat.sh"
 
 PHASE="${MAGPIE_RUN_PHASE:-all}"
 case "$PHASE" in
@@ -144,12 +144,7 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        if declare -F magpie_run_eval_persisted &>/dev/null; then
-            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
-        else
-            run_eval --framework lm-eval --port "$PORT" || exit $?
-            append_lm_eval_summary
-        fi
+        magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
     fi
 fi
 set +x

--- a/Magpie/scripts/benchmark/sglang_mi355x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi355x.sh
@@ -138,7 +138,8 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
             echo "[sglang_mi355x] RUN_EVAL=true with BENCHMARK_BASE_URL but magpie_run_eval_remote_direct shim not available; skipping eval (results gate will see accuracy=None)."
         fi
     else
-        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?
+        export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
+        run_eval --framework lm-eval --port "$PORT" || exit $?
         append_lm_eval_summary
     fi
 fi

--- a/Magpie/scripts/benchmark/sglang_mi355x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi355x.sh
@@ -17,7 +17,7 @@
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 # shellcheck source=magpie_bench_remote_compat.sh
-[[ -f "$(dirname "$0")/magpie_bench_remote_compat.sh" ]] && source "$(dirname "$0")/magpie_bench_remote_compat.sh"
+source "$(dirname "$0")/magpie_bench_remote_compat.sh"
 
 PHASE="${MAGPIE_RUN_PHASE:-all}"
 case "$PHASE" in
@@ -139,12 +139,7 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        if declare -F magpie_run_eval_persisted &>/dev/null; then
-            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
-        else
-            run_eval --framework lm-eval --port "$PORT" || exit $?
-            append_lm_eval_summary
-        fi
+        magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
     fi
 fi
 set +x

--- a/Magpie/scripts/benchmark/sglang_mi355x.sh
+++ b/Magpie/scripts/benchmark/sglang_mi355x.sh
@@ -139,8 +139,12 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        run_eval --framework lm-eval --port "$PORT" || exit $?
-        append_lm_eval_summary
+        if declare -F magpie_run_eval_persisted &>/dev/null; then
+            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
+        else
+            run_eval --framework lm-eval --port "$PORT" || exit $?
+            append_lm_eval_summary
+        fi
     fi
 fi
 set +x

--- a/Magpie/scripts/benchmark/vllm_mi300x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi300x.sh
@@ -151,9 +151,9 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
             echo "[vllm_mi300x] RUN_EVAL=true with BENCHMARK_BASE_URL but magpie_run_eval_remote_direct shim not available; skipping eval (results gate will see accuracy=None)."
         fi
     else
-        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?
+        export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
+        run_eval --framework lm-eval --port "$PORT" || exit $?
         append_lm_eval_summary
     fi
 fi
 set +x
-

--- a/Magpie/scripts/benchmark/vllm_mi300x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi300x.sh
@@ -152,8 +152,12 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        run_eval --framework lm-eval --port "$PORT" || exit $?
-        append_lm_eval_summary
+        if declare -F magpie_run_eval_persisted &>/dev/null; then
+            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
+        else
+            run_eval --framework lm-eval --port "$PORT" || exit $?
+            append_lm_eval_summary
+        fi
     fi
 fi
 set +x

--- a/Magpie/scripts/benchmark/vllm_mi300x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi300x.sh
@@ -21,7 +21,7 @@
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 # shellcheck source=magpie_bench_remote_compat.sh
-[[ -f "$(dirname "$0")/magpie_bench_remote_compat.sh" ]] && source "$(dirname "$0")/magpie_bench_remote_compat.sh"
+source "$(dirname "$0")/magpie_bench_remote_compat.sh"
 
 PHASE="${MAGPIE_RUN_PHASE:-all}"
 case "$PHASE" in
@@ -152,12 +152,7 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        if declare -F magpie_run_eval_persisted &>/dev/null; then
-            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
-        else
-            run_eval --framework lm-eval --port "$PORT" || exit $?
-            append_lm_eval_summary
-        fi
+        magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
     fi
 fi
 set +x

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -148,8 +148,12 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        run_eval --framework lm-eval --port "$PORT" || exit $?
-        append_lm_eval_summary
+        if declare -F magpie_run_eval_persisted &>/dev/null; then
+            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
+        else
+            run_eval --framework lm-eval --port "$PORT" || exit $?
+            append_lm_eval_summary
+        fi
     fi
 fi
 set +x

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -147,7 +147,8 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
             echo "[vllm_mi355x] RUN_EVAL=true with BENCHMARK_BASE_URL but magpie_run_eval_remote_direct shim not available; skipping eval (results gate will see accuracy=None)."
         fi
     else
-        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?
+        export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
+        run_eval --framework lm-eval --port "$PORT" || exit $?
         append_lm_eval_summary
     fi
 fi

--- a/Magpie/scripts/benchmark/vllm_mi355x.sh
+++ b/Magpie/scripts/benchmark/vllm_mi355x.sh
@@ -18,7 +18,7 @@
 source "$(dirname "$0")/benchmark_lib.sh"
 source "$(dirname "$0")/server_cleanup.sh"
 # shellcheck source=magpie_bench_remote_compat.sh
-[[ -f "$(dirname "$0")/magpie_bench_remote_compat.sh" ]] && source "$(dirname "$0")/magpie_bench_remote_compat.sh"
+source "$(dirname "$0")/magpie_bench_remote_compat.sh"
 
 PHASE="${MAGPIE_RUN_PHASE:-all}"
 case "$PHASE" in
@@ -148,12 +148,7 @@ if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
         fi
     else
         export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-${EVAL_CONCURRENT_REQUESTS:-$CONC}}"
-        if declare -F magpie_run_eval_persisted &>/dev/null; then
-            magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
-        else
-            run_eval --framework lm-eval --port "$PORT" || exit $?
-            append_lm_eval_summary
-        fi
+        magpie_run_eval_persisted --framework lm-eval --port "$PORT" || exit $?
     fi
 fi
 set +x

--- a/docs/how-to/benchmarking/benchmark.md
+++ b/docs/how-to/benchmarking/benchmark.md
@@ -69,13 +69,13 @@ A successful benchmark run creates a timestamped workspace directory with the fo
 ```
 results/benchmark_vllm_<timestamp>/
 ├── benchmark_report.json      # Main benchmark results
+├── accuracy_result.json       # Stable accuracy summary (when enabled)
 ├── summary.txt                # Human-readable summary
 ├── config.yaml                # Snapshot of benchmark configuration
 ├── container_stdout.log       # Container stdout
 ├── container_stderr.log       # Container stderr
 ├── inferencex_result.json     # Raw InferenceX performance output
 ├── lm_eval/                   # Accuracy artifacts (when RUN_EVAL=true)
-│   ├── accuracy_result.json   # Stable Magpie accuracy summary
 │   ├── results_*.json         # Raw lm-eval result
 │   └── meta_env.json          # Evaluation environment metadata
 ├── torch_trace/               # Raw torch profiler traces
@@ -98,7 +98,7 @@ results/benchmark_vllm_<timestamp>/
 └── tracelens_collective_csvs/ # Legacy/direct PyTorch multi-rank collective report
 ```
 
-`lm_eval/accuracy_result.json` provides the selected task, metric, score,
+`accuracy_result.json` provides the selected task, metric, score,
 effective sample count, and the path to the retained raw lm-eval result. It
 reports evaluation execution status only; acceptance thresholds remain the
 responsibility of the downstream qualification gate.

--- a/docs/how-to/benchmarking/benchmark.md
+++ b/docs/how-to/benchmarking/benchmark.md
@@ -69,7 +69,7 @@ A successful benchmark run creates a timestamped workspace directory with the fo
 ```
 results/benchmark_vllm_<timestamp>/
 ├── benchmark_report.json      # Main benchmark results
-├── accuracy_result.json       # Stable accuracy summary (when enabled)
+├── accuracy_report.json       # Stable accuracy summary (when enabled)
 ├── summary.txt                # Human-readable summary
 ├── config.yaml                # Snapshot of benchmark configuration
 ├── container_stdout.log       # Container stdout
@@ -98,7 +98,7 @@ results/benchmark_vllm_<timestamp>/
 └── tracelens_collective_csvs/ # Legacy/direct PyTorch multi-rank collective report
 ```
 
-`accuracy_result.json` provides the selected task, metric, score,
+`accuracy_report.json` provides the selected task, metric, score,
 effective sample count, and the path to the retained raw lm-eval result. It
 reports evaluation execution status only; acceptance thresholds remain the
 responsibility of the downstream qualification gate.

--- a/docs/how-to/benchmarking/benchmark.md
+++ b/docs/how-to/benchmarking/benchmark.md
@@ -73,7 +73,11 @@ results/benchmark_vllm_<timestamp>/
 ├── config.yaml                # Snapshot of benchmark configuration
 ├── container_stdout.log       # Container stdout
 ├── container_stderr.log       # Container stderr
-├── inferencex_result.json   # Raw InferenceX output
+├── inferencex_result.json     # Raw InferenceX performance output
+├── lm_eval/                   # Accuracy artifacts (when RUN_EVAL=true)
+│   ├── accuracy_result.json   # Stable Magpie accuracy summary
+│   ├── results_*.json         # Raw lm-eval result
+│   └── meta_env.json          # Evaluation environment metadata
 ├── torch_trace/               # Raw torch profiler traces
 │   ├── *-rank-0.*.pt.trace.json.gz
 │   ├── *-rank-1.*.pt.trace.json.gz
@@ -93,6 +97,11 @@ results/benchmark_vllm_<timestamp>/
 ├── tracelens_rank0_csvs/      # Legacy/direct PyTorch single-rank report
 └── tracelens_collective_csvs/ # Legacy/direct PyTorch multi-rank collective report
 ```
+
+`lm_eval/accuracy_result.json` provides the selected task, metric, score,
+effective sample count, and the path to the retained raw lm-eval result. It
+reports evaluation execution status only; acceptance thresholds remain the
+responsibility of the downstream qualification gate.
 
 For TraceLens inference runs, the
 `*_ISL*_OSL*_CONC*_kernel_roofline_simple.csv` files are the fastest starting

--- a/skills/magpie/reference.md
+++ b/skills/magpie/reference.md
@@ -112,7 +112,7 @@ Important outputs may include:
 - `benchmark_report.json`: throughput, latency, execution status, and optional profiling/analysis results;
 - `summary.txt`: human-readable summary;
 - framework benchmark results such as `inferencex_result.json`;
-- `accuracy_result.json` plus the retained raw result under `lm_eval/` when
+- `accuracy_report.json` plus the retained raw result under `lm_eval/` when
   accuracy evaluation is enabled;
 - stdout/stderr logs;
 - torch traces and profiler output;

--- a/skills/magpie/reference.md
+++ b/skills/magpie/reference.md
@@ -112,6 +112,8 @@ Important outputs may include:
 - `benchmark_report.json`: throughput, latency, execution status, and optional profiling/analysis results;
 - `summary.txt`: human-readable summary;
 - framework benchmark results such as `inferencex_result.json`;
+- `lm_eval/accuracy_result.json` plus the retained raw lm-eval result when
+  accuracy evaluation is enabled;
 - stdout/stderr logs;
 - torch traces and profiler output;
 - TraceLens reports;

--- a/skills/magpie/reference.md
+++ b/skills/magpie/reference.md
@@ -112,7 +112,7 @@ Important outputs may include:
 - `benchmark_report.json`: throughput, latency, execution status, and optional profiling/analysis results;
 - `summary.txt`: human-readable summary;
 - framework benchmark results such as `inferencex_result.json`;
-- `lm_eval/accuracy_result.json` plus the retained raw lm-eval result when
+- `accuracy_result.json` plus the retained raw result under `lm_eval/` when
   accuracy evaluation is enabled;
 - stdout/stderr logs;
 - torch traces and profiler output;

--- a/tests/test_eval_concurrency_scripts.py
+++ b/tests/test_eval_concurrency_scripts.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+LOCAL_EVAL_SCRIPTS = [
+    "atom_mi300x.sh",
+    "atom_mi355x.sh",
+    "sglang_mi300x.sh",
+    "sglang_mi355x.sh",
+    "vllm_mi300x.sh",
+    "vllm_mi355x.sh",
+]
+CONCURRENCY_EXPORT = (
+    'export EVAL_CONCURRENT_REQUESTS="${MAGPIE_EVAL_CONCURRENCY:-'
+    '${EVAL_CONCURRENT_REQUESTS:-$CONC}}"'
+)
+
+
+@pytest.mark.parametrize("script_name", LOCAL_EVAL_SCRIPTS)
+def test_local_eval_scripts_use_environment_for_concurrency(script_name: str):
+    script = ROOT / "Magpie" / "scripts" / "benchmark" / script_name
+    contents = script.read_text(encoding="utf-8")
+
+    assert CONCURRENCY_EXPORT in contents
+    assert 'run_eval --framework lm-eval --port "$PORT" || exit $?' in contents
+    assert "--concurrent-requests" not in contents
+
+
+def test_remote_eval_prefers_independent_accuracy_concurrency():
+    script = (
+        ROOT
+        / "Magpie"
+        / "scripts"
+        / "benchmark"
+        / "magpie_bench_remote_compat.sh"
+    )
+    contents = script.read_text(encoding="utf-8")
+
+    assert (
+        'local conc="${MAGPIE_EVAL_CONCURRENCY:-'
+        '${EVAL_CONCURRENT_REQUESTS:-${CONC:-8}}}"'
+    ) in contents

--- a/tests/test_eval_concurrency_scripts.py
+++ b/tests/test_eval_concurrency_scripts.py
@@ -1,3 +1,6 @@
+import json
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -41,3 +44,63 @@ def test_remote_eval_prefers_independent_accuracy_concurrency():
         'local conc="${MAGPIE_EVAL_CONCURRENCY:-'
         '${EVAL_CONCURRENT_REQUESTS:-${CONC:-8}}}"'
     ) in contents
+
+
+@pytest.mark.parametrize("script_name", LOCAL_EVAL_SCRIPTS)
+def test_local_eval_scripts_persist_accuracy_results(script_name: str):
+    script = ROOT / "Magpie" / "scripts" / "benchmark" / script_name
+    contents = script.read_text(encoding="utf-8")
+
+    assert "magpie_run_eval_persisted --framework lm-eval" in contents
+
+
+def test_persisted_eval_writes_raw_and_formatted_results(tmp_path: Path):
+    compat = (
+        ROOT
+        / "Magpie"
+        / "scripts"
+        / "benchmark"
+        / "magpie_bench_remote_compat.sh"
+    )
+    result_payload = {
+        "lm_eval_version": "0.4.8",
+        "results": {
+            "gsm8k": {
+                "exact_match,strict-match": 0.98,
+                "exact_match,flexible-extract": 0.99,
+            }
+        },
+        "n-samples": {"gsm8k": {"original": 1319, "effective": 100}},
+    }
+    shell = r'''
+source "$MAGPIE_COMPAT"
+run_eval() {
+  mkdir -p "$EVAL_RESULT_DIR/model"
+  printf '%s\n' "$FAKE_EVAL_RESULT" > "$EVAL_RESULT_DIR/model/results_123.json"
+}
+append_lm_eval_summary() {
+  printf '%s\n' '{"model":"test"}' > "$EVAL_RESULT_DIR/meta_env.json"
+  find "$EVAL_RESULT_DIR" -type f -name '*.json*' -exec mv -f {} . \;
+  rm -rf "$EVAL_RESULT_DIR"
+}
+magpie_run_eval_persisted --framework lm-eval --port 8888
+'''
+    env = {
+        **os.environ,
+        "MAGPIE_COMPAT": str(compat),
+        "RESULT_DIR": str(tmp_path),
+        "FAKE_EVAL_RESULT": json.dumps(result_payload),
+        "MAGPIE_EVAL_TASKS": "gsm8k",
+    }
+    subprocess.run(["bash", "-c", shell], check=True, env=env)
+
+    eval_dir = tmp_path / "lm_eval"
+    assert json.loads((eval_dir / "results_123.json").read_text()) == result_payload
+    assert (eval_dir / "meta_env.json").is_file()
+    summary = json.loads((eval_dir / "accuracy_result.json").read_text())
+    assert summary["status"] == "COMPLETED"
+    assert summary["task"] == "gsm8k"
+    assert summary["metric"] == "exact_match,strict-match"
+    assert summary["score"] == 0.98
+    assert summary["samples"] == 100
+    assert summary["source_result"] == "results_123.json"

--- a/tests/test_eval_concurrency_scripts.py
+++ b/tests/test_eval_concurrency_scripts.py
@@ -26,7 +26,8 @@ def test_local_eval_scripts_use_environment_for_concurrency(script_name: str):
     contents = script.read_text(encoding="utf-8")
 
     assert CONCURRENCY_EXPORT in contents
-    assert 'run_eval --framework lm-eval --port "$PORT" || exit $?' in contents
+    assert 'magpie_run_eval_persisted --framework lm-eval --port "$PORT"' in contents
+    assert "declare -F magpie_run_eval_persisted" not in contents
     assert "--concurrent-requests" not in contents
 
 
@@ -44,14 +45,6 @@ def test_remote_eval_prefers_independent_accuracy_concurrency():
         'local conc="${MAGPIE_EVAL_CONCURRENCY:-'
         '${EVAL_CONCURRENT_REQUESTS:-${CONC:-8}}}"'
     ) in contents
-
-
-@pytest.mark.parametrize("script_name", LOCAL_EVAL_SCRIPTS)
-def test_local_eval_scripts_persist_accuracy_results(script_name: str):
-    script = ROOT / "Magpie" / "scripts" / "benchmark" / script_name
-    contents = script.read_text(encoding="utf-8")
-
-    assert "magpie_run_eval_persisted --framework lm-eval" in contents
 
 
 def test_persisted_eval_writes_raw_and_formatted_results(tmp_path: Path):

--- a/tests/test_eval_concurrency_scripts.py
+++ b/tests/test_eval_concurrency_scripts.py
@@ -75,7 +75,7 @@ append_lm_eval_summary() {
   return 99
 }
 _write_lm_eval_meta_json() {
-  printf '%s\n' '{"model":"test"}' > "$1"
+  printf '{"model":"test","conc":%s}\n' "$3" > "$1"
 }
 magpie_run_eval_persisted --framework lm-eval --port 8888
 '''
@@ -87,12 +87,15 @@ magpie_run_eval_persisted --framework lm-eval --port 8888
         "EVAL_RESULT_DIR": str(source_dir),
         "FAKE_EVAL_RESULT": json.dumps(result_payload),
         "MAGPIE_EVAL_TASKS": "gsm8k",
+        "CONC": "64",
+        "EVAL_CONCURRENT_REQUESTS": "8",
     }
     subprocess.run(["bash", "-c", shell], check=True, env=env)
 
     eval_dir = tmp_path / "lm_eval"
     assert json.loads((source_dir / "model" / "results_123.json").read_text()) == result_payload
     assert (source_dir / "meta_env.json").is_file()
+    assert json.loads((source_dir / "meta_env.json").read_text())["conc"] == 8
     assert json.loads((eval_dir / "results_123.json").read_text()) == result_payload
     assert (eval_dir / "meta_env.json").is_file()
     summary = json.loads((tmp_path / "accuracy_report.json").read_text())
@@ -102,3 +105,82 @@ magpie_run_eval_persisted --framework lm-eval --port 8888
     assert summary["score"] == 0.98
     assert summary["samples"] == 100
     assert summary["source_result"] == "lm_eval/results_123.json"
+
+
+def test_persisted_eval_collects_batched_concurrency_results(tmp_path: Path):
+    compat = (
+        ROOT
+        / "Magpie"
+        / "scripts"
+        / "benchmark"
+        / "magpie_bench_remote_compat.sh"
+    )
+    shell = r'''
+source "$MAGPIE_COMPAT"
+run_eval() {
+  local conc
+  for conc in $EVAL_CONCURRENT_REQUESTS; do
+    printf '{"results":{"gsm8k":{"exact_match,strict-match":0.%s}}}\n' \
+      "$conc" > "results_conc${conc}.json"
+  done
+  export EVAL_BATCHED_CONCS="$EVAL_CONCURRENT_REQUESTS"
+  export EVAL_BATCHED_COMPLETED_CONCS="$EVAL_CONCURRENT_REQUESTS"
+  export EVAL_BATCHED_FAILED_CONCS=""
+  export EVAL_RESULT_DIR=""
+}
+append_lm_eval_summary() {
+  printf '%s\n' '{"eval_concs":[2,4]}' > ./meta_env.json
+}
+_write_lm_eval_meta_json() {
+  return 99
+}
+magpie_run_eval_persisted --framework lm-eval --port 8888
+'''
+    env = {
+        **os.environ,
+        "MAGPIE_COMPAT": str(compat),
+        "RESULT_DIR": str(tmp_path),
+        "EVAL_CONCURRENT_REQUESTS": "2 4",
+        "MAGPIE_EVAL_TASKS": "gsm8k",
+    }
+    subprocess.run(["bash", "-c", shell], check=True, env=env)
+
+    eval_dir = tmp_path / "lm_eval"
+    assert (eval_dir / "results_conc2.json").is_file()
+    assert (eval_dir / "results_conc4.json").is_file()
+    assert json.loads((eval_dir / "meta_env.json").read_text())["eval_concs"] == [
+        2,
+        4,
+    ]
+    summary = json.loads((tmp_path / "accuracy_report.json").read_text())
+    assert summary["status"] == "COMPLETED"
+    assert summary["task"] == "gsm8k"
+
+
+def test_remote_eval_propagates_accuracy_report_failure(tmp_path: Path):
+    compat = (
+        ROOT
+        / "Magpie"
+        / "scripts"
+        / "benchmark"
+        / "magpie_bench_remote_compat.sh"
+    )
+    shell = r'''
+source "$MAGPIE_COMPAT"
+magpie_write_accuracy_result() {
+  return 73
+}
+magpie_run_eval_remote_direct
+'''
+    env = {
+        **os.environ,
+        "MAGPIE_COMPAT": str(compat),
+        "RESULT_DIR": str(tmp_path),
+        "BENCHMARK_BASE_URL": "http://127.0.0.1:8888",
+        "MAGPIE_EVAL_PYTHON": "true",
+        "MODEL": "test-model",
+        "CONC": "8",
+    }
+    completed = subprocess.run(["bash", "-c", shell], check=False, env=env)
+
+    assert completed.returncode == 73

--- a/tests/test_eval_concurrency_scripts.py
+++ b/tests/test_eval_concurrency_scripts.py
@@ -95,7 +95,7 @@ magpie_run_eval_persisted --framework lm-eval --port 8888
     assert (source_dir / "meta_env.json").is_file()
     assert json.loads((eval_dir / "results_123.json").read_text()) == result_payload
     assert (eval_dir / "meta_env.json").is_file()
-    summary = json.loads((tmp_path / "accuracy_result.json").read_text())
+    summary = json.loads((tmp_path / "accuracy_report.json").read_text())
     assert summary["status"] == "COMPLETED"
     assert summary["task"] == "gsm8k"
     assert summary["metric"] == "exact_match,strict-match"

--- a/tests/test_eval_concurrency_scripts.py
+++ b/tests/test_eval_concurrency_scripts.py
@@ -95,10 +95,10 @@ magpie_run_eval_persisted --framework lm-eval --port 8888
     assert (source_dir / "meta_env.json").is_file()
     assert json.loads((eval_dir / "results_123.json").read_text()) == result_payload
     assert (eval_dir / "meta_env.json").is_file()
-    summary = json.loads((eval_dir / "accuracy_result.json").read_text())
+    summary = json.loads((tmp_path / "accuracy_result.json").read_text())
     assert summary["status"] == "COMPLETED"
     assert summary["task"] == "gsm8k"
     assert summary["metric"] == "exact_match,strict-match"
     assert summary["score"] == 0.98
     assert summary["samples"] == 100
-    assert summary["source_result"] == "results_123.json"
+    assert summary["source_result"] == "lm_eval/results_123.json"

--- a/tests/test_eval_concurrency_scripts.py
+++ b/tests/test_eval_concurrency_scripts.py
@@ -72,22 +72,27 @@ run_eval() {
   printf '%s\n' "$FAKE_EVAL_RESULT" > "$EVAL_RESULT_DIR/model/results_123.json"
 }
 append_lm_eval_summary() {
-  printf '%s\n' '{"model":"test"}' > "$EVAL_RESULT_DIR/meta_env.json"
-  find "$EVAL_RESULT_DIR" -type f -name '*.json*' -exec mv -f {} . \;
-  rm -rf "$EVAL_RESULT_DIR"
+  return 99
+}
+_write_lm_eval_meta_json() {
+  printf '%s\n' '{"model":"test"}' > "$1"
 }
 magpie_run_eval_persisted --framework lm-eval --port 8888
 '''
+    source_dir = tmp_path / "source"
     env = {
         **os.environ,
         "MAGPIE_COMPAT": str(compat),
         "RESULT_DIR": str(tmp_path),
+        "EVAL_RESULT_DIR": str(source_dir),
         "FAKE_EVAL_RESULT": json.dumps(result_payload),
         "MAGPIE_EVAL_TASKS": "gsm8k",
     }
     subprocess.run(["bash", "-c", shell], check=True, env=env)
 
     eval_dir = tmp_path / "lm_eval"
+    assert json.loads((source_dir / "model" / "results_123.json").read_text()) == result_payload
+    assert (source_dir / "meta_env.json").is_file()
     assert json.loads((eval_dir / "results_123.json").read_text()) == result_payload
     assert (eval_dir / "meta_env.json").is_file()
     summary = json.loads((eval_dir / "accuracy_result.json").read_text())


### PR DESCRIPTION
## Summary

Fix accuracy evaluation failures caused by passing the unsupported
`--concurrent-requests` argument to InferenceX `run_eval`, while ensuring
accuracy artifacts are reliably persisted for both local and remote evaluation.

## Changes

- Configure lm-eval concurrency through `EVAL_CONCURRENT_REQUESTS`.
- Add `MAGPIE_EVAL_CONCURRENCY` to control accuracy concurrency independently
  from performance benchmark concurrency.
- Apply the concurrency fix consistently to SGLang, vLLM, and ATOM benchmark
  scripts on MI300X and MI355X.
- Use the following concurrency precedence:
  1. `MAGPIE_EVAL_CONCURRENCY`
  2. `EVAL_CONCURRENT_REQUESTS`
  3. benchmark `CONC`
- Preserve raw lm-eval JSON/JSONL artifacts under `lm_eval/`.
- Generate a stable `accuracy_report.json` beside `benchmark_report.json`.
- Support batched concurrency values such as
  `EVAL_CONCURRENT_REQUESTS="2 4"` without losing staged results.
- Record the actual accuracy concurrency in `meta_env.json`, rather than the
  performance benchmark concurrency.
- Propagate accuracy-report persistence failures for remote evaluations instead
  of reporting a false success.
- Leave source lm-eval artifacts untouched when copying them into the benchmark
  workspace.
- Update benchmarking documentation and the Magpie skill reference.

## Output

When accuracy evaluation is enabled, the benchmark workspace now includes:

```text
results/benchmark_<framework>_<timestamp>/
├── benchmark_report.json
├── accuracy_report.json
└── lm_eval/
    ├── results_*.json
    ├── samples_*.jsonl
    └── meta_env.json